### PR TITLE
fix: Ends at calculation when playbackrate is not 1x

### DIFF
--- a/lib/screens/video_player/video_player_controls.dart
+++ b/lib/screens/video_player/video_player_controls.dart
@@ -441,7 +441,10 @@ class _DesktopControlsState extends ConsumerState<DesktopControls> {
         final List<String?> details = [
           if (AdaptiveLayout.of(context).isDesktop) item?.label(context),
           mediaPlayback.duration.inMinutes > 1
-              ? context.localized.endsAt(DateTime.now().add(mediaPlayback.duration - mediaPlayback.position))
+                ? context.localized.endsAt(DateTime.now().add(
+                  Duration(milliseconds: 
+                    (mediaPlayback.duration.inMilliseconds - mediaPlayback.position.inMilliseconds) ~/ ref.read(playbackRateProvider)))
+                  )
               : null
         ];
         return Column(


### PR DESCRIPTION
## Pull Request Description

The "Ends at" on player controls display end time with date + runtime, so it does not consider the playrate.

## Checklist

- [X] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [X] Check that any changes are related to the issue at hand.
