### PR TITLE
Added 'Add to AltStore' button to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,7 @@ The Android app is currently in testing you can help testing by joining this gro
 ### AltStore
 The iOS app can be currently installed through AltStore by adding the repo
 
-<a href='https://shorturl.at/xR8B9'><img alt='Get it on AltStore' src='https://camo.githubusercontent.com/d09e24361b730206b40f7c3a5950a17ba3341e67c533e27c155ddb34f0440b44/68747470733a2f2f692e696d6775722e636f6d2f343671684541762e706e67' width=250/></a>
-
-## How to Contribute
+<a href='[altstore://source?url=https://raw.githubusercontent.com/bazzadazza72/fladder-develop/refs/heads/develop/altstore.json](https://shorturl.at/KnT4S)'><img alt='Get it on AltStore' src='https://camo.githubusercontent.com/d09e24361b730206b40f7c3a5950a17ba3341e67c533e27c155ddb34f0440b44/68747470733a2f2f692e696d6775722e636f6d2f343671684541762e706e67' width=250/></a>
 
 Interest in contributing? Here are a couple of ways you can help:
 

--- a/README.md
+++ b/README.md
@@ -83,10 +83,11 @@ The Android app is currently in testing you can help testing by joining this gro
 <a href='https://play.google.com/store/apps/details?id=nl.jknaapen.fladder&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1'><img alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png' width=250/></a>
 
 ### AltStore
-The iOS app can be currently installed through AltStore by adding the repo
+The iOS app can be installed through AltStore by adding this repo
 
 <a href='https://shorturl.at/KnT4S'><img alt='Get it on AltStore' src='https://camo.githubusercontent.com/d09e24361b730206b40f7c3a5950a17ba3341e67c533e27c155ddb34f0440b44/68747470733a2f2f692e696d6775722e636f6d2f343671684541762e706e67' width=250/></a>
 
+## How to Contribute
 Interest in contributing? Here are a couple of ways you can help:
 
 ### 🐛 Reporting Bugs

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The Android app is currently in testing you can help testing by joining this gro
 ### AltStore
 The iOS app can be currently installed through AltStore by adding the repo
 
-<a href='https://github.com/DonutWare/Fladder/blob/develop/altstore.json'><img alt='Get it on AltStore' src='https://camo.githubusercontent.com/d09e24361b730206b40f7c3a5950a17ba3341e67c533e27c155ddb34f0440b44/68747470733a2f2f692e696d6775722e636f6d2f343671684541762e706e67' width=250/></a>
+<a href='altstore://source?url=https://github.com/DonutWare/Fladder/blob/develop/altstore.json'><img alt='Get it on AltStore' src='https://camo.githubusercontent.com/d09e24361b730206b40f7c3a5950a17ba3341e67c533e27c155ddb34f0440b44/68747470733a2f2f692e696d6775722e636f6d2f343671684541762e706e67' width=250/></a>
 
 ## How to Contribute
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The Android app is currently in testing you can help testing by joining this gro
 ### AltStore
 The iOS app can be installed through AltStore by adding this repo
 
-<a href='https://shorturl.at/KnT4S'><img alt='Get it on AltStore' src='https://camo.githubusercontent.com/d09e24361b730206b40f7c3a5950a17ba3341e67c533e27c155ddb34f0440b44/68747470733a2f2f692e696d6775722e636f6d2f343671684541762e706e67' width=250/></a>
+<a href='https://shorturl.at/Pj7Z7'><img alt='Get it on AltStore' src='https://camo.githubusercontent.com/d09e24361b730206b40f7c3a5950a17ba3341e67c533e27c155ddb34f0440b44/68747470733a2f2f692e696d6775722e636f6d2f343671684541762e706e67' width=250/></a>
 
 ## How to Contribute
 Interest in contributing? Here are a couple of ways you can help:

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The Android app is currently in testing you can help testing by joining this gro
 ### AltStore
 The iOS app can be currently installed through AltStore by adding the repo
 
-<a href='altstore://source?url=https://github.com/DonutWare/Fladder/blob/develop/altstore.json'><img alt='Get it on AltStore' src='https://camo.githubusercontent.com/d09e24361b730206b40f7c3a5950a17ba3341e67c533e27c155ddb34f0440b44/68747470733a2f2f692e696d6775722e636f6d2f343671684541762e706e67' width=250/></a>
+<a href='https://shorturl.at/xR8B9'><img alt='Get it on AltStore' src='https://camo.githubusercontent.com/d09e24361b730206b40f7c3a5950a17ba3341e67c533e27c155ddb34f0440b44/68747470733a2f2f692e696d6775722e636f6d2f343671684541762e706e67' width=250/></a>
 
 ## How to Contribute
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,11 @@ The Android app is currently in testing you can help testing by joining this gro
 
 <a href='https://play.google.com/store/apps/details?id=nl.jknaapen.fladder&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1'><img alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png' width=250/></a>
 
+### AltStore
+The iOS app can be currently installed through AltStore by adding the repo
+
+<a href='https://github.com/DonutWare/Fladder/blob/develop/altstore.json'><img alt='Get it on AltStore' src='https://camo.githubusercontent.com/d09e24361b730206b40f7c3a5950a17ba3341e67c533e27c155ddb34f0440b44/68747470733a2f2f692e696d6775722e636f6d2f343671684541762e706e67' width=250/></a>
+
 ## How to Contribute
 
 Interest in contributing? Here are a couple of ways you can help:

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The Android app is currently in testing you can help testing by joining this gro
 ### AltStore
 The iOS app can be currently installed through AltStore by adding the repo
 
-<a href='[altstore://source?url=https://raw.githubusercontent.com/bazzadazza72/fladder-develop/refs/heads/develop/altstore.json](https://shorturl.at/KnT4S)'><img alt='Get it on AltStore' src='https://camo.githubusercontent.com/d09e24361b730206b40f7c3a5950a17ba3341e67c533e27c155ddb34f0440b44/68747470733a2f2f692e696d6775722e636f6d2f343671684541762e706e67' width=250/></a>
+<a href='https://shorturl.at/KnT4S'><img alt='Get it on AltStore' src='https://camo.githubusercontent.com/d09e24361b730206b40f7c3a5950a17ba3341e67c533e27c155ddb34f0440b44/68747470733a2f2f692e696d6775722e636f6d2f343671684541762e706e67' width=250/></a>
 
 Interest in contributing? Here are a couple of ways you can help:
 


### PR DESCRIPTION
## Pull Request Description

Added a button that allows quick addition of the repo to AltStore from an iDevice. Due to the README not allowing 'altstore://' links, I had to do it through a link shortener. The non shortened URL is:
`altstore://source?url=https://raw.githubusercontent.com/bazzadazza72/fladder-develop/refs/heads/develop/altstore.json`

## Issue Being Fixed

No issue being fixed, just added the shortcut.

Issue Number: N/A

## Screenshots / Recordings
N/A

## Checklist

- [ ] If a new package was added, did you ensure it works for all supported platforms? Is the package also well maintained?
- [ ] Did you add localization for any text? If yes, did you sort the .arb file using ```arb_utils sort <INPUT_FILE>```?
- [ ] Check that any changes are related to the issue at hand.