### PR TITLE
[Improvement] Fix RPATHs for shared libraries and binary in Linux builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -220,7 +220,7 @@ jobs:
       - name: Get packages
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y ninja-build libgtk-3-dev libmpv-dev
+          sudo apt-get install -y ninja-build libgtk-3-dev libmpv-dev patchelf
 
       - name: Build Linux app
         run: |
@@ -234,6 +234,14 @@ jobs:
             --build-name=$VERSION_NAME \
             --build-number=${{ github.run_number }}
 
+      - name: Fix RPATH
+        run: |
+          for lib in "build/linux/x64/release/bundle/lib"/*.so; do
+            [[ -f "$lib" && -n "$(patchelf --print-rpath "$lib")" ]] && \
+            patchelf --set-rpath '$ORIGIN' "$lib"
+          done
+          patchelf --set-rpath '$ORIGIN/lib' "build/linux/x64/release/bundle/Fladder"
+          
       - name: Archive Linux artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Pull Request Description

This updates the RPATHs for the shared libraries and the main executable in the Linux build. Currently, the RPATH points to a path specific to the GitHub Actions runner, which could cause issues. 


Example of current RPATH from the GitHub runner:
```
❯ patchelf --print-rpath ./lib/libdynamic_color_plugin.so
/home/runner/work/Fladder/Fladder/linux/flutter/ephemeral
```
after this change:
```
❯ patchelf --print-rpath ./lib/libdynamic_color_plugin.so
$ORIGIN
```

Changes:

- Add a step in the Actions workflow to set the RPATH for the libraries and the executable using patchelf.
- Changed the RPATH to `$ORIGIN` for the shared libraries and ensure the main executable looks for its libraries in the lib directory next to it by using `$ORIGIN/lib`.



## Checklist

- [ ] If a new package was added, did you ensure it works for all supported platforms? Is the package also well maintained?
- [ ] Did you add localization for any text? If yes, did you sort the .arb file using ```arb_utils sort <INPUT_FILE>```?
- [ ] Check that any changes are related to the issue at hand.