### PR TITLE
Automatically build a Flatpak bundle

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,167 +24,167 @@ jobs:
           echo "version_name=${VERSION_NAME}" >> "$GITHUB_OUTPUT"
         shell: bash
         
-  # build-android:
-  #   needs: [fetch-info]
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v4.1.1
+  build-android:
+    needs: [fetch-info]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4.1.1
 
-  #     - name: Decode Keystore
-  #       env:
-  #         ENCODED_STRING: ${{ secrets.KEYSTORE_BASE_64 }}
-  #         RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
-  #         RELEASE_KEYSTORE_ALIAS: ${{ secrets.RELEASE_KEYSTORE_ALIAS }}
-  #         RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
-  #         GITHUB_RUN_NUMBER: ${{ github.run_number }}
-  #       run: |
-  #         echo "$ENCODED_STRING" | base64 -d > android/app/keystore.jks
+      - name: Decode Keystore
+        env:
+          ENCODED_STRING: ${{ secrets.KEYSTORE_BASE_64 }}
+          RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
+          RELEASE_KEYSTORE_ALIAS: ${{ secrets.RELEASE_KEYSTORE_ALIAS }}
+          RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+          GITHUB_RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          echo "$ENCODED_STRING" | base64 -d > android/app/keystore.jks
 
-  #         # Create the key.properties file
-  #         cat > android/app/key.properties <<EOF
-  #         storePassword=$RELEASE_KEYSTORE_PASSWORD
-  #         keyPassword=$RELEASE_KEY_PASSWORD
-  #         keyAlias=$RELEASE_KEYSTORE_ALIAS
-  #         EOF
+          # Create the key.properties file
+          cat > android/app/key.properties <<EOF
+          storePassword=$RELEASE_KEYSTORE_PASSWORD
+          keyPassword=$RELEASE_KEY_PASSWORD
+          keyAlias=$RELEASE_KEYSTORE_ALIAS
+          EOF
 
-  #     - name: Setup Java
-  #       uses: actions/setup-java@v4
-  #       with:
-  #         distribution: "zulu"
-  #         java-version: "17"
-  #         cache: "gradle"
-  #         check-latest: true
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: "zulu"
+          java-version: "17"
+          cache: "gradle"
+          check-latest: true
 
-  #     - name: Set up Flutter
-  #       uses: subosito/flutter-action@v2.16.0
-  #       with:
-  #         channel: ${{ vars.FLUTTER_CHANNEL }}
-  #         flutter-version: ${{ vars.FLUTTER_VERSION }}
-  #         cache: true
-  #         cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
-  #         cache-path: "${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:"
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2.16.0
+        with:
+          channel: ${{ vars.FLUTTER_CHANNEL }}
+          flutter-version: ${{ vars.FLUTTER_VERSION }}
+          cache: true
+          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
+          cache-path: "${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:"
 
-  #     - name: Get dependencies
-  #       run: flutter pub get
+      - name: Get dependencies
+        run: flutter pub get
 
-  #     - name: Build Android APK and AAB
-  #       run: |
-  #         flutter build apk --release --build-number=${{github.run_number}} --flavor production
-  #         flutter build appbundle --release --build-number=${{github.run_number}} --flavor production    
+      - name: Build Android APK and AAB
+        run: |
+          flutter build apk --release --build-number=${{github.run_number}} --flavor production
+          flutter build appbundle --release --build-number=${{github.run_number}} --flavor production    
 
-  #     - name: Rename APK and AAB
-  #       run: |
-  #         mkdir -p build/app/outputs/android_artifacts
-  #         mv build/app/outputs/flutter-apk/app-production-release.apk "build/app/outputs/android_artifacts/release-signed.apk"
-  #         mv build/app/outputs/bundle/productionRelease/app-production-release.aab "build/app/outputs/android_artifacts/release-signed.aab"
+      - name: Rename APK and AAB
+        run: |
+          mkdir -p build/app/outputs/android_artifacts
+          mv build/app/outputs/flutter-apk/app-production-release.apk "build/app/outputs/android_artifacts/release-signed.apk"
+          mv build/app/outputs/bundle/productionRelease/app-production-release.aab "build/app/outputs/android_artifacts/release-signed.aab"
 
-  #     - name: Archive Android artifacts
-  #       uses: actions/upload-artifact@v4.0.0
-  #       with:
-  #         name: fladder-android
-  #         path: build/app/outputs/android_artifacts/            
+      - name: Archive Android artifacts
+        uses: actions/upload-artifact@v4.0.0
+        with:
+          name: fladder-android
+          path: build/app/outputs/android_artifacts/            
 
-  # build-windows:
-  #   #Use windows-2019, latest(2022) causes MSVCP140.dll related crashes
-  #   runs-on: windows-2019
-  #   needs: [fetch-info]
+  build-windows:
+    #Use windows-2019, latest(2022) causes MSVCP140.dll related crashes
+    runs-on: windows-2019
+    needs: [fetch-info]
 
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v4.1.1
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4.1.1
 
-  #     - name: Set up Flutter
-  #       uses: subosito/flutter-action@v2.16.0
-  #       with:
-  #         channel: ${{ vars.FLUTTER_CHANNEL }}
-  #         flutter-version: ${{ vars.FLUTTER_VERSION }}
-  #         cache: true
-  #         cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:" # optional, change this to force refresh cache
-  #         cache-path: "${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:" # optional, change this to specify the cache path
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2.16.0
+        with:
+          channel: ${{ vars.FLUTTER_CHANNEL }}
+          flutter-version: ${{ vars.FLUTTER_VERSION }}
+          cache: true
+          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:" # optional, change this to force refresh cache
+          cache-path: "${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:" # optional, change this to specify the cache path
 
-  #     - name: Get dependencies
-  #       run: flutter pub get
+      - name: Get dependencies
+        run: flutter pub get
 
-  #     - name: Build Windows EXE
-  #       run: flutter build windows --build-number=${{ github.run_number }}
+      - name: Build Windows EXE
+        run: flutter build windows --build-number=${{ github.run_number }}
 
-  #     - name: Archive Windows artifact
-  #       uses: actions/upload-artifact@v4.0.0
-  #       with:
-  #         name: fladder-windows
-  #         path: build\windows\x64\runner\Release\
+      - name: Archive Windows artifact
+        uses: actions/upload-artifact@v4.0.0
+        with:
+          name: fladder-windows
+          path: build\windows\x64\runner\Release\
 
