### PR TITLE
fix: Locale selection issue with country-specific locales

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -291,8 +291,11 @@ class _MainState extends ConsumerState<Main> with WindowListener, WidgetsBinding
             builder: (context, child) => Localizations.override(
               context: context,
               locale: AppLocalizations.supportedLocales.firstWhere(
-                (element) => element.languageCode == language.languageCode,
-                orElse: () => const Locale('en', "GB"),
+                (element) => element.languageCode == language.languageCode && element.countryCode == language.countryCode,
+                orElse: () => AppLocalizations.supportedLocales.firstWhere(
+                  (element) => element.languageCode == language.languageCode,
+                  orElse: () => const Locale('en', "GB"),
+                ),
               ),
               child: LocalizationContextWrapper(child: ScaffoldMessenger(child: child ?? Container())),
             ),

--- a/lib/screens/settings/client_sections/client_settings_visual.dart
+++ b/lib/screens/settings/client_sections/client_settings_visual.dart
@@ -46,7 +46,7 @@ List<Widget> buildClientSettingsVisual(
                         context: context,
                         locale: entry,
                         child: Builder(builder: (context) {
-                          return Text("${context.localized.nativeName} (${entry.languageCode.toUpperCase()})");
+                          return Text("${context.localized.nativeName} (${entry.languageCode.toUpperCase()}${entry.countryCode != null ? '-${entry.countryCode!.toUpperCase()}' : ''})");
                         }),
                       ),
                       onTap: () => ref


### PR DESCRIPTION
## Pull Request Description
Fixed locale selection issue where country-specific locales (like `pt_BR`) were incorrectly falling back to language-only locales (like `pt`). Also improved the UI to display both language and country codes in the locale selector.

## Issue Being Fixed
When users selected `pt_BR` in the interface, the app would use `pt` instead of _Brazilian Portuguese_ because the matching logic only compared languageCode, ignoring countryCode.

## Changes Made
1. **Locale matching logic:**
   - Primary match: Exact match for both language and country codes
   - Fallback match: Language-only match if exact match fails
   - Default fallback _(unchanged)_: English (GB) if no matches found 

2. **Locale display in popup menu:**
   - Now shows country codes alongside language codes
   - Format: "Native Name (LANG-COUNTRY)" or "Native Name (LANG)" for language-only locales

## Checklist
- [x] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [x] Check that any changes are related to the issue at hand.