### PR TITLE
fix: Playback not cancelling if no compatible media was found

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1081,5 +1081,8 @@
   "autoNextOffStaticTitle": "Static",
   "autoNextOffStaticDesc": "Show the next-up screen when 30 seconds of playtime remain",
   "playbackRate": "Playback rate",
-  "speed": "Speed"
+  "speed": "Speed",
+  "unableToPlayMedia": "There was an error finding a compatible media type",
+  "errorOpeningMedia": "Something went trying to play this media",
+  "unableToPlayBooksOnWeb": "Books are not supported on web for now"
 }

--- a/lib/screens/video_player/components/video_progress_bar.dart
+++ b/lib/screens/video_player/components/video_progress_bar.dart
@@ -1,6 +1,10 @@
 import 'dart:math' as math;
 
+import 'package:flutter/material.dart';
+
 import 'package:collection/collection.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
 import 'package:fladder/models/items/chapters_model.dart';
 import 'package:fladder/models/items/intro_skip_model.dart';
 import 'package:fladder/providers/video_player_provider.dart';
@@ -10,8 +14,6 @@ import 'package:fladder/util/string_extensions.dart';
 import 'package:fladder/widgets/gapped_container_shape.dart';
 import 'package:fladder/widgets/shared/fladder_slider.dart';
 import 'package:fladder/widgets/shared/trickplay_image.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 class ChapterProgressSlider extends ConsumerStatefulWidget {
   final Function(bool value) wasPlayingChanged;
@@ -171,7 +173,8 @@ class _ChapterProgressSliderState extends ConsumerState<ChapterProgressSlider> {
                     Positioned(
                       left: 0,
                       child: SizedBox(
-                        width: (constraints.maxWidth / (widget.duration.inMilliseconds / widget.buffer.inMilliseconds)),
+                        width: (constraints.maxWidth / (widget.duration.inMilliseconds / widget.buffer.inMilliseconds))
+                            .clamp(1, constraints.maxWidth),
                         height: sliderHeight,
                         child: GappedContainerShape(
                           activeColor: Theme.of(context).colorScheme.primary.withOpacity(0.5),
@@ -223,7 +226,8 @@ class _ChapterProgressSliderState extends ConsumerState<ChapterProgressSlider> {
             if (!widget.buffering) ...[
               chapterCard(context, position, isVisible),
               Positioned(
-                left: (constraints.maxWidth / (widget.duration.inMilliseconds / position.inMilliseconds)),
+                left: (constraints.maxWidth / (widget.duration.inMilliseconds / position.inMilliseconds))
+                    .clamp(1, constraints.maxWidth),
                 child: Transform.translate(
                   offset: Offset(-(constraints.maxHeight / 2), 0),
                   child: IgnorePointer(

--- a/lib/util/item_base_model/play_item_helpers.dart
+++ b/lib/util/item_base_model/play_item_helpers.dart
@@ -1,4 +1,10 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
 import 'package:collection/collection.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:window_manager/window_manager.dart';
+
 import 'package:fladder/models/book_model.dart';
 import 'package:fladder/models/item_base_model.dart';
 import 'package:fladder/models/items/photos_model.dart';
@@ -18,11 +24,8 @@ import 'package:fladder/screens/shared/fladder_snackbar.dart';
 import 'package:fladder/screens/video_player/video_player.dart';
 import 'package:fladder/util/adaptive_layout.dart';
 import 'package:fladder/util/list_extensions.dart';
+import 'package:fladder/util/localization_helper.dart';
 import 'package:fladder/util/refresh_state.dart';
-import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:window_manager/window_manager.dart';
 
 Future<void> _showLoadingIndicator(BuildContext context) async {
   return showDialog(
@@ -70,7 +73,7 @@ Future<void> _playVideo(
   if (current == null) {
     if (context.mounted) {
       Navigator.of(context, rootNavigator: true).pop();
-      fladderSnackbar(context, title: "No video found to play");
+      fladderSnackbar(context, title: context.localized.unableToPlayMedia);
     }
     return;
   }
@@ -83,7 +86,7 @@ Future<void> _playVideo(
   if (!loadedCorrectly) {
     if (context.mounted) {
       Navigator.of(context, rootNavigator: true).pop();
-      fladderSnackbar(context, title: "An error occurred loading media");
+      fladderSnackbar(context, title: context.localized.errorOpeningMedia);
     }
     return;
   }
@@ -121,11 +124,10 @@ extension BookBaseModelExtension on BookModel? {
     BuildContext? parentContext,
   }) async {
     if (kIsWeb) {
-      fladderSnackbar(context, title: "Books are not supported on web for now.");
+      fladderSnackbar(context, title: context.localized.unableToPlayBooksOnWeb);
       return;
     }
     if (this == null) {
-      fladderSnackbar(context, title: "Not a selected book");
       return;
     }
     var newProvider = provider;
@@ -237,10 +239,6 @@ extension ItemBaseModelExtensions on ItemBaseModel? {
     } else {
       model = (await ref.read(playbackModelHelper).createServerPlaybackModel(itemModel, PlaybackType.directStream)) ??
           await ref.read(playbackModelHelper).createOfflinePlaybackModel(itemModel, syncedItem);
-    }
-
-    if (model == null) {
-      return;
     }
 
     await _playVideo(context, startPosition: startPosition, current: model, ref: ref);


### PR DESCRIPTION
## Pull Request Description

When no compatible media format is returned we now properly close the loading indicator and show an error message.
Also fixed a small overflow bug that only caused debug logging.