-  # build-ios:
-  #   runs-on: macos-latest
-  #   needs: [fetch-info]
+  build-ios:
+    runs-on: macos-latest
+    needs: [fetch-info]
 
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v4.1.1
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4.1.1
 
-  #     - name: Set up Flutter
-  #       uses: subosito/flutter-action@v2.16.0
-  #       with:
-  #         channel: ${{ vars.FLUTTER_CHANNEL }}
-  #         flutter-version: ${{ vars.FLUTTER_VERSION }}
-  #         cache: true
-  #         cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:" # optional, change this to specify the cache path
-  #         cache-path: "${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:" # optional, change this to specify the cache path
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2.16.0
+        with:
+          channel: ${{ vars.FLUTTER_CHANNEL }}
+          flutter-version: ${{ vars.FLUTTER_VERSION }}
+          cache: true
+          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:" # optional, change this to specify the cache path
+          cache-path: "${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:" # optional, change this to specify the cache path
 
-  #     - name: Get dependencies
-  #       run: flutter pub get
+      - name: Get dependencies
+        run: flutter pub get
 
-  #     - name: Build iOS app
-  #       run: flutter build ipa --no-codesign --flavor production --build-number=${{ github.run_number }} 
+      - name: Build iOS app
+        run: flutter build ipa --no-codesign --flavor production --build-number=${{ github.run_number }} 
 
-  #     - name: Create unsigned IPA
-  #       run: |
-  #         cd build/ios/archive/Runner.xcarchive/Products/Applications/
-  #         mkdir Payload
-  #         mv Runner.app Payload/
-  #         zip -r iOS.ipa Payload
+      - name: Create unsigned IPA
+        run: |
+          cd build/ios/archive/Runner.xcarchive/Products/Applications/
+          mkdir Payload
+          mv Runner.app Payload/
+          zip -r iOS.ipa Payload
 
-  #     - name: Archive iOS IPA artifact
-  #       uses: actions/upload-artifact@v4.0.0
-  #       with:
-  #         name: fladder-iOS
-  #         path: build/ios/archive/Runner.xcarchive/Products/Applications/iOS.ipa
+      - name: Archive iOS IPA artifact
+        uses: actions/upload-artifact@v4.0.0
+        with:
+          name: fladder-iOS
+          path: build/ios/archive/Runner.xcarchive/Products/Applications/iOS.ipa
 
-  # build-macos:
-  #   runs-on: macos-latest
-  #   needs: [fetch-info]
+  build-macos:
+    runs-on: macos-latest
+    needs: [fetch-info]
     
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v4.1.1
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4.1.1
 
-  #     - name: Set up Flutter
-  #       uses: subosito/flutter-action@v2.16.0
-  #       with:
-  #         channel: ${{ vars.FLUTTER_CHANNEL }}
-  #         flutter-version: ${{ vars.FLUTTER_VERSION }}
-  #         cache: true
-  #         cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:" # optional, change this to force refresh cache
-  #         cache-path: "${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:" # optional, change this to specify the cache path
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2.16.0
+        with:
+          channel: ${{ vars.FLUTTER_CHANNEL }}
+          flutter-version: ${{ vars.FLUTTER_VERSION }}
+          cache: true
+          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:" # optional, change this to force refresh cache
+          cache-path: "${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:" # optional, change this to specify the cache path
 
-  #     - name: Get dependencies
-  #       run: flutter pub get
+      - name: Get dependencies
+        run: flutter pub get
 
-  #     - name: Build macOS app
-  #       run: flutter build macos --flavor production --build-number=${{ github.run_number }}
+      - name: Build macOS app
+        run: flutter build macos --flavor production --build-number=${{ github.run_number }}
 
-  #     - name: Create DMG file
-  #       run:  hdiutil create -format UDZO -srcfolder build/macos/Build/Products/Release-production/fladder.app build/macos/Build/Products/Release-production/macOS.dmg
+      - name: Create DMG file
+        run:  hdiutil create -format UDZO -srcfolder build/macos/Build/Products/Release-production/fladder.app build/macos/Build/Products/Release-production/macOS.dmg
 
-  #     - name: Archive macOS artifact
-  #       uses: actions/upload-artifact@v4.0.0
-  #       with:
-  #         name: fladder-macOS
-  #         path: build/macos/Build/Products/Release-production/macOS.dmg
+      - name: Archive macOS artifact
+        uses: actions/upload-artifact@v4.0.0
+        with:
+          name: fladder-macOS
+          path: build/macos/Build/Products/Release-production/macOS.dmg
 
   build-linux:
-    runs-on: ubuntu-24.04  # bumped as it would otherwise use libmpv1
+    runs-on: ubuntu-24.04  # bumped from 22.04 (latest) as it would otherwise use libmpv1
     needs: [fetch-info]
 
     steps:
@@ -255,110 +255,110 @@ jobs:
           name: fladder-linux-flatpak
           path: Fladder-Linux.flatpak
 
-  # build-web:
-  #   runs-on: ubuntu-latest
-  #   needs: [fetch-info]
+  build-web:
+    runs-on: ubuntu-latest
+    needs: [fetch-info]
 
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v4.1.1
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4.1.1
 
-  #     - name: Set up Flutter
-  #       uses: subosito/flutter-action@v2.16.0
-  #       with:
-  #         channel: ${{ vars.FLUTTER_CHANNEL }}
-  #         flutter-version: ${{ vars.FLUTTER_VERSION }}
-  #         cache: true
-  #         cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:" # optional, change this to force refresh cache
-  #         cache-path: "${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:" # optional, change this to specify the cache path
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2.16.0
+        with:
+          channel: ${{ vars.FLUTTER_CHANNEL }}
+          flutter-version: ${{ vars.FLUTTER_VERSION }}
+          cache: true
+          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:" # optional, change this to force refresh cache
+          cache-path: "${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:" # optional, change this to specify the cache path
 
-  #     - name: Get dependencies
-  #       run: flutter pub get
+      - name: Get dependencies
+        run: flutter pub get
 
-  #     - name: Build web app
-  #       run: |
-  #         flutter build web --release --build-number=${{github.run_number}}
+      - name: Build web app
+        run: |
+          flutter build web --release --build-number=${{github.run_number}}
 
-  #     - name: Archive web artifact
-  #       uses: actions/upload-artifact@v4.0.0
-  #       with:
-  #         name: fladder-web
-  #         path: build/web
+      - name: Archive web artifact
+        uses: actions/upload-artifact@v4.0.0
+        with:
+          name: fladder-web
+          path: build/web
 
