### PR TITLE
chore: Changed case naming for Mac OS App

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -214,6 +214,14 @@ jobs:
       - name: Build macOS app
         run: flutter build macos --flavor production --build-number=${{ github.run_number }}
 
+      - name: Ensure correct app name casing
+        run: |
+          APP_DIR="build/macos/Build/Products/Release-production"
+          # Check if the app exists with potentially wrong casing
+          if [ -d "$APP_DIR/fladder.app" ] && [ ! -d "$APP_DIR/Fladder.app" ]; then
+            mv "$APP_DIR/fladder.app" "$APP_DIR/Fladder.app"
+          fi
+
       - name: Create DMG file
         run: hdiutil create -format UDZO -srcfolder build/macos/Build/Products/Release-production/Fladder.app build/macos/Build/Products/Release-production/macOS.dmg
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -215,7 +215,7 @@ jobs:
         run: flutter build macos --flavor production --build-number=${{ github.run_number }}
 
       - name: Create DMG file
-        run: hdiutil create -format UDZO -srcfolder build/macos/Build/Products/Release-production/fladder.app build/macos/Build/Products/Release-production/macOS.dmg
+        run: hdiutil create -format UDZO -srcfolder build/macos/Build/Products/Release-production/Fladder.app build/macos/Build/Products/Release-production/macOS.dmg
 
       - name: Archive macOS artifact
         uses: actions/upload-artifact@v4.0.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -217,10 +217,7 @@ jobs:
       - name: Ensure correct app name casing
         run: |
           APP_DIR="build/macos/Build/Products/Release-production"
-          # Check if the app exists with potentially wrong casing
-          if [ -d "$APP_DIR/fladder.app" ] && [ ! -d "$APP_DIR/Fladder.app" ]; then
-            mv "$APP_DIR/fladder.app" "$APP_DIR/Fladder.app"
-          fi
+          mv "$APP_DIR/fladder.app" "$APP_DIR/Fladder.app"
 
       - name: Create DMG file
         run: hdiutil create -format UDZO -srcfolder build/macos/Build/Products/Release-production/Fladder.app build/macos/Build/Products/Release-production/macOS.dmg


### PR DESCRIPTION
## Pull Request Description

This PR changes the first letter of the Mac app to be capital instead, this should be the same as the rest of the apps on other OSes

## Checklist

- [ ] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [ ] Check that any changes are related to the issue at hand.
