### PR TITLE
fix: Fix mediaSegments not loading when pressing series banner

### DIFF
--- a/lib/models/playback/playback_model.dart
+++ b/lib/models/playback/playback_model.dart
@@ -238,7 +238,7 @@ class PlaybackModelHelper {
         defaultSubStreamIndex: subStreamIndex,
       );
 
-      final mediaSegments = await api.mediaSegmentsGet(id: item.id);
+      final mediaSegments = await api.mediaSegmentsGet(id: firstItemToPlay.id);
       final trickPlay = (await api.getTrickPlay(item: fullItem.body, ref: ref))?.body;
       final chapters = fullItem.body?.overview.chapters ?? [];
 


### PR DESCRIPTION
## Pull Request Description

Fetch the correct mediaSegments when loading a show

## Issue Being Fixed

Resolves #338 