-  #     - name: Deploy to ghcr.io
-  #       if: startsWith(github.ref, 'refs/tags/v')
-  #       uses: mr-smithers-excellent/docker-build-push@v6
-  #       with:
-  #         image: fladder
-  #         addLatest: true
-  #         registry: ghcr.io
-  #         username: ${{ github.actor }}
-  #         password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Deploy to ghcr.io
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: mr-smithers-excellent/docker-build-push@v6
+        with:
+          image: fladder
+          addLatest: true
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-  #     - name: Build Github pages web
-  #       if: startsWith(github.ref, 'refs/tags/v')        
-  #       run: flutter build web --base-href /${{ github.event.repository.name }}/ --release --build-number=$GITHUB_RUN_NUMBER
+      - name: Build Github pages web
+        if: startsWith(github.ref, 'refs/tags/v')        
+        run: flutter build web --base-href /${{ github.event.repository.name }}/ --release --build-number=$GITHUB_RUN_NUMBER
 
-  #     - name: Deploy to GitHub Pages
-  #       if: startsWith(github.ref, 'refs/tags/v')        
-  #       uses: peaceiris/actions-gh-pages@v4
-  #       with:
-  #         github_token: ${{ secrets.GITHUB_TOKEN }} # Automatically provided by GitHub Actions
-  #         publish_dir: ./build/web
+      - name: Deploy to GitHub Pages
+        if: startsWith(github.ref, 'refs/tags/v')        
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }} # Automatically provided by GitHub Actions
+          publish_dir: ./build/web
 
   create_release:
     name: Create Release
     needs:
       - fetch-info
-      # - build-android
-      # - build-windows
-      # - build-ios
-      # - build-macos
+      - build-android
+      - build-windows
+      - build-ios
+      - build-macos
       - build-linux
       - build-linux-flatpak
-      # - build-web
+      - build-web
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')       
     steps:
-      # - name: Download Artifacts Android
-      #   uses: actions/download-artifact@v4
-      #   with:
-      #     name: fladder-android
-      #     path: fladder-android
+      - name: Download Artifacts Android
+        uses: actions/download-artifact@v4
+        with:
+          name: fladder-android
+          path: fladder-android
 
-      # - name: Move Android
-      #   run: |
-      #     mv fladder-android/release-signed.apk Fladder-Android-${{needs.fetch-info.outputs.version_name}}.apk
-      #     mv fladder-android/release-signed.aab Fladder-Android-${{needs.fetch-info.outputs.version_name}}.aab
+      - name: Move Android
+        run: |
+          mv fladder-android/release-signed.apk Fladder-Android-${{needs.fetch-info.outputs.version_name}}.apk
+          mv fladder-android/release-signed.aab Fladder-Android-${{needs.fetch-info.outputs.version_name}}.aab
 
-      # - name: Download Artifacts Windows
-      #   uses: actions/download-artifact@v4
-      #   with:
-      #     name: fladder-windows
-      #     path: fladder-windows
+      - name: Download Artifacts Windows
+        uses: actions/download-artifact@v4
+        with:
+          name: fladder-windows
+          path: fladder-windows
 
-      # - name: Compress Windows
-      #   run:  |
-      #     cd fladder-windows
-      #     zip -r ../Fladder-Windows-${{needs.fetch-info.outputs.version_name}}.zip .
+      - name: Compress Windows
+        run:  |
+          cd fladder-windows
+          zip -r ../Fladder-Windows-${{needs.fetch-info.outputs.version_name}}.zip .
       
-      # - name: Download Artifacts iOS
-      #   uses: actions/download-artifact@v4
-      #   with:
-      #     name: fladder-iOS
-      #     path: fladder-iOS
+      - name: Download Artifacts iOS
+        uses: actions/download-artifact@v4
+        with:
+          name: fladder-iOS
+          path: fladder-iOS
 
-      # - name: Move iOS
-      #   run: mv fladder-iOS/iOS.ipa Fladder-iOS-${{needs.fetch-info.outputs.version_name}}.ipa
+      - name: Move iOS
+        run: mv fladder-iOS/iOS.ipa Fladder-iOS-${{needs.fetch-info.outputs.version_name}}.ipa
 
-      # - name: Download Artifacts macOS
-      #   uses: actions/download-artifact@v4
-      #   with:
-      #     name: fladder-macOS
-      #     path: fladder-macOS
+      - name: Download Artifacts macOS
+        uses: actions/download-artifact@v4
+        with:
+          name: fladder-macOS
+          path: fladder-macOS
 
-      # - name: Move macOS
-      #   run: mv fladder-macOS/macOS.dmg Fladder-macOS-${{needs.fetch-info.outputs.version_name}}.dmg
+      - name: Move macOS
+        run: mv fladder-macOS/macOS.dmg Fladder-macOS-${{needs.fetch-info.outputs.version_name}}.dmg
 
       - name: Download Artifacts Linux
         uses: actions/download-artifact@v4
@@ -380,16 +380,16 @@ jobs:
       - name: Move Linux Flatpak
         run: mv fladder-linux-flatpak/Fladder-Linux.flatpak Fladder-Linux-${{needs.fetch-info.outputs.version_name}}.flatpak
 
-      # - name: Download Artifacts Web
-      #   uses: actions/download-artifact@v4
-      #   with:
-      #     name: fladder-web
-      #     path: fladder-web
+      - name: Download Artifacts Web
+        uses: actions/download-artifact@v4
+        with:
+          name: fladder-web
+          path: fladder-web
 
-      # - name: Compress Web
-      #   run: |
-      #     cd fladder-web
-      #     zip -r ../Fladder-Web-${{needs.fetch-info.outputs.version_name}}.zip .
+      - name: Compress Web
+        run: |
+          cd fladder-web
+          zip -r ../Fladder-Web-${{needs.fetch-info.outputs.version_name}}.zip .
 
       - name: Release
         uses: softprops/action-gh-release@v2
@@ -397,12 +397,12 @@ jobs:
           draft: true
           fail_on_unmatched_files: true
           generate_release_notes: true
