### PR TITLE
chore: Made bug report allow screenshots

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,6 +1,6 @@
 name: "🐛 Bug Report"
 description: Create a new ticket for a bug.
-title: "🐛 <title>"
+title: "🐛 "
 labels: ["bug"]
 type: "Bug"
 body:
@@ -30,9 +30,7 @@ body:
     attributes:
       label: "Screenshots"
       description: If applicable, add screenshots to help explain your problem.
-      value: |
-        ![DESCRIPTION](LINK.png)
-      render: bash
+      placeholder: "Drag and drop screenshots here, or paste image URLs using ![description](image-url)"
     validations:
       required: false
   - type: textarea


### PR DESCRIPTION
## Pull Request Description

Currently as the bug report is you can't really add screenshots to it since it is bash, now it has been fixed and should allow screenshots.  I have also changed the title to not include the `<title>` since I think it is more confusing personally. Should you want the former reverted let me know.

## Issue Being Fixed

Removed the render bash command for screenshots

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [ ] Check that any changes are related to the issue at hand.
