### PR TITLE
fix: WakeLock calls now get called properly

### DIFF
--- a/lib/wrappers/media_control_wrapper.dart
+++ b/lib/wrappers/media_control_wrapper.dart
@@ -146,11 +146,6 @@ class MediaControlsWrapper extends BaseAudioHandler {
         updatePosition: value.position,
       ));
       smtc?.setPosition(value.position);
-      if (value.playing) {
-        WakelockPlus.enable();
-      } else {
-        WakelockPlus.disable();
-      }
       playbackState.add(playbackState.value.copyWith(
         playing: value.playing,
       ));
@@ -160,6 +155,7 @@ class MediaControlsWrapper extends BaseAudioHandler {
 
   @override
   Future<void> play() async {
+    WakelockPlus.enable();
     _player?.play();
     if (!ref.read(clientSettingsProvider).enableMediaKeys) return;
 
@@ -248,6 +244,11 @@ class MediaControlsWrapper extends BaseAudioHandler {
       playing: _player?.lastState.playing ?? false,
       controls: [MediaControl.play],
     ));
+    if (playbackState.value.playing) {
+      WakelockPlus.enable();
+    } else {
+      WakelockPlus.disable();
+    }
     final playerState = _player;
     if (playerState != null) {
       ref

--- a/lib/wrappers/players/lib_mpv.dart
+++ b/lib/wrappers/players/lib_mpv.dart
@@ -156,7 +156,7 @@ class LibMPV extends BasePlayer {
           : Video(
               key: key,
               controller: _controller!,
-              wakelock: true,
+              wakelock: false,
               fill: Colors.transparent,
               fit: fit,
               subtitleViewConfiguration: const SubtitleViewConfiguration(visible: false),


### PR DESCRIPTION
## Pull Request Description

This fixes wakelock being called every time the players state changes to only when pausing/playing the video.