-            # Fladder-Android-${{needs.fetch-info.outputs.version_name}}.apk
-            # Fladder-Windows-${{needs.fetch-info.outputs.version_name}}.zip
-            # Fladder-iOS-${{needs.fetch-info.outputs.version_name}}.ipa
-            # Fladder-macOS-${{needs.fetch-info.outputs.version_name}}.dmg
-            # Fladder-Web-${{needs.fetch-info.outputs.version_name}}.zip
           files: |
+            Fladder-Android-${{needs.fetch-info.outputs.version_name}}.apk
+            Fladder-Windows-${{needs.fetch-info.outputs.version_name}}.zip
+            Fladder-iOS-${{needs.fetch-info.outputs.version_name}}.ipa
+            Fladder-macOS-${{needs.fetch-info.outputs.version_name}}.dmg
+            Fladder-Web-${{needs.fetch-info.outputs.version_name}}.zip
             Fladder-Linux-${{needs.fetch-info.outputs.version_name}}.zip
             Fladder-Linux-${{needs.fetch-info.outputs.version_name}}.flatpak
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,167 +24,167 @@ jobs:
           echo "version_name=${VERSION_NAME}" >> "$GITHUB_OUTPUT"
         shell: bash
         
-  build-android:
-    needs: [fetch-info]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4.1.1
+  # build-android:
+  #   needs: [fetch-info]
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v4.1.1
 
-      - name: Decode Keystore
-        env:
-          ENCODED_STRING: ${{ secrets.KEYSTORE_BASE_64 }}
-          RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
-          RELEASE_KEYSTORE_ALIAS: ${{ secrets.RELEASE_KEYSTORE_ALIAS }}
-          RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
-          GITHUB_RUN_NUMBER: ${{ github.run_number }}
-        run: |
-          echo "$ENCODED_STRING" | base64 -d > android/app/keystore.jks
+  #     - name: Decode Keystore
+  #       env:
+  #         ENCODED_STRING: ${{ secrets.KEYSTORE_BASE_64 }}
+  #         RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
+  #         RELEASE_KEYSTORE_ALIAS: ${{ secrets.RELEASE_KEYSTORE_ALIAS }}
+  #         RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+  #         GITHUB_RUN_NUMBER: ${{ github.run_number }}
+  #       run: |
+  #         echo "$ENCODED_STRING" | base64 -d > android/app/keystore.jks
 
-          # Create the key.properties file
-          cat > android/app/key.properties <<EOF
-          storePassword=$RELEASE_KEYSTORE_PASSWORD
-          keyPassword=$RELEASE_KEY_PASSWORD
-          keyAlias=$RELEASE_KEYSTORE_ALIAS
-          EOF
+  #         # Create the key.properties file
+  #         cat > android/app/key.properties <<EOF
+  #         storePassword=$RELEASE_KEYSTORE_PASSWORD
+  #         keyPassword=$RELEASE_KEY_PASSWORD
+  #         keyAlias=$RELEASE_KEYSTORE_ALIAS
+  #         EOF
 
-      - name: Setup Java
-        uses: actions/setup-java@v4
-        with:
-          distribution: "zulu"
-          java-version: "17"
-          cache: "gradle"
-          check-latest: true
+  #     - name: Setup Java
+  #       uses: actions/setup-java@v4
+  #       with:
+  #         distribution: "zulu"
+  #         java-version: "17"
+  #         cache: "gradle"
+  #         check-latest: true
 
-      - name: Set up Flutter
-        uses: subosito/flutter-action@v2.16.0
-        with:
-          channel: ${{ vars.FLUTTER_CHANNEL }}
-          flutter-version: ${{ vars.FLUTTER_VERSION }}
-          cache: true
-          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
-          cache-path: "${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:"
+  #     - name: Set up Flutter
+  #       uses: subosito/flutter-action@v2.16.0
+  #       with:
+  #         channel: ${{ vars.FLUTTER_CHANNEL }}
+  #         flutter-version: ${{ vars.FLUTTER_VERSION }}
+  #         cache: true
+  #         cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
+  #         cache-path: "${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:"
 
-      - name: Get dependencies
-        run: flutter pub get
+  #     - name: Get dependencies
+  #       run: flutter pub get
 
-      - name: Build Android APK and AAB
-        run: |
-          flutter build apk --release --build-number=${{github.run_number}} --flavor production
-          flutter build appbundle --release --build-number=${{github.run_number}} --flavor production    
+  #     - name: Build Android APK and AAB
+  #       run: |
+  #         flutter build apk --release --build-number=${{github.run_number}} --flavor production
+  #         flutter build appbundle --release --build-number=${{github.run_number}} --flavor production    
 
-      - name: Rename APK and AAB
-        run: |
-          mkdir -p build/app/outputs/android_artifacts
-          mv build/app/outputs/flutter-apk/app-production-release.apk "build/app/outputs/android_artifacts/release-signed.apk"
-          mv build/app/outputs/bundle/productionRelease/app-production-release.aab "build/app/outputs/android_artifacts/release-signed.aab"
+  #     - name: Rename APK and AAB
+  #       run: |
+  #         mkdir -p build/app/outputs/android_artifacts
+  #         mv build/app/outputs/flutter-apk/app-production-release.apk "build/app/outputs/android_artifacts/release-signed.apk"
+  #         mv build/app/outputs/bundle/productionRelease/app-production-release.aab "build/app/outputs/android_artifacts/release-signed.aab"
 
-      - name: Archive Android artifacts
-        uses: actions/upload-artifact@v4.0.0
-        with:
-          name: fladder-android
-          path: build/app/outputs/android_artifacts/            
+  #     - name: Archive Android artifacts
+  #       uses: actions/upload-artifact@v4.0.0
+  #       with:
+  #         name: fladder-android
+  #         path: build/app/outputs/android_artifacts/            
 
-  build-windows:
-    #Use windows-2019, latest(2022) causes MSVCP140.dll related crashes
-    runs-on: windows-2019
-    needs: [fetch-info]
+  # build-windows:
+  #   #Use windows-2019, latest(2022) causes MSVCP140.dll related crashes
+  #   runs-on: windows-2019
+  #   needs: [fetch-info]
 
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4.1.1
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v4.1.1
 
-      - name: Set up Flutter
-        uses: subosito/flutter-action@v2.16.0
-        with:
-          channel: ${{ vars.FLUTTER_CHANNEL }}
-          flutter-version: ${{ vars.FLUTTER_VERSION }}
-          cache: true
-          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:" # optional, change this to force refresh cache
-          cache-path: "${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:" # optional, change this to specify the cache path
+  #     - name: Set up Flutter
+  #       uses: subosito/flutter-action@v2.16.0
+  #       with:
+  #         channel: ${{ vars.FLUTTER_CHANNEL }}
+  #         flutter-version: ${{ vars.FLUTTER_VERSION }}
+  #         cache: true
+  #         cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:" # optional, change this to force refresh cache
+  #         cache-path: "${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:" # optional, change this to specify the cache path
 
