### PR TITLE
fix(Desktop): Input no longer passed through titlebar

### DIFF
--- a/lib/screens/shared/default_title_bar.dart
+++ b/lib/screens/shared/default_title_bar.dart
@@ -46,22 +46,25 @@ class _DefaultTitleBarState extends ConsumerState<DefaultTitleBar> with WindowLi
         TargetPlatform.windows || TargetPlatform.linux => Row(
             children: [
               Expanded(
-                child: DragToMoveArea(
-                  child: Row(
-                    crossAxisAlignment: CrossAxisAlignment.stretch,
-                    mainAxisSize: MainAxisSize.max,
-                    children: [
-                      Container(
-                        padding: const EdgeInsets.only(left: 16),
-                        child: DefaultTextStyle(
-                          style: TextStyle(
-                            color: iconColor,
-                            fontSize: 14,
+                child: Container(
+                  color: Colors.black.withOpacity(0),
+                  child: DragToMoveArea(
+                    child: Row(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      mainAxisSize: MainAxisSize.max,
+                      children: [
+                        Container(
+                          padding: const EdgeInsets.only(left: 16),
+                          child: DefaultTextStyle(
+                            style: TextStyle(
+                              color: iconColor,
+                              fontSize: 14,
+                            ),
+                            child: Text(widget.label ?? ""),
                           ),
-                          child: Text(widget.label ?? ""),
                         ),
-                      ),
-                    ],
+                      ],
+                    ),
                   ),
                 ),
               ),


### PR DESCRIPTION
## Pull Request Description
This fixes the title bar passing the input through the widgets below. 
