### PR TITLE
bugfix: Fix sending NowPlayingQueue in progress reports

### DIFF
--- a/lib/models/playback/direct_playback_model.dart
+++ b/lib/models/playback/direct_playback_model.dart
@@ -121,7 +121,6 @@ class DirectPlaybackModel implements PlaybackModel {
             isMuted: false,
             isPaused: false,
             repeatMode: RepeatMode.repeatall,
-            nowPlayingQueue: itemsInQueue,
           ),
         );
     return null;
@@ -138,7 +137,6 @@ class DirectPlaybackModel implements PlaybackModel {
             playSessionId: playbackInfo.playSessionId,
             positionTicks: position.toRuntimeTicks,
             failed: false,
-            nowPlayingQueue: itemsInQueue,
           ),
           totalDuration: totalDuration,
         );
@@ -170,7 +168,6 @@ class DirectPlaybackModel implements PlaybackModel {
         isMuted: false,
         positionTicks: position.toRuntimeTicks,
         repeatMode: RepeatMode.repeatall,
-        nowPlayingQueue: itemsInQueue,
       ),
     );
 

--- a/lib/models/playback/transcode_playback_model.dart
+++ b/lib/models/playback/transcode_playback_model.dart
@@ -122,7 +122,6 @@ class TranscodePlaybackModel implements PlaybackModel {
             isMuted: false,
             isPaused: false,
             repeatMode: RepeatMode.repeatall,
-            nowPlayingQueue: itemsInQueue,
           ),
         );
     return null;
@@ -139,7 +138,6 @@ class TranscodePlaybackModel implements PlaybackModel {
             playSessionId: playbackInfo.playSessionId,
             positionTicks: position.toRuntimeTicks,
             failed: false,
-            nowPlayingQueue: itemsInQueue,
           ),
           totalDuration: totalDuration,
         );
@@ -172,7 +170,6 @@ class TranscodePlaybackModel implements PlaybackModel {
         isPaused: !isPlaying,
         isMuted: false,
         repeatMode: RepeatMode.repeatall,
-        nowPlayingQueue: itemsInQueue,
       ),
     );
     return this;


### PR DESCRIPTION
## Pull Request Description

Fixes a potential thread pool starvation error on the server side when reporting the player's progress, by not sending any `NowPlayingQueue`. The `Next Up` banner/screen still shows up at the end of the content, and I haven't found any side effects.

## Issue Being Fixed

Resolves #121

## Screenshots / Recordings


## Checklist

- [X] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [X] Check that any changes are related to the issue at hand.
