### PR TITLE
chore: Winget package automation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -716,3 +716,30 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build/web
+
+  # Winget package submission for release builds
+  winget-package-submit-release:
+    runs-on: ubuntu-latest
+    needs: [check-trigger, create_release]
+    if: needs.check-trigger.outputs.build_type == 'release'
+    steps:
+      - name: Submit to Winget
+        uses: vedantmgoyal9/winget-releaser@19e706d4c9121098010096f9c495a70a7518b30f
+        with:
+          identifier: DonutWare.Fladder
+          installers-regex: 'Fladder-Windows-.*-Setup\.exe$'
+          token: ${{ secrets.WINGET_TOKEN }}
+
+  # Winget package submission for nightly builds
+  winget-package-submit-nightly:
+    runs-on: ubuntu-latest
+    needs: [check-trigger, create_release]
+    if: needs.check-trigger.outputs.build_type == 'nightly'
+    steps:
+      - name: Submit to Winget (Nightly)
+        uses: vedantmgoyal9/winget-releaser@19e706d4c9121098010096f9c495a70a7518b30f
+        with:
+          identifier: DonutWare.Fladder.Nightly
+          installers-regex: 'Fladder-Windows-.*-Setup\.exe$'
+          token: ${{ secrets.WINGET_TOKEN }}
+          max-versions-to-keep: 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -721,7 +721,6 @@ jobs:
   winget-package-submit:
     runs-on: ubuntu-latest
     needs: [check-trigger, create_release]
-    if: needs.check-trigger.outputs.build_type == 'release' || needs.check-trigger.outputs.build_type == 'nightly'
     strategy:
       matrix:
         include:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -717,29 +717,26 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build/web
 
-  # Winget package submission for release builds
-  winget-package-submit-release:
+  # Winget package submission
+  winget-package-submit:
     runs-on: ubuntu-latest
     needs: [check-trigger, create_release]
-    if: needs.check-trigger.outputs.build_type == 'release'
+    if: needs.check-trigger.outputs.build_type == 'release' || needs.check-trigger.outputs.build_type == 'nightly'
+    strategy:
+      matrix:
+        include:
+          - build_type: release
+            identifier: DonutWare.Fladder
+            max_versions: ""
+          - build_type: nightly
+            identifier: DonutWare.Fladder.Nightly
+            max_versions: "1"
     steps:
-      - name: Submit to Winget
+      - name: Submit to Winget (${{ matrix.build_type }})
+        if: needs.check-trigger.outputs.build_type == matrix.build_type
         uses: vedantmgoyal9/winget-releaser@19e706d4c9121098010096f9c495a70a7518b30f
         with:
-          identifier: DonutWare.Fladder
+          identifier: ${{ matrix.identifier }}
           installers-regex: 'Fladder-Windows-.*-Setup\.exe$'
           token: ${{ secrets.WINGET_TOKEN }}
-
-  # Winget package submission for nightly builds
-  winget-package-submit-nightly:
-    runs-on: ubuntu-latest
-    needs: [check-trigger, create_release]
-    if: needs.check-trigger.outputs.build_type == 'nightly'
-    steps:
-      - name: Submit to Winget (Nightly)
-        uses: vedantmgoyal9/winget-releaser@19e706d4c9121098010096f9c495a70a7518b30f
-        with:
-          identifier: DonutWare.Fladder.Nightly
-          installers-regex: 'Fladder-Windows-.*-Setup\.exe$'
-          token: ${{ secrets.WINGET_TOKEN }}
-          max-versions-to-keep: 1
+          max-versions-to-keep: ${{ matrix.max_versions || '' }}


### PR DESCRIPTION
## Pull Request Description

Adds winget package automation so that winget packages are updated automatically with each release.

For this to work a fork of the https://github.com/microsoft/winget-pkgs repo needs to be done on the DonutWare account, and then a classic token needs to be created (make sure to set it to never expire, unless you want to change it every couple of months) and added to this repo in the secrets section and it needs to be called `WINGET_TOKEN`.

I also decided to keep it to a specific SHA because the latest version v2 is not up to date with the newest changes which are needed for smooth operation.

More info can be found here: https://github.com/vedantmgoyal9/winget-releaser

## Checklist

- [ ] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [ ] Check that any changes are related to the issue at hand.
