### PR TITLE
fix: Nested hero widget in widget video_player_next_wrapper

### DIFF
--- a/lib/widgets/shared/progress_floating_button.dart
+++ b/lib/widgets/shared/progress_floating_button.dart
@@ -158,7 +158,7 @@ class _ProgressFloatingButtonState extends ConsumerState<ProgressFloatingButton>
             }
           : null,
       child: FloatingActionButton(
-        heroTag: "Progress_Floating_Button",
+        heroTag: null,
         onPressed: isActive ? timer.cancel : timer.play,
         child: Stack(
           fit: StackFit.expand,


### PR DESCRIPTION
Set the `heroTag` property of the `FloatingActionButton` to `null` instead of a fixed string, preventing potential hero animation conflicts when multiple floating buttons are present.…e to FloatingActionButton

Fix this error that happen on video player init
```
SEVERE: 2025-09-07 12:50:27.994093: Flutter error: 'package:flutter/src/widgets/heroes.dart': Failed assertion: line 401 pos 7: 'context.findAncestorWidgetOfExactType<Hero>() == null': A Hero widget cannot be the descendant of another Hero widget.
```

I not realy sure of the consequence of setting null to the hero tag but it's the fix that need the minimal changes

## Checklist

- [ ] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [ ] Check that any changes are related to the issue at hand.
