### PR TITLE
fix: Incorrect playback reporting

### DIFF
--- a/lib/models/playback/direct_playback_model.dart
+++ b/lib/models/playback/direct_playback_model.dart
@@ -110,9 +110,7 @@ class DirectPlaybackModel implements PlaybackModel {
             mediaSourceId: item.id,
             playSessionId: playbackInfo.playSessionId,
             positionTicks: position.toRuntimeTicks,
-            failed: false,
           ),
-          totalDuration: totalDuration,
         );
 
     return null;

--- a/lib/models/playback/transcode_playback_model.dart
+++ b/lib/models/playback/transcode_playback_model.dart
@@ -111,9 +111,7 @@ class TranscodePlaybackModel implements PlaybackModel {
             mediaSourceId: item.id,
             playSessionId: playbackInfo.playSessionId,
             positionTicks: position.toRuntimeTicks,
-            failed: false,
           ),
-          totalDuration: totalDuration,
         );
 
     return null;

--- a/lib/providers/service_provider.dart
+++ b/lib/providers/service_provider.dart
@@ -17,7 +17,6 @@ import 'package:fladder/models/items/trick_play_model.dart';
 import 'package:fladder/providers/auth_provider.dart';
 import 'package:fladder/providers/image_provider.dart';
 import 'package:fladder/providers/user_provider.dart';
-import 'package:fladder/util/duration_extensions.dart';
 import 'package:fladder/util/jellyfin_extension.dart';
 
 class ServerQueryResult {
@@ -492,25 +491,8 @@ class JellyService {
 
   Future<Response> sessionsPlayingStoppedPost({
     required PlaybackStopInfo? body,
-    Duration? totalDuration,
-  }) async {
-    final position = body?.positionTicks;
-    final totalTime = totalDuration?.toRuntimeTicks;
-    final maxTime = ref.read(userProvider.select((value) => value?.serverConfiguration?.maxResumePct ?? 90));
-
-    final response = await api.sessionsPlayingStoppedPost(
-      body: body?.copyWith(
-        failed: false,
-      ),
-    );
-
-    //This is a temporary fix
-    if (totalTime != null && position != null && position > (totalTime * (maxTime / 100))) {
-      await usersUserIdPlayedItemsItemIdPost(itemId: body?.itemId, datePlayed: DateTime.now());
-    }
-
-    return response;
-  }
+  }) =>
+      api.sessionsPlayingStoppedPost(body: body);
 
   Future<Response> sessionsPlayingProgressPost({required PlaybackProgressInfo? body}) async =>
       api.sessionsPlayingProgressPost(body: body);

--- a/lib/providers/video_player_provider.dart
+++ b/lib/providers/video_player_provider.dart
@@ -62,7 +62,7 @@ class VideoPlayerNotifier extends StateNotifier<MediaControlsWrapper> {
     final lastPosition = ref.read(mediaPlaybackProvider.select((value) => value.lastPosition));
     final diff = (position.inMilliseconds - lastPosition.inMilliseconds).abs();
 
-    if (diff > const Duration(seconds: 1, milliseconds: 500).inMilliseconds) {
+    if (diff > const Duration(seconds: 10).inMilliseconds) {
       mediaState.update((value) => value.copyWith(
             position: event,
             playing: playbackState.playing,


### PR DESCRIPTION
## Pull Request Description

There was a small race condition when reporting playback progress and stopping.
Increase progress report rate to every 10 seconds.
Added a small delay for reporting a stoppped playback.

## Issue Being Fixed

Resolves #206 