-      - name: Get dependencies
-        run: flutter pub get
+  #     - name: Get dependencies
+  #       run: flutter pub get
 
-      - name: Build Windows EXE
-        run: flutter build windows --build-number=${{ github.run_number }}
+  #     - name: Build Windows EXE
+  #       run: flutter build windows --build-number=${{ github.run_number }}
 
-      - name: Archive Windows artifact
-        uses: actions/upload-artifact@v4.0.0
-        with:
-          name: fladder-windows
-          path: build\windows\x64\runner\Release\
+  #     - name: Archive Windows artifact
+  #       uses: actions/upload-artifact@v4.0.0
+  #       with:
+  #         name: fladder-windows
+  #         path: build\windows\x64\runner\Release\
 
-  build-ios:
-    runs-on: macos-latest
-    needs: [fetch-info]
+  # build-ios:
+  #   runs-on: macos-latest
+  #   needs: [fetch-info]
 
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4.1.1
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v4.1.1
 
-      - name: Set up Flutter
-        uses: subosito/flutter-action@v2.16.0
-        with:
-          channel: ${{ vars.FLUTTER_CHANNEL }}
-          flutter-version: ${{ vars.FLUTTER_VERSION }}
-          cache: true
-          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:" # optional, change this to specify the cache path
-          cache-path: "${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:" # optional, change this to specify the cache path
+  #     - name: Set up Flutter
+  #       uses: subosito/flutter-action@v2.16.0
+  #       with:
+  #         channel: ${{ vars.FLUTTER_CHANNEL }}
+  #         flutter-version: ${{ vars.FLUTTER_VERSION }}
+  #         cache: true
+  #         cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:" # optional, change this to specify the cache path
+  #         cache-path: "${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:" # optional, change this to specify the cache path
 
-      - name: Get dependencies
-        run: flutter pub get
+  #     - name: Get dependencies
+  #       run: flutter pub get
 
-      - name: Build iOS app
-        run: flutter build ipa --no-codesign --flavor production --build-number=${{ github.run_number }} 
+  #     - name: Build iOS app
+  #       run: flutter build ipa --no-codesign --flavor production --build-number=${{ github.run_number }} 
 
-      - name: Create unsigned IPA
-        run: |
-          cd build/ios/archive/Runner.xcarchive/Products/Applications/
-          mkdir Payload
-          mv Runner.app Payload/
-          zip -r iOS.ipa Payload
+  #     - name: Create unsigned IPA
+  #       run: |
+  #         cd build/ios/archive/Runner.xcarchive/Products/Applications/
+  #         mkdir Payload
+  #         mv Runner.app Payload/
+  #         zip -r iOS.ipa Payload
 
-      - name: Archive iOS IPA artifact
-        uses: actions/upload-artifact@v4.0.0
-        with:
-          name: fladder-iOS
-          path: build/ios/archive/Runner.xcarchive/Products/Applications/iOS.ipa
+  #     - name: Archive iOS IPA artifact
+  #       uses: actions/upload-artifact@v4.0.0
+  #       with:
+  #         name: fladder-iOS
+  #         path: build/ios/archive/Runner.xcarchive/Products/Applications/iOS.ipa
 
-  build-macos:
-    runs-on: macos-latest
-    needs: [fetch-info]
+  # build-macos:
+  #   runs-on: macos-latest
+  #   needs: [fetch-info]
     
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4.1.1
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v4.1.1
 
-      - name: Set up Flutter
-        uses: subosito/flutter-action@v2.16.0
-        with:
-          channel: ${{ vars.FLUTTER_CHANNEL }}
-          flutter-version: ${{ vars.FLUTTER_VERSION }}
-          cache: true
-          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:" # optional, change this to force refresh cache
-          cache-path: "${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:" # optional, change this to specify the cache path
+  #     - name: Set up Flutter
+  #       uses: subosito/flutter-action@v2.16.0
+  #       with:
+  #         channel: ${{ vars.FLUTTER_CHANNEL }}
+  #         flutter-version: ${{ vars.FLUTTER_VERSION }}
+  #         cache: true
+  #         cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:" # optional, change this to force refresh cache
+  #         cache-path: "${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:" # optional, change this to specify the cache path
 
-      - name: Get dependencies
-        run: flutter pub get
+  #     - name: Get dependencies
+  #       run: flutter pub get
 
-      - name: Build macOS app
-        run: flutter build macos --flavor production --build-number=${{ github.run_number }}
+  #     - name: Build macOS app
+  #       run: flutter build macos --flavor production --build-number=${{ github.run_number }}
 
-      - name: Create DMG file
-        run:  hdiutil create -format UDZO -srcfolder build/macos/Build/Products/Release-production/fladder.app build/macos/Build/Products/Release-production/macOS.dmg
+  #     - name: Create DMG file
+  #       run:  hdiutil create -format UDZO -srcfolder build/macos/Build/Products/Release-production/fladder.app build/macos/Build/Products/Release-production/macOS.dmg
 
-      - name: Archive macOS artifact
-        uses: actions/upload-artifact@v4.0.0
-        with:
-          name: fladder-macOS
-          path: build/macos/Build/Products/Release-production/macOS.dmg
+  #     - name: Archive macOS artifact
+  #       uses: actions/upload-artifact@v4.0.0
+  #       with:
+  #         name: fladder-macOS
+  #         path: build/macos/Build/Products/Release-production/macOS.dmg
 
   build-linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04  # bumped as it would otherwise use libmpv1
     needs: [fetch-info]
 
     steps:
@@ -206,7 +206,7 @@ jobs:
       - name: Get packages
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y ninja-build libgtk-3-dev libmpv-dev patchelf
+          sudo apt-get install -y ninja-build libgtk-3-dev libmpv-dev patchelf cmake clang
 
       - name: Build Linux app
         run: flutter build linux --release --build-number=${{ github.run_number }}
@@ -225,102 +225,140 @@ jobs:
           name: fladder-linux
           path: build/linux/x64/release/bundle
 
-  build-web:
+  build-linux-flatpak:
+    name: "Flatpak"
     runs-on: ubuntu-latest
