### PR TITLE
fix: specials being shown in season views

### DIFF
--- a/lib/models/items/season_model.dart
+++ b/lib/models/items/season_model.dart
@@ -1,10 +1,9 @@
 // ignore_for_file: public_member_api_docs, sort_constructors_first
 
-import 'package:collection/collection.dart';
-import 'package:fladder/models/items/overview_model.dart';
-import 'package:fladder/models/items/series_model.dart';
-import 'package:fladder/util/localization_helper.dart';
 import 'package:flutter/material.dart';
+
+import 'package:collection/collection.dart';
+import 'package:dart_mappable/dart_mappable.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:fladder/jellyfin/jellyfin_open_api.swagger.dart' as dto;
@@ -12,8 +11,9 @@ import 'package:fladder/models/item_base_model.dart';
 import 'package:fladder/models/items/episode_model.dart';
 import 'package:fladder/models/items/images_models.dart';
 import 'package:fladder/models/items/item_shared_models.dart';
-
-import 'package:dart_mappable/dart_mappable.dart';
+import 'package:fladder/models/items/overview_model.dart';
+import 'package:fladder/models/items/series_model.dart';
+import 'package:fladder/util/localization_helper.dart';
 
 part 'season_model.mapper.dart';
 
@@ -24,6 +24,7 @@ class SeasonModel extends ItemBaseModel with SeasonModelMappable {
   final List<EpisodeModel> episodes;
   final int episodeCount;
   final String seriesId;
+  final int season;
   final String seriesName;
   const SeasonModel({
     required this.parentImages,
@@ -31,6 +32,7 @@ class SeasonModel extends ItemBaseModel with SeasonModelMappable {
     this.episodes = const [],
     required this.episodeCount,
     required this.seriesId,
+    required this.season,
     required this.seriesName,
     required super.name,
     required super.id,
@@ -50,6 +52,7 @@ class SeasonModel extends ItemBaseModel with SeasonModelMappable {
       name: item.name ?? "",
       id: item.id ?? "",
       childCount: item.childCount,
+      season: item.indexNumber ?? 0,
       overview: OverviewModel.fromBaseItemDto(item, ref),
       userData: UserData.fromDto(item.userData),
       parentId: item.seasonId ?? item.parentId,

--- a/lib/models/items/season_model.mapper.dart
+++ b/lib/models/items/season_model.mapper.dart
@@ -39,6 +39,8 @@ class SeasonModelMapper extends SubClassMapperBase<SeasonModel> {
   static String _$seriesId(SeasonModel v) => v.seriesId;
   static const Field<SeasonModel, String> _f$seriesId =
       Field('seriesId', _$seriesId);
+  static int _$season(SeasonModel v) => v.season;
+  static const Field<SeasonModel, int> _f$season = Field('season', _$season);
   static String _$seriesName(SeasonModel v) => v.seriesName;
   static const Field<SeasonModel, String> _f$seriesName =
       Field('seriesName', _$seriesName);
@@ -84,6 +86,7 @@ class SeasonModelMapper extends SubClassMapperBase<SeasonModel> {
     #episodes: _f$episodes,
     #episodeCount: _f$episodeCount,
     #seriesId: _f$seriesId,
+    #season: _f$season,
     #seriesName: _f$seriesName,
     #name: _f$name,
     #id: _f$id,
@@ -116,6 +119,7 @@ class SeasonModelMapper extends SubClassMapperBase<SeasonModel> {
         episodes: data.dec(_f$episodes),
         episodeCount: data.dec(_f$episodeCount),
         seriesId: data.dec(_f$seriesId),
+        season: data.dec(_f$season),
         seriesName: data.dec(_f$seriesName),
         name: data.dec(_f$name),
         id: data.dec(_f$id),
@@ -184,6 +188,7 @@ abstract class SeasonModelCopyWith<$R, $In extends SeasonModel, $Out>
       List<EpisodeModel>? episodes,
       int? episodeCount,
       String? seriesId,
+      int? season,
       String? seriesName,
       String? name,
       String? id,
@@ -226,6 +231,7 @@ class _SeasonModelCopyWithImpl<$R, $Out>
           List<EpisodeModel>? episodes,
           int? episodeCount,
           String? seriesId,
+          int? season,
           String? seriesName,
           String? name,
           String? id,
@@ -245,6 +251,7 @@ class _SeasonModelCopyWithImpl<$R, $Out>
         if (episodes != null) #episodes: episodes,
         if (episodeCount != null) #episodeCount: episodeCount,
         if (seriesId != null) #seriesId: seriesId,
+        if (season != null) #season: season,
         if (seriesName != null) #seriesName: seriesName,
         if (name != null) #name: name,
         if (id != null) #id: id,
@@ -266,6 +273,7 @@ class _SeasonModelCopyWithImpl<$R, $Out>
       episodes: data.get(#episodes, or: $value.episodes),
       episodeCount: data.get(#episodeCount, or: $value.episodeCount),
       seriesId: data.get(#seriesId, or: $value.seriesId),
+      season: data.get(#season, or: $value.season),
       seriesName: data.get(#seriesName, or: $value.seriesName),
       name: data.get(#name, or: $value.name),
       id: data.get(#id, or: $value.id),

--- a/lib/providers/items/season_details_provider.dart
+++ b/lib/providers/items/season_details_provider.dart
@@ -1,10 +1,11 @@
 import 'package:chopper/chopper.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
 import 'package:fladder/jellyfin/jellyfin_open_api.swagger.dart';
 import 'package:fladder/models/items/episode_model.dart';
 import 'package:fladder/models/items/season_model.dart';
 import 'package:fladder/providers/api_provider.dart';
 import 'package:fladder/providers/service_provider.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 final seasonDetailsProvider =
     StateNotifierProvider.autoDispose.family<SeasonDetailsNotifier, SeasonModel?, String>((ref, id) {
@@ -25,8 +26,15 @@ class SeasonDetailsNotifier extends StateNotifier<SeasonModel?> {
     if (season.body != null) newState = season.bodyOrThrow as SeasonModel;
 
     final episodes = await api.showsSeriesIdEpisodesGet(
-        seriesId: newState?.seriesId ?? "", seasonId: seasonId, fields: [ItemFields.overview]);
-    newState = newState?.copyWith(episodes: EpisodeModel.episodesFromDto(episodes.body?.items, ref));
+      seriesId: newState?.seriesId ?? "",
+      seasonId: newState?.id,
+      season: newState?.season,
+      fields: [ItemFields.overview],
+    );
+    newState = newState?.copyWith(
+        episodes: EpisodeModel.episodesFromDto(episodes.body?.items, ref)
+            .where((element) => element.season == newState?.season)
+            .toList());
     state = newState;
     return season;
   }


### PR DESCRIPTION
## Pull Request Description

When misssing episodes are enabled the episode api endpoint returns specials inside of other seasons for some reason.
This fixes that problem.