### PR TITLE
chore: Changed copyright year

### DIFF
--- a/macos/Runner/Configs/AppInfo.xcconfig
+++ b/macos/Runner/Configs/AppInfo.xcconfig
@@ -11,4 +11,4 @@ PRODUCT_NAME = Fladder
 PRODUCT_BUNDLE_IDENTIFIER = nl.jknaapen.fladder
 
 // The copyright displayed in application information
-PRODUCT_COPYRIGHT = Copyright © 2023 Donutware. All rights reserved.
+PRODUCT_COPYRIGHT = Copyright © 2025 Donutware. All rights reserved.

--- a/windows/runner/Runner.rc
+++ b/windows/runner/Runner.rc
@@ -93,7 +93,7 @@ BEGIN
             VALUE "FileDescription", "fladder" "\0"
             VALUE "FileVersion", VERSION_AS_STRING "\0"
             VALUE "InternalName", "nl.jknaapen.fladder" "\0"
-            VALUE "LegalCopyright", "Copyright (C) 2023 DonutWare. All rights reserved." "\0"
+            VALUE "LegalCopyright", "Copyright (C) 2025 DonutWare. All rights reserved." "\0"
             VALUE "OriginalFilename", "fladder.exe" "\0"
             VALUE "ProductName", "fladder" "\0"
             VALUE "ProductVersion", VERSION_AS_STRING "\0"


### PR DESCRIPTION
## Pull Request Description

Changed copyright year to 2025 instead of 2023, so that it shows that the app is still being updated.

## Issue Being Fixed

Changed copyright year from 2023 to 2025

## Checklist

- [ ] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [ ] Check that any changes are related to the issue at hand.