-    needs: [fetch-info]
-
+    needs: [fetch-info, build-linux]
+    container:
+      image: bilelmoussaoui/flatpak-github-actions:gnome-46
+      options: --privileged
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4.1.1
-
-      - name: Set up Flutter
-        uses: subosito/flutter-action@v2.16.0
         with:
-          channel: ${{ vars.FLUTTER_CHANNEL }}
-          flutter-version: ${{ vars.FLUTTER_VERSION }}
-          cache: true
-          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:" # optional, change this to force refresh cache
-          cache-path: "${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:" # optional, change this to specify the cache path
+          submodules: true
 
-      - name: Get dependencies
-        run: flutter pub get
-
-      - name: Build web app
-        run: |
-          flutter build web --release --build-number=${{github.run_number}}
-
-      - name: Archive web artifact
-        uses: actions/upload-artifact@v4.0.0
+      - name: Download Artifacts Linux
+        uses: actions/download-artifact@v4
         with:
-          name: fladder-web
-          path: build/web
+          name: fladder-linux
+          path: build/linux/x64/release/bundle
 
-      - name: Deploy to ghcr.io
-        if: startsWith(github.ref, 'refs/tags/v')
-        uses: mr-smithers-excellent/docker-build-push@v6
+      - uses: flatpak/flatpak-github-actions/flatpak-builder@v6
         with:
-          image: fladder
-          addLatest: true
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          bundle: Fladder-Linux.flatpak
+          manifest-path: flatpak/nl.jknaapen.fladder.yaml
 
-      - name: Build Github pages web
-        if: startsWith(github.ref, 'refs/tags/v')        
-        run: flutter build web --base-href /${{ github.event.repository.name }}/ --release --build-number=$GITHUB_RUN_NUMBER
-
-      - name: Deploy to GitHub Pages
-        if: startsWith(github.ref, 'refs/tags/v')        
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Archive Linux Flatpak bundle
+        uses: actions/upload-artifact@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }} # Automatically provided by GitHub Actions
-          publish_dir: ./build/web
+          name: fladder-linux-flatpak
+          path: Fladder-Linux.flatpak
+
+  # build-web:
+  #   runs-on: ubuntu-latest
+  #   needs: [fetch-info]
+
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v4.1.1
+
+  #     - name: Set up Flutter
+  #       uses: subosito/flutter-action@v2.16.0
+  #       with:
+  #         channel: ${{ vars.FLUTTER_CHANNEL }}
+  #         flutter-version: ${{ vars.FLUTTER_VERSION }}
+  #         cache: true
+  #         cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:" # optional, change this to force refresh cache
+  #         cache-path: "${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:" # optional, change this to specify the cache path
+
+  #     - name: Get dependencies
+  #       run: flutter pub get
+
+  #     - name: Build web app
+  #       run: |
+  #         flutter build web --release --build-number=${{github.run_number}}
+
+  #     - name: Archive web artifact
+  #       uses: actions/upload-artifact@v4.0.0
+  #       with:
+  #         name: fladder-web
+  #         path: build/web
+
+  #     - name: Deploy to ghcr.io
+  #       if: startsWith(github.ref, 'refs/tags/v')
+  #       uses: mr-smithers-excellent/docker-build-push@v6
+  #       with:
+  #         image: fladder
+  #         addLatest: true
+  #         registry: ghcr.io
+  #         username: ${{ github.actor }}
+  #         password: ${{ secrets.GITHUB_TOKEN }}
+
+  #     - name: Build Github pages web
+  #       if: startsWith(github.ref, 'refs/tags/v')        
+  #       run: flutter build web --base-href /${{ github.event.repository.name }}/ --release --build-number=$GITHUB_RUN_NUMBER
+
+  #     - name: Deploy to GitHub Pages
+  #       if: startsWith(github.ref, 'refs/tags/v')        
+  #       uses: peaceiris/actions-gh-pages@v4
+  #       with:
+  #         github_token: ${{ secrets.GITHUB_TOKEN }} # Automatically provided by GitHub Actions
+  #         publish_dir: ./build/web
 
   create_release:
     name: Create Release
-    needs: [fetch-info,build-android,build-windows,build-ios,build-macos,build-linux,build-web]
+    needs:
+      - fetch-info
+      # - build-android
+      # - build-windows
+      # - build-ios
+      # - build-macos
+      - build-linux
+      - build-linux-flatpak
+      # - build-web
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')       
     steps:
-      - name: Download Artifacts Android
-        uses: actions/download-artifact@v4
-        with:
-          name: fladder-android
-          path: fladder-android
+      # - name: Download Artifacts Android
+      #   uses: actions/download-artifact@v4
+      #   with:
+      #     name: fladder-android
+      #     path: fladder-android
 
-      - name: Move Android
-        run: |
-          mv fladder-android/release-signed.apk Fladder-Android-${{needs.fetch-info.outputs.version_name}}.apk
-          mv fladder-android/release-signed.aab Fladder-Android-${{needs.fetch-info.outputs.version_name}}.aab
+      # - name: Move Android
+      #   run: |
+      #     mv fladder-android/release-signed.apk Fladder-Android-${{needs.fetch-info.outputs.version_name}}.apk
+      #     mv fladder-android/release-signed.aab Fladder-Android-${{needs.fetch-info.outputs.version_name}}.aab
 
-      - name: Download Artifacts Windows
-        uses: actions/download-artifact@v4
-        with:
-          name: fladder-windows
-          path: fladder-windows
+      # - name: Download Artifacts Windows
+      #   uses: actions/download-artifact@v4
+      #   with:
+      #     name: fladder-windows
+      #     path: fladder-windows
 
-      - name: Compress Windows
-        run:  |
-          cd fladder-windows
-          zip -r ../Fladder-Windows-${{needs.fetch-info.outputs.version_name}}.zip .
+      # - name: Compress Windows
+      #   run:  |
+      #     cd fladder-windows
+      #     zip -r ../Fladder-Windows-${{needs.fetch-info.outputs.version_name}}.zip .
       
-      - name: Download Artifacts iOS
-        uses: actions/download-artifact@v4
-        with:
-          name: fladder-iOS
-          path: fladder-iOS
+      # - name: Download Artifacts iOS
+      #   uses: actions/download-artifact@v4
+      #   with:
+      #     name: fladder-iOS
+      #     path: fladder-iOS
 
