### PR TITLE
fix: Standardize precision used in communityRating

### DIFF
--- a/lib/models/item_base_model.dart
+++ b/lib/models/item_base_model.dart
@@ -90,7 +90,7 @@ class ItemBaseModel with ItemBaseModelMappable {
                     color: Colors.yellowAccent,
                   ),
                   const SizedBox(width: 6),
-                  Text((overview.communityRating ?? 0.0).toString())
+                  Text((overview.communityRating ?? 0.0).toStringAsFixed(2))
                 ],
               )
             : null,

--- a/lib/models/item_base_model.dart
+++ b/lib/models/item_base_model.dart
@@ -87,7 +87,7 @@ class ItemBaseModel with ItemBaseModelMappable {
                 color: Colors.yellowAccent,
               ),
               const SizedBox(width: 6),
-              Text(overview.communityRating?.toStringAsFixed(2) ?? "0.0"),
+              Text(overview.communityRating?.toStringAsFixed(2) ?? "--"),
             ],
           ),
         _ => null,

--- a/lib/models/item_base_model.dart
+++ b/lib/models/item_base_model.dart
@@ -68,32 +68,28 @@ class ItemBaseModel with ItemBaseModelMappable {
   }
 
   Widget? subTitle(SortingOptions options) => switch (options) {
-        SortingOptions.parentalRating => overview.parentalRating != null
-            ? Row(
-                children: [
-                  const Icon(
-                    IconsaxPlusBold.star_1,
-                    size: 14,
-                    color: Colors.yellowAccent,
-                  ),
-                  const SizedBox(width: 6),
-                  Text((overview.parentalRating ?? 0.0).toString())
-                ],
-              )
-            : null,
-        SortingOptions.communityRating => overview.communityRating != null
-            ? Row(
-                children: [
-                  const Icon(
-                    IconsaxPlusBold.star_1,
-                    size: 14,
-                    color: Colors.yellowAccent,
-                  ),
-                  const SizedBox(width: 6),
-                  Text((overview.communityRating ?? 0.0).toStringAsFixed(2))
-                ],
-              )
-            : null,
+        SortingOptions.parentalRating => Row(
+            children: [
+              const Icon(
+                IconsaxPlusBold.star_1,
+                size: 14,
+                color: Colors.yellowAccent,
+              ),
+              const SizedBox(width: 6),
+              Text(overview.parentalRating?.toString() ?? "--"),
+            ],
+          ),
+        SortingOptions.communityRating => Row(
+            children: [
+              const Icon(
+                IconsaxPlusBold.star_1,
+                size: 14,
+                color: Colors.yellowAccent,
+              ),
+              const SizedBox(width: 6),
+              Text(overview.communityRating?.toStringAsFixed(2) ?? "0.0"),
+            ],
+          ),
         _ => null,
       };
 

--- a/lib/screens/details_screens/components/overview_header.dart
+++ b/lib/screens/details_screens/components/overview_header.dart
@@ -130,7 +130,7 @@ class OverviewHeader extends ConsumerWidget {
                             color: Theme.of(context).colorScheme.primary,
                           ),
                           Text(
-                            communityRating?.toStringAsFixed(1) ?? "",
+                            communityRating?.toStringAsFixed(2) ?? "",
                             style: subStyle,
                           ),
                         ],

--- a/lib/screens/shared/media/poster_widget.dart
+++ b/lib/screens/shared/media/poster_widget.dart
@@ -83,25 +83,24 @@ class PosterWidget extends ConsumerWidget {
                   ),
                 ),
                 Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [
                     if (subTitle != null) ...[
-                      Opacity(
-                        opacity: opacity,
-                        child: subTitle!,
+                      Flexible(
+                        child: Opacity(
+                          opacity: opacity,
+                          child: subTitle!,
+                        ),
                       ),
-                      const Spacer()
                     ],
                     if (poster.subText?.isNotEmpty ?? false)
                       Flexible(
-                        child: Align(
-                          alignment: subTitle == null ? Alignment.centerLeft : Alignment.centerRight,
-                          child: ClickableText(
-                            opacity: opacity,
-                            text: poster.subText ?? "",
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                            style: Theme.of(context).textTheme.titleSmall?.copyWith(fontWeight: FontWeight.bold),
-                          ),
+                        child: ClickableText(
+                          opacity: opacity,
+                          text: poster.subText ?? "",
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: Theme.of(context).textTheme.titleSmall?.copyWith(fontWeight: FontWeight.bold),
                         ),
                       )
                     else

--- a/lib/screens/shared/media/poster_widget.dart
+++ b/lib/screens/shared/media/poster_widget.dart
@@ -93,12 +93,15 @@ class PosterWidget extends ConsumerWidget {
                     ],
                     if (poster.subText?.isNotEmpty ?? false)
                       Flexible(
-                        child: ClickableText(
-                          opacity: opacity,
-                          text: poster.subText ?? "",
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                          style: Theme.of(context).textTheme.titleSmall?.copyWith(fontWeight: FontWeight.bold),
+                        child: Align(
+                          alignment: subTitle == null ? Alignment.centerLeft : Alignment.centerRight,
+                          child: ClickableText(
+                            opacity: opacity,
+                            text: poster.subText ?? "",
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: Theme.of(context).textTheme.titleSmall?.copyWith(fontWeight: FontWeight.bold),
+                          ),
                         ),
                       )
                     else


### PR DESCRIPTION
## Pull Request Description

I tried to keep this as minimal as possible to only the issue(s) presented in the discussion. The only changes were to the precision of the base model item and the overview header. I've provided screenshots of both changes. Additionally, for the poster widget, I'd like some feedback on how to proceed with the changes. Currently, a ternary operator is used to check if `subTitle` exists to ensure that the year is aligned to the left or right. This has an unintended consequence (image 3) of the year being aligned to the left if an entry does not have a `subTitle` but other entries do. This is inconsistent, but the alternative would be that if at least one item in the whole library filtered/displayed has a `subTitle` then the year must be to the right.

## Issue Being Fixed


Resolves #422 

## Screenshots / Recordings

<img width="1264" height="711" alt="image" src="https://github.com/user-attachments/assets/b3f85408-2ea6-4422-adba-c47667bfae77" />

<img width="1264" height="711" alt="image" src="https://github.com/user-attachments/assets/b48c360a-3a9b-41b3-b9ee-79dc82e0dd4a" />

<img width="444" height="352" alt="image" src="https://github.com/user-attachments/assets/9b379372-666c-4527-a902-db9b8f64c5fb" />


## Checklist

- [x] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [x] Check that any changes are related to the issue at hand.
