### PR TITLE
bug: Fix undefined Inno `AppVersion`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -211,9 +211,7 @@ jobs:
         uses: Minionguyjpro/Inno-Setup-Action@v1.2.2
         with:
           path: windows/windows_setup.iss
-          options: /O+
-        env:
-          FLADDER_VERSION: ${{ needs.fetch-info.outputs.version_name }}
+          options: /O+ /DFLADDER_VERSION="${{ needs.fetch-info.outputs.version_name }}"
 
       - name: Archive Windows portable artifact
         uses: actions/upload-artifact@v4.0.0

--- a/windows/windows_setup.iss
+++ b/windows/windows_setup.iss
@@ -1,9 +1,13 @@
 #define SourcePath ".."
 
+#ifndef FLADDER_VERSION
+  #define FLADDER_VERSION "latest"
+#endif
+
 [Setup]
 AppId={{D573EDD5-117A-47AD-88AC-62C8EBD11DC7}
 AppName="Fladder"
-AppVersion={%FLADDER_VERSION|latest}
+AppVersion={#FLADDER_VERSION}
 AppPublisher="DonutWare"
 AppPublisherURL="https://github.com/DonutWare/Fladder"
 AppSupportURL="https://github.com/DonutWare/Fladder"


### PR DESCRIPTION
## Pull Request Description

It seems to be that there is an issue where the `FLADDER_VERSION` environment variable is not defined so the inno installer defaults to latest everytime. This causes several issues such as:

- Inno installer just saying latest
- App Version in Settings/Control Panel saying latest
- Issues with creating new Winget manifests

This PR should fix this issue by overwriting the inno installer  file with the latest version.

## Issue Being Fixed

Inno installer version not being defined correctly.

## Screenshots / Recordings

Before:

<img width="637" height="116" alt="image" src="https://github.com/user-attachments/assets/d3cdfb40-0c1b-4e11-90d5-179c01187098" />


<img width="333" height="87" alt="image" src="https://github.com/user-attachments/assets/69876daa-3ab9-446f-9b1a-562c9bd4ce25" />


After:

<img width="661" height="114" alt="image" src="https://github.com/user-attachments/assets/aa5f82a4-85b6-4b9e-80cc-f6223f1da84a" />


<img width="453" height="118" alt="image" src="https://github.com/user-attachments/assets/19106e49-91fe-4d9e-b929-4732ee1e35a6" />

## Checklist

- [ ] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [ ] Check that any changes are related to the issue at hand.