-      - name: Move iOS
-        run: mv fladder-iOS/iOS.ipa Fladder-iOS-${{needs.fetch-info.outputs.version_name}}.ipa
+      # - name: Move iOS
+      #   run: mv fladder-iOS/iOS.ipa Fladder-iOS-${{needs.fetch-info.outputs.version_name}}.ipa
 
-      - name: Download Artifacts macOS
-        uses: actions/download-artifact@v4
-        with:
-          name: fladder-macOS
-          path: fladder-macOS
+      # - name: Download Artifacts macOS
+      #   uses: actions/download-artifact@v4
+      #   with:
+      #     name: fladder-macOS
+      #     path: fladder-macOS
 
-      - name: Move macOS
-        run: mv fladder-macOS/macOS.dmg Fladder-macOS-${{needs.fetch-info.outputs.version_name}}.dmg
+      # - name: Move macOS
+      #   run: mv fladder-macOS/macOS.dmg Fladder-macOS-${{needs.fetch-info.outputs.version_name}}.dmg
 
       - name: Download Artifacts Linux
         uses: actions/download-artifact@v4
@@ -333,16 +371,25 @@ jobs:
           cd fladder-linux
           zip -r ../Fladder-Linux-${{needs.fetch-info.outputs.version_name}}.zip .
 
-      - name: Download Artifacts Web
+      - name: Download Artifacts Linux Flatpak
         uses: actions/download-artifact@v4
         with:
-          name: fladder-web
-          path: fladder-web
+          name: fladder-linux-flatpak
+          path: fladder-linux-flatpak
 
-      - name: Compress Web
-        run: |
-          cd fladder-web
-          zip -r ../Fladder-Web-${{needs.fetch-info.outputs.version_name}}.zip .
+      - name: Move Linux Flatpak
+        run: mv fladder-linux-flatpak/Fladder-Linux.flatpak Fladder-Linux-${{needs.fetch-info.outputs.version_name}}.flatpak
+
+      # - name: Download Artifacts Web
+      #   uses: actions/download-artifact@v4
+      #   with:
+      #     name: fladder-web
+      #     path: fladder-web
+
+      # - name: Compress Web
+      #   run: |
+      #     cd fladder-web
+      #     zip -r ../Fladder-Web-${{needs.fetch-info.outputs.version_name}}.zip .
 
       - name: Release
         uses: softprops/action-gh-release@v2
@@ -350,12 +397,13 @@ jobs:
           draft: true
           fail_on_unmatched_files: true
           generate_release_notes: true
+            # Fladder-Android-${{needs.fetch-info.outputs.version_name}}.apk
+            # Fladder-Windows-${{needs.fetch-info.outputs.version_name}}.zip
+            # Fladder-iOS-${{needs.fetch-info.outputs.version_name}}.ipa
+            # Fladder-macOS-${{needs.fetch-info.outputs.version_name}}.dmg
+            # Fladder-Web-${{needs.fetch-info.outputs.version_name}}.zip
           files: |
-            Fladder-Android-${{needs.fetch-info.outputs.version_name}}.apk
-            Fladder-Windows-${{needs.fetch-info.outputs.version_name}}.zip
-            Fladder-iOS-${{needs.fetch-info.outputs.version_name}}.ipa
-            Fladder-macOS-${{needs.fetch-info.outputs.version_name}}.dmg
             Fladder-Linux-${{needs.fetch-info.outputs.version_name}}.zip
-            Fladder-Web-${{needs.fetch-info.outputs.version_name}}.zip
+            Fladder-Linux-${{needs.fetch-info.outputs.version_name}}.flatpak
 
   

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ app.*.map.json
 
 # FVM Version Cache
 .fvm/
+
+# flatpak
+.flatpak-builder

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = flatpak/shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/flatpak/Fladder.desktop
+++ b/flatpak/Fladder.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=Fladder
+StartupWMClass=nl.jknaapen.fladder
+Comment=A Simple Jellyfin Frontend built on top of Flutter.
+Exec=Fladder
+Icon=nl.jknaapen.fladder
+Terminal=false
+Type=Application
+Categories=Entertainment;

