### PR TITLE
chore: Remove `version` attribute from `docker-compose.yml`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.4'
-
 services:
   fladder:
     image: ghcr.io/donutware/fladder:latest


### PR DESCRIPTION
## Pull Request Description

This PR removes the `version` attribute from the `docker-compose.yml` file. In its current state, when deployed, the file returns a warning similar to this one:

```
WARN[0000] /home/bailey/docker-compose.yaml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
```

The attribute is considered obsolete according to [Docker's documentation](https://docs.docker.com/reference/compose-file/version-and-name/#version-top-level-element-obsolete), and removing it will solve some confusion for users that decide to use Docker to run Fladder.

## Issue Being Fixed

This PR doesn't solve an issue.

## Screenshots / Recordings

*No screenshots are required.*

## Checklist

- [x] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [x] Check that any changes are related to the issue at hand.
