### PR TITLE
Create dio_provider.dart

### DIFF
--- a/lib/providers/dio_provider.dart
+++ b/lib/providers/dio_provider.dart
@@ -1,0 +1,18 @@
+import 'package:dio/dio.dart';
+import 'package:fladder/providers/sync_provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+
+final dioProvider = Provider<Dio>((ref) {
+  final dio = Dio();
+  final apiKey = ref.read(apiKeyProvider);
+  dio.interceptors.add(
+    InterceptorsWrapper(
+      onRequest: (options, handler) {
+        options.headers['X-Emby-Token'] = apiKey;
+        return handler.next(options);
+      },
+    ),
+  );
+  return dio;
+});


### PR DESCRIPTION
## Pull Request Description

Added a centralized `dioProvider` that provides a configured Dio instance with global settings and interceptors. This allows consistent HTTP client configuration and easier maintenance, such as adding authentication headers in one place.

## Issue Being Fixed

Previously, new Dio instances were created ad-hoc, causing duplicated configuration and inconsistent behavior. This update fixes that by centralizing Dio configuration.

## Screenshots / Recordings

N/A

## Checklist

- [x] Confirmed the provider works on all supported platforms.
- [x] Changes are scoped to Dio client configuration.
