### PR TITLE
feat: make shortcuts list collapsible

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1294,6 +1294,7 @@
   "usePostersForLibraryIconsDesc": "Show posters instead of icons for libraries",
   "offline": "Offline",
   "shortCuts": "Shortcuts",
+  "keyboardShortCuts": "Keyboard shortcuts",
   "skipForwardLength": "Skip forward length",
   "skipBackLength": "Skip back length",
   "playPause": "Play/Pause",

--- a/lib/screens/settings/player_settings_page.dart
+++ b/lib/screens/settings/player_settings_page.dart
@@ -206,29 +206,36 @@ class _PlayerSettingsPageState extends ConsumerState<PlayerSettingsPage> {
                   )),
             ),
             if (AdaptiveLayout.inputDeviceOf(context) == InputDevice.pointer)
-              ...VideoHotKeys.values.map(
-                (entry) => Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                  child: Row(
-                    children: [
-                      Expanded(
-                        child: Text(
-                          entry.label(context),
-                          style: Theme.of(context).textTheme.titleLarge,
-                        ),
-                      ),
-                      Flexible(
-                        child: KeyCombinationWidget(
-                          currentKey: videoSettings.hotKeys[entry],
-                          defaultKey: videoSettings.defaultShortCuts[entry]!,
-                          onChanged: (value) =>
-                              ref.read(videoPlayerSettingsProvider.notifier).setShortcuts(MapEntry(entry, value)),
-                        ),
-                      )
-                    ],
-                  ),
+              ExpansionTile(
+                title: Text(
+                  context.localized.keyboardShortCuts,
+                  style: Theme.of(context).textTheme.titleLarge,
                 ),
-              )
+                children: VideoHotKeys.values.map(
+                  (entry) => Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                    child: Row(
+                      children: [
+                        Expanded(
+                          child: Text(
+                            entry.label(context),
+                            style: Theme.of(context).textTheme.titleMedium,
+                          ),
+                        ),
+                        Flexible(
+                          child: KeyCombinationWidget(
+                            currentKey: videoSettings.hotKeys[entry],
+                            defaultKey: videoSettings.defaultShortCuts[entry]!,
+                            onChanged: (value) => ref
+                                .read(videoPlayerSettingsProvider.notifier)
+                                .setShortcuts(MapEntry(entry, value)),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ).toList(),
+              ),
           ],
         ),
         const SizedBox(height: 12),

--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -53,6 +53,10 @@ class FladderTheme {
         margin: EdgeInsets.zero,
         shape: smallShape,
       ),
+      expansionTileTheme: ExpansionTileThemeData(
+        shape: RoundedRectangleBorder(borderRadius: FladderTheme.defaultShape.borderRadius),
+        collapsedShape: RoundedRectangleBorder(borderRadius: FladderTheme.defaultShape.borderRadius),
+      ),
       progressIndicatorTheme: const ProgressIndicatorThemeData(),
       floatingActionButtonTheme: FloatingActionButtonThemeData(
         backgroundColor: scheme?.secondaryContainer,
@@ -62,7 +66,7 @@ class FladderTheme {
       snackBarTheme: SnackBarThemeData(
         backgroundColor: scheme?.secondary,
         behavior: SnackBarBehavior.fixed,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+        shape: RoundedRectangleBorder(borderRadius: FladderTheme.defaultShape.borderRadius),
         elevation: 5,
         dismissDirection: DismissDirection.horizontal,
       ),


### PR DESCRIPTION
This pull request improves the player settings page by making keyboard shortcut settings more accessible and organized. The main change is grouping all video hotkey settings under an expandable section labeled "Keyboard shortcuts," making the UI cleaner and easier to navigate for users with pointer input devices. Additionally, a new localization string for "Keyboard shortcuts" has been added.

**UI/UX Improvements:**

* Groups all video hotkey settings under an `ExpansionTile` labeled "Keyboard shortcuts" on the player settings page, improving organization and user experience for pointer input devices (`lib/screens/settings/player_settings_page.dart`).

## Screenshots / Recordings
<img width="837" height="267" alt="image" src="https://github.com/user-attachments/assets/5470086c-98dd-473b-84a1-bd32308f5c53" />
<img width="1270" height="793" alt="image" src="https://github.com/user-attachments/assets/72c5ca0e-416b-4470-bb92-745d3406c958" />


## Checklist

- [ ] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [ ] Check that any changes are related to the issue at hand.