--- a/flatpak/nl.jknaapen.fladder.yaml
+++ b/flatpak/nl.jknaapen.fladder.yaml
@@ -1,0 +1,216 @@
+id: nl.jknaapen.fladder
+runtime: org.gnome.Platform
+runtime-version: '46'
+sdk: org.gnome.Sdk
+
+command: Fladder
+finish-args:
+  # X11/Wayland access
+  - --share=ipc
+  - --socket=fallback-x11
+  - --socket=wayland
+  # Audio playback
+  - --socket=pulseaudio
+  # Network access for Jellyfin streaming
+  - --share=network
+  # File access for downloads/media
+  - --filesystem=home
+  # Hardware acceleration
+  - --device=dri
+  # Allow notification access
+  - --talk-name=org.freedesktop.Notifications
+  - --talk-name=org.freedesktop.PowerManagement
+  - --talk-name=org.freedesktop.ScreenSaver
+  - --talk-name=org.freedesktop.portal.*
+
+modules:
+  - name: mpv
+    buildsystem: meson
+    config-opts:
+      - -Dlibmpv=true
+      - -Dcplayer=false
+      - -Dbuild-date=false
+      - -Dmanpage-build=disabled
+      - -Dvaapi=enabled
+      - -Dcuda-hwaccel=enabled
+      - -Dpulse=enabled
+      - -Dalsa=enabled
+      - -Duchardet=enabled
+    cleanup:
+      - /lib/pkgconfig
+      - /share
+      - /include
+    sources:
+      - type: git
+        url: https://github.com/mpv-player/mpv.git
+        tag: v0.39.0
+        commit: a0fba7be57f3822d967b04f0f6b6d6341e7516e7
+        x-checker-data:
+          type: git
+          tag-pattern: ^v([\d.]+)$
+    modules:
+      - name: ffnvcodec
+        buildsystem: simple
+        build-commands:
+          - make install PREFIX=/app
+        cleanup:
+          - /lib/pkgconfig
+          - /include
+        sources:
+          - type: git
+            url: https://github.com/FFmpeg/nv-codec-headers.git
+            tag: n12.2.72.0
+            commit: c69278340ab1d5559c7d7bf0edf615dc33ddbba7
+            x-checker-data:
+              type: git
+              tag-pattern: ^n([\d.]+)$
+
+      - name: ffmpeg
+        config-opts:
+          - --enable-shared
+          - --disable-static
+          - --enable-gnutls
+          - --enable-pic
+          - --disable-doc
+          - --disable-programs
+          - --disable-encoders
+          - --disable-muxers
+          - --disable-devices
+          - --enable-vaapi
+          - --enable-cuvid
+          - --enable-libdav1d
+          - --enable-gpl
+        cleanup:
+          - /lib/pkgconfig
+          - /share
+          - /include
+        sources:
+          - type: git
+            url: https://github.com/FFmpeg/FFmpeg.git
+            tag: n7.1
+            commit: b08d7969c550a804a59511c7b83f2dd8cc0499b8
+            x-checker-data:
+              type: git
+              tag-pattern: ^n([\d.]+)$
+
+      - shared-modules/luajit/luajit.json
+
+      - name: libass
+        config-opts:
+          - --enable-shared
+          - --disable-static
+        cleanup:
+          - /lib/*.la
+          - /lib/pkgconfig
+          - /include
+        sources:
+          - type: git
+            url: https://github.com/libass/libass.git
+            tag: 0.17.3
+            commit: e46aedea0a0d17da4c4ef49d84b94a7994664ab5
+            x-checker-data:
+              type: git
+              tag-pattern: ^([\d.]+)$
+
+      - name: uchardet
+        buildsystem: cmake-ninja
+        config-opts:
+          - -DCMAKE_BUILD_TYPE=Release
+          - -DCMAKE_INSTALL_LIBDIR=lib
+          - -DBUILD_BINARY=OFF
+        cleanup:
+          - /lib/*.a
+          - /lib/pkgconfig
+          - /share
+          - /include
+        sources:
+          - type: archive
+            url: https://www.freedesktop.org/software/uchardet/releases/uchardet-0.0.8.tar.xz
+            sha256: e97a60cfc00a1c147a674b097bb1422abd9fa78a2d9ce3f3fdcc2e78a34ac5f0
+            x-checker-data:
+              type: html
+              url: https://www.freedesktop.org/software/uchardet/releases/
+              version-pattern: uchardet-(\d+\.\d+\.\d+)\.tar\.xz
+              url-template: https://www.freedesktop.org/software/uchardet/releases/uchardet-$version.tar.xz
+
+      - name: libplacebo
+        buildsystem: meson
+        config-opts:
+          - -Dvulkan=enabled
+          - -Dshaderc=enabled
+        cleanup:
+          - /include
+          - /lib/pkgconfig
+        sources:
+          - type: git
+            url: https://code.videolan.org/videolan/libplacebo.git
+            tag: v7.349.0
+            commit: 1fd3c7bde7b943fe8985c893310b5269a09b46c5
+            x-checker-data:
+              type: git
+              tag-pattern: ^v([\d.]+)$
+        modules:
+          - name: shaderc
+            buildsystem: cmake-ninja
+            builddir: true
+            config-opts:
+              - -DSHADERC_SKIP_COPYRIGHT_CHECK=ON
+              - -DSHADERC_SKIP_EXAMPLES=ON
+              - -DSHADERC_SKIP_TESTS=ON
+              - -DSPIRV_SKIP_EXECUTABLES=ON
+              - -DENABLE_GLSLANG_BINARIES=OFF
+              - -DCMAKE_BUILD_TYPE=Release
+            cleanup:
+              - /bin
+              - /include
+              - /lib/*.a
+              - /lib/cmake
+              - /lib/pkgconfig
+            sources:
+              - type: git
+                url: https://github.com/google/shaderc.git
+                tag: v2024.2
+                commit: 3ac03b8ad85a8e328a6182cddee8d05810bd5a2c
+                x-checker-data:
+                  type: git
+                  tag-pattern: ^v([\d.]+)$
+              - type: git
+                url: https://github.com/KhronosGroup/SPIRV-Tools.git
+                tag: v2023.2
+                commit: 44d72a9b36702f093dd20815561a56778b2d181e
+                dest: third_party/spirv-tools
+              - type: git
+                url: https://github.com/KhronosGroup/SPIRV-Headers.git
+                tag: sdk-1.3.250.1
+                commit: 268a061764ee69f09a477a695bf6a11ffe311b8d
+                dest: third_party/spirv-headers
+              - type: git
+                url: https://github.com/KhronosGroup/glslang.git
+                tag: 14.3.0
+                commit: fa9c3deb49e035a8abcabe366f26aac010f6cbfb
+                dest: third_party/glslang
+                x-checker-data:
+                  type: git
+                  tag-pattern: ^([\d.]+)$
+
+  - name: zenity
+    buildsystem: meson
+    sources:
+      - type: git
+        url: https://gitlab.gnome.org/GNOME/zenity.git
+        tag: 4.0.3
+        commit: 7f7ac1840cfd914dfac69d947f0849dc50b0f695
+
+  - name: fladder
+    buildsystem: simple
+    build-commands:
+      - mkdir -p /app/bin
+      - cp -r build/linux/x64/release/bundle/* /app/bin/
+      - chmod +x /app/bin/Fladder
+      - mkdir -p /app/share/applications
+      - mkdir -p /app/share/icons/hicolor/scalable/apps
+      - install -Dm644 flatpak/Fladder.desktop /app/share/applications/${FLATPAK_ID}.desktop
+      - install -Dm644 icons/fladder_icon.svg /app/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg
+    sources:
+      - type: dir
+        path: ..

--- a/linux/my_application.cc
+++ b/linux/my_application.cc
@@ -109,6 +109,7 @@ static void my_application_init(MyApplication *self) {}
 
 MyApplication *my_application_new()
 {
+	g_set_prgname(APPLICATION_ID);
 	return MY_APPLICATION(g_object_new(my_application_get_type(),
 									   "application-id", APPLICATION_ID,
 									   "flags", G_APPLICATION_NON_UNIQUE,


### PR DESCRIPTION
## Pull Request Description

This adds the manifest file to build a flatpak bundle with each release. It does not cover publishing to Flathub, which is a different topic IMO.

Heavily inspired by the [Jellyfin Media Player flatpak manifest](https://github.com/flathub/com.github.iwalton3.jellyfin-media-player/blob/master/com.github.iwalton3.jellyfin-media-player.json), building ffmpeg, mpv and other dependencies by source as recommended for flatpaks.

## Issue Being Fixed

It is a potential solution to #53

## Checklist

- [X] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [X Check that any changes are related to the issue at hand.
