### PR TITLE
Fix "Ends at" don't use playrate and next episode change selected stream

### DIFF
--- a/DEVELOPEMENT.md
+++ b/DEVELOPEMENT.md
@@ -1,0 +1,64 @@
+# 🚀 Fladder Dev Setup
+
+## 🔧 Requirements
+
+Ensure the following tools are installed:
+
+- [Flutter SDK](https://flutter.dev/docs/get-started/install) (latest stable)
+- [Android Studio](https://developer.android.com/studio) (for Android development and emulators)
+- [VS Code](https://code.visualstudio.com/) with:
+  - Flutter extension
+  - Dart extension
+
+Verify your Flutter setup with:
+
+```bash
+flutter doctor
+```
+
+## 🚀 Quick Start
+
+```bash
+# Clone the repository
+git clone https://github.com/DonutWare/Fladder.git
+cd Fladder
+
+# Install dependencies
+flutter pub get
+```
+
+## 🐧 Linux Dependencies
+
+If you're on **Linux**, install the `mpv` dependency:
+
+```bash
+sudo apt install libmpv-dev
+```
+
+## 🛠️ Running the App
+
+1. **Connect a device** or launch an emulator.
+2. In VS Code:
+   - Select the target device (bottom right corner).
+   - Press `F5` or go to **Run > Start Debugging**.
+   - If prompted, select **"Run Anyway"**.
+
+## ⚙️ Code Generation
+
+Generate build files (e.g., for `json_serializable`, `freezed`, etc.):
+
+```bash
+flutter pub run build_runner build
+```
+
+> Tip: Use `watch` for continuous builds during development:
+```bash
+flutter pub run build_runner watch
+```
+
+## 🌐 Using the Fake Server
+To connect to the fake server :
+Add a new server with the following details:
+   - **Server URL**: `http://22b469df.fladder.nl`  
+   - **Username**: `User 1`  
+   - **Password**: `Txnw6RWYb8yEtD`

--- a/lib/models/playback/playback_model.dart
+++ b/lib/models/playback/playback_model.dart
@@ -201,8 +201,8 @@ class PlaybackModelHelper {
         itemId: firstItemToPlay.id,
         body: PlaybackInfoDto(
           startTimeTicks: startPosition?.toRuntimeTicks,
-          audioStreamIndex: streamModel?.defaultAudioStreamIndex,
-          subtitleStreamIndex: streamModel?.defaultSubStreamIndex,
+          audioStreamIndex: oldModel?.mediaStreams?.currentAudioStream?.index ?? streamModel?.defaultAudioStreamIndex,
+          subtitleStreamIndex: oldModel?.mediaStreams?.currentSubStream?.index ?? streamModel?.defaultSubStreamIndex,
           enableTranscoding: true,
           autoOpenLiveStream: true,
           deviceProfile: ref.read(videoProfileProvider),
@@ -223,8 +223,8 @@ class PlaybackModelHelper {
       if (mediaSource == null) return null;
 
       final mediaStreamsWithUrls = MediaStreamsModel.fromMediaStreamsList(playbackInfo.mediaSources, ref).copyWith(
-        defaultAudioStreamIndex: streamModel?.defaultAudioStreamIndex,
-        defaultSubStreamIndex: streamModel?.defaultSubStreamIndex,
+        defaultAudioStreamIndex: oldModel?.mediaStreams?.currentAudioStream?.index ?? streamModel?.defaultAudioStreamIndex,
+        defaultSubStreamIndex: oldModel?.mediaStreams?.currentSubStream?.index ?? streamModel?.defaultSubStreamIndex,
       );
 
       final mediaSegments = await api.mediaSegmentsGet(id: item.id);
@@ -328,8 +328,8 @@ class PlaybackModelHelper {
 
     final currentPosition = ref.read(mediaPlaybackProvider.select((value) => value.position));
 
-    final audioIndex = playbackModel.mediaStreams?.defaultAudioStreamIndex;
-    final subIndex = playbackModel.mediaStreams?.defaultSubStreamIndex;
+    final audioIndex = playbackModel.mediaStreams?.currentAudioStream?.index ?? playbackModel.mediaStreams?.defaultAudioStreamIndex;
+    final subIndex = playbackModel.mediaStreams?.currentSubStream?.index ?? playbackModel.mediaStreams?.defaultSubStreamIndex;
 
     Response<PlaybackInfoResponse> response = await api.itemsItemIdPlaybackInfoPost(
       itemId: item.id,

--- a/lib/screens/video_player/components/video_player_options_sheet.dart
+++ b/lib/screens/video_player/components/video_player_options_sheet.dart
@@ -502,9 +502,9 @@ Future<void> showPlaybackSpeed(BuildContext context) {
                           width: 250,
                           child: FladderSlider(
                             min: 0.25,
-                            max: 10,
+                            max: 3,
                             value: lastSpeed,
-                            divisions: 39,
+                            divisions: 55,
                             onChanged: (value) {
                               ref.read(playbackRateProvider.notifier).state = value;
                               player.setSpeed(value);

--- a/lib/screens/video_player/video_player_controls.dart
+++ b/lib/screens/video_player/video_player_controls.dart
@@ -441,7 +441,10 @@ class _DesktopControlsState extends ConsumerState<DesktopControls> {
         final List<String?> details = [
           if (AdaptiveLayout.of(context).isDesktop) item?.label(context),
           mediaPlayback.duration.inMinutes > 1
-              ? context.localized.endsAt(DateTime.now().add(mediaPlayback.duration - mediaPlayback.position))
+                ? context.localized.endsAt(DateTime.now().add(
+                  Duration(milliseconds: 
+                    (mediaPlayback.duration.inMilliseconds - mediaPlayback.position.inMilliseconds) ~/ ref.read(playbackRateProvider)))
+                  )
               : null
         ];
         return Column(


### PR DESCRIPTION
## Pull Request Description

- The "Ends at" on player controls display end time with date + runtime, so it does not consider the playrate. 

- I'v updated the playback speed slider to use a step size of 5% and set the maximum speed at 3, i my opinion 10 was a bit hight and only a little partion of the slider was usefull

- When switching to the next video using player button it reset the streams selection to the default ones, the app now preserves the current audio and subtitle stream indices. This avoids falling back to defaults streams index that return the server.
For sysnced items i can't test it because in `createOfflinePlaybackModel` of **playback_model.dart**, 
```dart
    final children = ref.read(syncChildrenProvider(syncedItem));
    final syncedItems = children.where((element) => element.videoFile.existsSync()).toList();
    final itemQueue = syncedItems.map((e) => e.createItemModel(ref));

```
`ref.read(syncChildrenProvider(syncedItem));` return and empty list even if next episode is download

Also i've added a DEVELOPMENT.md file to help set up the project, including installation steps, Linux dependencies, and usage of a fake server for testing, maybe i'm not doing it the best way but might be usefull.

As the change were few lines i didn't create separate PR, but if you prefer i can do that.

## Checklist

- [x] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [x] Check that any changes are related to the issue at hand.
