### PR TITLE
fix: make image cache key unique

### DIFF
--- a/lib/models/item_base_model.dart
+++ b/lib/models/item_base_model.dart
@@ -87,7 +87,11 @@ class ItemBaseModel with ItemBaseModelMappable {
                 color: Colors.yellowAccent,
               ),
               const SizedBox(width: 6),
+<<<<<<< HEAD
               Text(overview.communityRating?.toStringAsFixed(2) ?? "--"),
+=======
+              Text(overview.communityRating?.toStringAsFixed(2) ?? "0.0"),
+>>>>>>> 9088937 (implement feedback)
             ],
           ),
         _ => null,

--- a/lib/models/item_base_model.dart
+++ b/lib/models/item_base_model.dart
@@ -87,11 +87,7 @@ class ItemBaseModel with ItemBaseModelMappable {
                 color: Colors.yellowAccent,
               ),
               const SizedBox(width: 6),
-<<<<<<< HEAD
               Text(overview.communityRating?.toStringAsFixed(2) ?? "--"),
-=======
-              Text(overview.communityRating?.toStringAsFixed(2) ?? "0.0"),
->>>>>>> 9088937 (implement feedback)
             ],
           ),
         _ => null,

--- a/lib/models/items/images_models.dart
+++ b/lib/models/items/images_models.dart
@@ -61,7 +61,7 @@ class ImagesData {
                       maxWidth: primary.width.toInt(),
                       quality: quality,
                     ),
-              key: item.imageTags?['Primary'],
+              key: "${itemid}_primary_${item.imageTags?['Primary']}",
               hash: item.imageBlurHashes?.primary?[item.imageTags?['Primary']] ?? "",
             )
           : null,
@@ -79,7 +79,7 @@ class ImagesData {
                       maxWidth: logo.width.toInt(),
                       quality: quality,
                     ),
-              key: item.imageTags?['Logo'],
+              key: "${itemid}_logo_${item.imageTags?['Logo']}",
               hash: item.imageBlurHashes?.logo?[item.imageTags?['Logo']] ?? "")
           : null,
       backDrop: (item.backdropImageTags ?? [])
@@ -100,7 +100,7 @@ class ImagesData {
                         maxWidth: backDrop.width.toInt(),
                         quality: quality,
                       ),
-                key: backdrop,
+                key: "${itemid}_backdrop_${index}_$backdrop",
                 hash: item.imageBlurHashes?.backdrop?[backdrop] ?? "",
               );
               return image;
@@ -134,7 +134,7 @@ class ImagesData {
                 maxWidth: primary.width.toInt(),
                 quality: quality,
               ),
-              key: item.seriesPrimaryImageTag ?? "",
+              key: "${item.seriesId}_primary_${item.seriesPrimaryImageTag ?? ""}",
               hash: item.imageBlurHashes?.primary?[item.seriesPrimaryImageTag] ?? "")
           : null,
       logo: (item.parentLogoImageTag != null)
@@ -146,7 +146,7 @@ class ImagesData {
                 maxWidth: logo.width.toInt(),
                 quality: quality,
               ),
-              key: item.parentLogoImageTag ?? "",
+              key: "${item.seriesId}_logo_${item.parentLogoImageTag ?? ""}",
               hash: item.imageBlurHashes?.logo?[item.parentLogoImageTag] ?? "")
           : null,
       backDrop: (item.backdropImageTags ?? [])
@@ -163,7 +163,7 @@ class ImagesData {
                   maxWidth: backDrop.width.toInt(),
                   quality: quality,
                 ),
-                key: backdrop,
+                key: "${itemId}_backdrop_${index}_$backdrop",
                 hash: item.imageBlurHashes?.backdrop?[backdrop] ?? "",
               );
               return image;
@@ -193,7 +193,7 @@ class ImagesData {
                     maxWidth: primary.width.toInt(),
                     quality: quality,
                   ),
-              key: item.primaryImageTag ?? "",
+              key: "${item.id ?? ""}_primary_${item.primaryImageTag ?? ''}",
               hash: item.imageBlurHashes?.primary?[item.primaryImageTag] ?? '')
           : null,
       logo: null,


### PR DESCRIPTION
## Pull Request Description

The current implementation assumes that Jellyfin's tags are unique and can therefore be used as keys. However, [their logic to create tags](https://github.com/jellyfin/jellyfin/blob/9e36fa426335289b4be90034640ad38b38e3de79/src/Jellyfin.Drawing/ImageProcessor.cs#L409) can lead to duplicate tags across images in the same location (backdrop.jpg, logo.jpg, etc can share the same tag) and same timestamp.

Consider this url example from my server. The tags are the same:

http://localhost:8096/Items/61139a4c4ce0f3e26032c35a7e1adde8/Images/Primary?maxWidth=575&tag=497955eaadd4d4d31609987a736d8374

http://server:8096/Items/61139a4c4ce0f3e26032c35a7e1adde8/Images/Logo?maxWidth=575&tag=497955eaadd4d4d31609987a736d8374

Since the key is assumed to be unique, when we request a logo, we do so with the key. However, this often leads to a primary or backdrop being returned since in our cache, that key belongs to one of those. See below for screenshots.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

N/A

## Screenshots / Recordings

Fladder 0.7.0:

<img width="952" height="536" alt="fladder_xZQthz1iw6" src="https://github.com/user-attachments/assets/d49284e7-19b4-4943-a5d6-46b6642be8c5" />
<img width="952" height="536" alt="fladder_dq6Rsbak4n" src="https://github.com/user-attachments/assets/97babbea-0dd3-4bbc-bafe-b565a3d80de8" />

This PR:
<img width="893" height="593" alt="fladder_dRdGlrFNgH" src="https://github.com/user-attachments/assets/5f7cdea3-bf69-4856-a962-d2aae181f38b" />
<img width="893" height="593" alt="fladder_yH4EeruV4A" src="https://github.com/user-attachments/assets/4b07fc84-e0c1-40e7-85ea-511c0ce23f91" />



## Checklist

- [x] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [x] Check that any changes are related to the issue at hand.
