### PR TITLE
feat: remove the unwatched orange dot and show watched

### DIFF
--- a/lib/screens/shared/media/components/poster_image.dart
+++ b/lib/screens/shared/media/components/poster_image.dart
@@ -1,3 +1,4 @@
+import 'package:fladder/models/items/movie_model.dart';
 import 'package:flutter/material.dart';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -200,22 +201,6 @@ class _PosterImageState extends ConsumerState<PosterImage> {
                   ],
                 ),
               ),
-              // if (widget.poster.unWatched)
-              //   Align(
-              //     alignment: Alignment.topLeft,
-              //     child: StatusCard(
-              //       color: Colors.amber,
-              //       child: Padding(
-              //         padding: const EdgeInsets.all(10),
-              //         child: Container(
-              //           decoration: const BoxDecoration(
-              //             shape: BoxShape.circle,
-              //             color: Colors.amber,
-              //           ),
-              //         ),
-              //       ),
-              //     ),
-              //   ),
               if (widget.inlineTitle)
                 IgnorePointer(
                   child: Align(
@@ -230,7 +215,8 @@ class _PosterImageState extends ConsumerState<PosterImage> {
                     ),
                   ),
                 ),
-              if (widget.poster.unPlayedItemCount != null && widget.poster is SeriesModel)
+              if ((widget.poster.unPlayedItemCount != null && widget.poster is SeriesModel) 
+                || (widget.poster is MovieModel && !widget.poster.unWatched))
                 IgnorePointer(
                   child: Align(
                     alignment: Alignment.topRight,

--- a/lib/screens/shared/media/components/poster_image.dart
+++ b/lib/screens/shared/media/components/poster_image.dart
@@ -200,22 +200,22 @@ class _PosterImageState extends ConsumerState<PosterImage> {
                   ],
                 ),
               ),
-              if (widget.poster.unWatched)
-                Align(
-                  alignment: Alignment.topLeft,
-                  child: StatusCard(
-                    color: Colors.amber,
-                    child: Padding(
-                      padding: const EdgeInsets.all(10),
-                      child: Container(
-                        decoration: const BoxDecoration(
-                          shape: BoxShape.circle,
-                          color: Colors.amber,
-                        ),
-                      ),
-                    ),
-                  ),
-                ),
+              // if (widget.poster.unWatched)
+              //   Align(
+              //     alignment: Alignment.topLeft,
+              //     child: StatusCard(
+              //       color: Colors.amber,
+              //       child: Padding(
+              //         padding: const EdgeInsets.all(10),
+              //         child: Container(
+              //           decoration: const BoxDecoration(
+              //             shape: BoxShape.circle,
+              //             color: Colors.amber,
+              //           ),
+              //         ),
+              //       ),
+              //     ),
+              //   ),
               if (widget.inlineTitle)
                 IgnorePointer(
                   child: Align(


### PR DESCRIPTION
I propose removing the orange dot that shows the unwatched status on the poster. Actually, before looking at the code, I wasn’t sure what this dot meant, and in my opinion, it’s much clearer this way.
So I propose showing the watched status consistently instead of this dot (as it’s done in the official client).

For shows, I only remove the dot for isolated unwatched episodes.
For movies, I remove the dot and add the mark icon for watched movies.

see pictures bellow.

## Screenshots / Recordings
### Home view
before 
<img width="1608" height="829" alt="image" src="https://github.com/user-attachments/assets/22c7fecd-26d9-4e3c-be36-250ab82016c1" />

after
<img width="1608" height="829" alt="image" src="https://github.com/user-attachments/assets/9ba9cf5b-d325-498c-adfc-75adb804db78" />

### Films view
before 
<img width="1816" height="700" alt="image" src="https://github.com/user-attachments/assets/8cd4fffc-f9b4-443d-9c2e-624c502908da" />


after
<img width="1822" height="840" alt="image" src="https://github.com/user-attachments/assets/bd47ec3f-da2d-4aac-9343-a4b7cb040d89" />

## Checklist

- [ ] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [ ] Check that any changes are related to the issue at hand.
