### PR TITLE
Feat speed shortcuts 

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1302,6 +1302,8 @@
   "mute": "Mute",
   "volumeUp": "Volume Up",
   "volumeDown": "Volume Down",
+  "speedUp": "Speed Up",
+  "speedDown": "Speed Down",
   "nextVideo": "Next Video",
   "prevVideo": "Previous Video",
   "nextChapter": "Next Chapter",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1327,5 +1327,13 @@
         "type": "int"
       }
     }
+  },
+  "speedIndicator": "Playback rate: {speed}",
+  "@speedIndicator": {
+    "placeholders": {
+      "speed": {
+        "type": "double"
+      }
+    }
   }
 }

--- a/lib/models/settings/video_player_settings.dart
+++ b/lib/models/settings/video_player_settings.dart
@@ -20,6 +20,8 @@ enum VideoHotKeys {
   mute,
   volumeUp,
   volumeDown,
+  speedUp,
+  speedDown,
   nextVideo,
   prevVideo,
   nextChapter,
@@ -38,6 +40,8 @@ enum VideoHotKeys {
       VideoHotKeys.mute => context.localized.mute,
       VideoHotKeys.volumeUp => context.localized.volumeUp,
       VideoHotKeys.volumeDown => context.localized.volumeDown,
+      VideoHotKeys.speedUp => context.localized.speedUp,
+      VideoHotKeys.speedDown => context.localized.speedDown,
       VideoHotKeys.nextVideo => context.localized.nextVideo,
       VideoHotKeys.prevVideo => context.localized.prevVideo,
       VideoHotKeys.nextChapter => context.localized.nextChapter,
@@ -180,6 +184,8 @@ Map<VideoHotKeys, KeyCombination> get _defaultVideoHotKeys => {
           VideoHotKeys.mute => KeyCombination(key: LogicalKeyboardKey.keyM),
           VideoHotKeys.volumeUp => KeyCombination(key: LogicalKeyboardKey.arrowUp),
           VideoHotKeys.volumeDown => KeyCombination(key: LogicalKeyboardKey.arrowDown),
+          VideoHotKeys.speedUp => KeyCombination(key: LogicalKeyboardKey.arrowUp, modifier: LogicalKeyboardKey.controlLeft),
+          VideoHotKeys.speedDown => KeyCombination(key: LogicalKeyboardKey.arrowDown, modifier: LogicalKeyboardKey.controlLeft),
           VideoHotKeys.prevVideo =>
             KeyCombination(key: LogicalKeyboardKey.keyP, modifier: LogicalKeyboardKey.shiftLeft),
           VideoHotKeys.nextVideo =>

--- a/lib/models/settings/video_player_settings.g.dart
+++ b/lib/models/settings/video_player_settings.g.dart
@@ -138,6 +138,8 @@ const _$VideoHotKeysEnumMap = {
   VideoHotKeys.mute: 'mute',
   VideoHotKeys.volumeUp: 'volumeUp',
   VideoHotKeys.volumeDown: 'volumeDown',
+  VideoHotKeys.speedUp: 'speedUp',
+  VideoHotKeys.speedDown: 'speedDown',
   VideoHotKeys.nextVideo: 'nextVideo',
   VideoHotKeys.prevVideo: 'prevVideo',
   VideoHotKeys.nextChapter: 'nextChapter',

--- a/lib/providers/settings/video_player_settings_provider.dart
+++ b/lib/providers/settings/video_player_settings_provider.dart
@@ -69,6 +69,15 @@ class VideoPlayerSettingsProviderNotifier extends StateNotifier<VideoPlayerSetti
     ref.read(videoPlayerProvider).setVolume(value);
   }
 
+  void steppedSpeed(double i) {
+    final value = double.parse(
+      ((ref.read(playbackRateProvider) + i).clamp(0.25, 3))
+          .toStringAsFixed(2),
+    );
+    ref.read(playbackRateProvider.notifier).state = value;
+    ref.read(videoPlayerProvider).setSpeed(value);
+  }
+
   void toggleOrientation(Set<DeviceOrientation>? orientation) =>
       state = state.copyWith(allowedOrientations: orientation);
 

--- a/lib/providers/settings/video_player_settings_provider.dart
+++ b/lib/providers/settings/video_player_settings_provider.dart
@@ -15,6 +15,8 @@ final videoPlayerSettingsProvider =
   return VideoPlayerSettingsProviderNotifier(ref);
 });
 
+final playbackRateProvider = StateProvider<double>((ref) => 1.0);
+
 class VideoPlayerSettingsProviderNotifier extends StateNotifier<VideoPlayerSettingsModel> {
   VideoPlayerSettingsProviderNotifier(this.ref) : super(VideoPlayerSettingsModel());
 

--- a/lib/screens/video_player/components/video_player_options_sheet.dart
+++ b/lib/screens/video_player/components/video_player_options_sheet.dart
@@ -34,7 +34,6 @@ import 'package:fladder/widgets/shared/fladder_slider.dart';
 import 'package:fladder/widgets/shared/modal_bottom_sheet.dart';
 import 'package:fladder/widgets/shared/spaced_list_tile.dart';
 
-final playbackRateProvider = StateProvider<double>((ref) => 1.0);
 
 Future<void> showVideoPlayerOptions(BuildContext context, Function() minimizePlayer) {
   return showBottomSheetPill(

--- a/lib/screens/video_player/components/video_player_speed_indicator.dart
+++ b/lib/screens/video_player/components/video_player_speed_indicator.dart
@@ -1,0 +1,87 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+
+import 'package:async/async.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:iconsax_plus/iconsax_plus.dart';
+
+import 'package:fladder/providers/settings/video_player_settings_provider.dart';
+import 'package:fladder/util/localization_helper.dart';
+
+class VideoPlayerSpeedIndicator extends ConsumerStatefulWidget {
+  const VideoPlayerSpeedIndicator({super.key});
+
+  @override
+  ConsumerState<ConsumerStatefulWidget> createState() => _VideoPlayerSpeedIndicatorState();
+}
+
+class _VideoPlayerSpeedIndicatorState extends ConsumerState<VideoPlayerSpeedIndicator> {
+  late double currentSpeed = ref.read(playbackRateProvider);
+
+  bool showIndicator = false;
+  late final timer = RestartableTimer(const Duration(seconds: 1), () {
+    setState(() {
+      showIndicator = false;
+    });
+  });
+
+  @override
+  void dispose() {
+    showIndicator = false;
+    timer.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    ref.listen(
+      playbackRateProvider,
+      (previous, next) {
+        setState(() {
+          showIndicator = true;
+          currentSpeed = next;
+        });
+        timer.reset();
+      },
+    );
+    return IgnorePointer(
+      child: AnimatedOpacity(
+        duration: const Duration(milliseconds: 250),
+        opacity: showIndicator ? 1 : 0,
+        child: Center(
+          child: Container(
+            decoration: BoxDecoration(
+              color: Colors.black.withValues(alpha: 0.85),
+              borderRadius: BorderRadius.circular(16),
+            ),
+            child: Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                spacing: 12,
+                children: [
+                  Transform.rotate(
+                    angle: currentSpeed < 1 ? pi : 0,
+                    child: Icon(speedIcon(currentSpeed)),
+                  ),
+                  Text(context.localized.speedIndicator(currentSpeed)),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+IconData speedIcon(double value) {
+  if (value < 1) {
+    return IconsaxPlusBroken.flash;
+  }
+  if (value == 1) {
+    return IconsaxPlusLinear.flash_slash;
+  }
+  return IconsaxPlusLinear.flash;
+}

--- a/lib/screens/video_player/video_player_controls.dart
+++ b/lib/screens/video_player/video_player_controls.dart
@@ -26,6 +26,7 @@ import 'package:fladder/screens/video_player/components/video_player_controls_ex
 import 'package:fladder/screens/video_player/components/video_player_options_sheet.dart';
 import 'package:fladder/screens/video_player/components/video_player_quality_controls.dart';
 import 'package:fladder/screens/video_player/components/video_player_seek_indicator.dart';
+import 'package:fladder/screens/video_player/components/video_player_speed_indicator.dart';
 import 'package:fladder/screens/video_player/components/video_player_volume_indicator.dart';
 import 'package:fladder/screens/video_player/components/video_progress_bar.dart';
 import 'package:fladder/screens/video_player/components/video_volume_slider.dart';
@@ -125,6 +126,7 @@ class _DesktopControlsState extends ConsumerState<DesktopControls> {
                 ),
                 const VideoPlayerSeekIndicator(),
                 const VideoPlayerVolumeIndicator(),
+                const VideoPlayerSpeedIndicator(),
                 Consumer(
                   builder: (context, ref, child) {
                     final position = ref.watch(mediaPlaybackProvider.select((value) => value.position));

--- a/lib/screens/video_player/video_player_controls.dart
+++ b/lib/screens/video_player/video_player_controls.dart
@@ -697,6 +697,14 @@ class _DesktopControlsState extends ConsumerState<DesktopControls> {
         resetTimer();
         ref.read(videoPlayerSettingsProvider.notifier).steppedVolume(-5);
         return true;
+      case VideoHotKeys.speedUp:
+        resetTimer();
+        ref.read(videoPlayerSettingsProvider.notifier).steppedSpeed(0.1);
+        return true;
+      case VideoHotKeys.speedDown:
+        resetTimer();
+        ref.read(videoPlayerSettingsProvider.notifier).steppedSpeed(-0.1);
+        return true;
       case VideoHotKeys.fullScreen:
         fullScreenHelper.toggleFullScreen(ref);
         return true;

--- a/lib/wrappers/media_control_wrapper.dart
+++ b/lib/wrappers/media_control_wrapper.dart
@@ -297,7 +297,7 @@ class MediaControlsWrapper extends BaseAudioHandler {
   Future<int> setSubtitleTrack(SubStreamModel? model, PlaybackModel playbackModel) async =>
       await _player?.setSubtitleTrack(model, playbackModel) ?? -1;
 
-  Future<void> setVolume(double speed) async => _player?.setVolume(speed);
+  Future<void> setVolume(double volume) async => _player?.setVolume(volume);
 
   @override
   Future<void> seek(Duration position) {


### PR DESCRIPTION
Introduces playback speed control shortcuts and speed indicator overlay, and the necessary localization and state management updates.

**Playback Speed Control Improvements:**

* Added `speedUp` and `speedDown` hotkeys to the `VideoHotKeys` enum, updated their display names, serialization, and default key combinations (Ctrl+Up/Ctrl+Down). (`lib/models/settings/video_player_settings.dart`, `lib/models/settings/video_player_settings.g.dart`) 

* Implemented handling of the new speed hotkeys in the desktop video player controls, calling the new `steppedSpeed` method to adjust playback rate. (`lib/screens/video_player/video_player_controls.dart`)

**Playback Speed State and Indicator:**

* Introduced a `playbackRateProvider` using Riverpod for managing the current playback speed, and a `steppedSpeed` method in the settings notifier to update the speed, clamp it, and notify the player. (`lib/providers/settings/video_player_settings_provider.dart`) 
* Added a new `VideoPlayerSpeedIndicator` widget that listens for speed changes and displays an overlay with the current playback rate and an icon, shown briefly after each adjustment. (`lib/screens/video_player/components/video_player_speed_indicator.dart`, `lib/screens/video_player/video_player_controls.dart`)

## Screenshots / Recordings
<img width="1281" height="115" alt="image" src="https://github.com/user-attachments/assets/3869b3c6-596a-4a6b-b14e-5fdc4027afaa" />


[Screencast_20250907_153343.webm](https://github.com/user-attachments/assets/5dd842d9-f56d-479c-968b-129daf90f405)

## Checklist

- [ ] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [ ] Check that any changes are related to the issue at hand.
