### PR TITLE
feat: playbackrate changes - max set to 3 and smaller steps

### DIFF
--- a/lib/screens/video_player/components/video_player_options_sheet.dart
+++ b/lib/screens/video_player/components/video_player_options_sheet.dart
@@ -502,9 +502,9 @@ Future<void> showPlaybackSpeed(BuildContext context) {
                           width: 250,
                           child: FladderSlider(
                             min: 0.25,
-                            max: 10,
+                            max: 3,
                             value: lastSpeed,
-                            divisions: 39,
+                            divisions: 55,
                             onChanged: (value) {
                               ref.read(playbackRateProvider.notifier).state = value;
                               player.setSpeed(value);


### PR DESCRIPTION
## Pull Request Description

Updated of the playback speed slider to use a step size of 5% and set the maximum speed at 3, i my opinion 10 was a bit hight and only a little partion of the slider was usefull

## Checklist

- [X] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [X] Check that any changes are related to the issue at hand.
