### PR TITLE
fix: 

### DIFF
--- a/lib/util/bitrate_helper.dart
+++ b/lib/util/bitrate_helper.dart
@@ -34,7 +34,7 @@ enum Bitrate {
   String label(BuildContext context) => switch (this) {
         Bitrate.original => context.localized.qualityOptionsOriginal,
         Bitrate.auto => context.localized.qualityOptionsAuto,
-        _ => name.toString().replaceAll('b', '').replaceAll('_', '.').toUpperCaseSplit()
+        _ => name.toString().replaceFirst('b', '').replaceAll('_', '.').toUpperCaseSplit()
       };
 }
 


### PR DESCRIPTION
## Pull Request Description

I noticed that the Quality Options displayed 'Mps' and 'kps' instead of 'Mbps' and 'kbps'. I do not know if this was done on purpose, but according to standards they are usually presented as the latter. This PR should fix that.

## Issue Being Fixed

Changes 'Mps' and 'kps' to 'Mbps' and 'kbps' respectively

## Screenshots / Recordings

<img width="1200" height="446" alt="Screenshot 2025-08-08 at 22 10 07" src="https://github.com/user-attachments/assets/f1032d07-91fa-46d1-a8ed-5c0e8d4102cb" />

## Checklist

- [ ] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [ ] Check that any changes are related to the issue at hand.
