### PR TITLE
Bug: Fixes inno App Version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -187,6 +187,8 @@ jobs:
   build-windows:
     runs-on: windows-latest
     needs: [fetch-info]
+    env:
+      FLADDER_VERSION: ${{ needs.fetch-info.outputs.version_name }}
 
     steps:
       - name: Checkout repository
@@ -207,13 +209,25 @@ jobs:
       - name: Build Windows EXE
         run: flutter build windows --build-number=${{ github.run_number }}
 
+      - name: Debug version info
+        run: |
+          echo "Version from fetch-info: ${{ needs.fetch-info.outputs.version_name }}"
+          echo "FLADDER_VERSION will be set to: ${{ needs.fetch-info.outputs.version_name }}"
+        shell: pwsh
+
+      - name: Set version in Inno Setup script
+        run: |
+          $version = "${{ needs.fetch-info.outputs.version_name }}"
+          $content = Get-Content "windows/windows_setup.iss" -Raw
+          $content = $content -replace '\{%FLADDER_VERSION\|latest\}', $version
+          Set-Content "windows/windows_setup.iss" -Value $content
+        shell: pwsh
+
       - name: Compile Inno Setup installer
         uses: Minionguyjpro/Inno-Setup-Action@v1.2.2
         with:
           path: windows/windows_setup.iss
           options: /O+
-        env:
-          FLADDER_VERSION: ${{ needs.fetch-info.outputs.version_name }}
 
       - name: Archive Windows portable artifact
         uses: actions/upload-artifact@v4.0.0


### PR DESCRIPTION
## Pull Request Description

It seems to be that there is an issue where the `FLADDER_VERSION` environment variable is not defined so the inno installer defaults to latest. This causes several issues such as:

- Inno installer just saying latest
- App Version in settings saying latest

This PR should fix this issue by overwriting the inno installer  file with the latest version.

## Issue Being Fixed

Inno installer version not being defined correctly.

Resolves #issue-number

## Screenshots / Recordings

Before:

<img width="637" height="116" alt="image" src="https://github.com/user-attachments/assets/d3cdfb40-0c1b-4e11-90d5-179c01187098" />


<img width="333" height="87" alt="image" src="https://github.com/user-attachments/assets/69876daa-3ab9-446f-9b1a-562c9bd4ce25" />


After:

<img width="661" height="114" alt="image" src="https://github.com/user-attachments/assets/aa5f82a4-85b6-4b9e-80cc-f6223f1da84a" />


<img width="453" height="118" alt="image" src="https://github.com/user-attachments/assets/19106e49-91fe-4d9e-b929-4732ee1e35a6" />

## Checklist

- [ ] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [ ] Check that any changes are related to the issue at hand.
