### PR TITLE
Add appropriate padding to navigation rail on macOS

### DIFF
--- a/lib/widgets/navigation_scaffold/components/navigation_body.dart
+++ b/lib/widgets/navigation_scaffold/components/navigation_body.dart
@@ -120,6 +120,7 @@ class _NavigationBodyState extends ConsumerState<NavigationBody> {
             style: Theme.of(context).textTheme.titleSmall,
           ),
         },
+        if (AdaptiveLayout.of(context).platform == TargetPlatform.macOS) SizedBox(height: MediaQuery.of(context).padding.top),
         Flexible(
           child: Padding(
             key: const Key('navigation_rail'),


### PR DESCRIPTION
## Pull Request Description

Fixes system chrome overlapping the navigation rail on desktop macOS by adding padding to the top of the column layout. Extra padding is only applied if the target platform is macOS to prevent unintended consequences on other devices.

## Issue Being Fixed

Resolved #93 

## Screenshots / Recordings
Before:
<img width="87" alt="Screenshot 2024-10-31 at 6 22 06 PM" src="https://github.com/user-attachments/assets/5a5560d7-d8f9-493c-a10a-eef1059cfc5a">

After:
<img width="86" alt="Screenshot 2024-10-31 at 6 21 56 PM" src="https://github.com/user-attachments/assets/8c7d9ec2-0db6-48d8-b15b-56feb031961e">



## Checklist

- [x] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [x] Check that any changes are related to the issue at hand.
