### PR TITLE
fix: `Drag with mouse` switch

### DIFF
--- a/lib/screens/settings/client_settings_page.dart
+++ b/lib/screens/settings/client_settings_page.dart
@@ -498,7 +498,9 @@ class _ClientSettingsPageState extends ConsumerState<ClientSettingsPage> {
                   .update((current) => current.copyWith(mouseDragSupport: !clientSettings.mouseDragSupport)),
               trailing: Switch(
                 value: clientSettings.mouseDragSupport,
-                onChanged: (value) => ref.read(clientSettingsProvider.notifier).setAmoledBlack(value),
+                onChanged: (value) => ref
+                  .read(clientSettingsProvider.notifier)
+                  .update((current) => current.copyWith(mouseDragSupport: !clientSettings.mouseDragSupport)),
               ),
             ),
           ],


### PR DESCRIPTION
## Pull Request Description

Previously, the "Drag with mouse" switch in the settings would turn on the "AMOLED black" switch and would not respond to input unless the latter switch was turned off.

Now, it works as it should and responds correctly to users enabling the setting.

## Issue Being Fixed

Resolves #194

## Screenshots / Recordings

*No screenshots/recordings required*

## Checklist

- [x] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [x] Check that any changes are related to the issue at hand.
