### PR TITLE
fix: Disable media tunneling by default with the option to enable it

### DIFF
--- a/android/app/src/main/kotlin/nl/jknaapen/fladder/api/PlayerSettingsHelper.g.kt
+++ b/android/app/src/main/kotlin/nl/jknaapen/fladder/api/PlayerSettingsHelper.g.kt
@@ -93,6 +93,7 @@ enum class SegmentSkip(val raw: Int) {
 
 /** Generated class from Pigeon that represents data sent in messages. */
 data class PlayerSettings (
+  val enableTunneling: Boolean,
   val skipTypes: Map<SegmentType, SegmentSkip>,
   val skipForward: Long,
   val skipBackward: Long
@@ -100,14 +101,16 @@ data class PlayerSettings (
  {
   companion object {
     fun fromList(pigeonVar_list: List<Any?>): PlayerSettings {
-      val skipTypes = pigeonVar_list[0] as Map<SegmentType, SegmentSkip>
-      val skipForward = pigeonVar_list[1] as Long
-      val skipBackward = pigeonVar_list[2] as Long
-      return PlayerSettings(skipTypes, skipForward, skipBackward)
+      val enableTunneling = pigeonVar_list[0] as Boolean
+      val skipTypes = pigeonVar_list[1] as Map<SegmentType, SegmentSkip>
+      val skipForward = pigeonVar_list[2] as Long
+      val skipBackward = pigeonVar_list[3] as Long
+      return PlayerSettings(enableTunneling, skipTypes, skipForward, skipBackward)
     }
   }
   fun toList(): List<Any?> {
     return listOf(
+      enableTunneling,
       skipTypes,
       skipForward,
       skipBackward,

--- a/android/app/src/main/kotlin/nl/jknaapen/fladder/composables/controls/ItemHeader.kt
+++ b/android/app/src/main/kotlin/nl/jknaapen/fladder/composables/controls/ItemHeader.kt
@@ -32,8 +32,8 @@ fun ItemHeader(state: PlayableData?) {
                 contentDescription = title ?: "logo",
                 alignment = Alignment.CenterStart,
                 modifier = Modifier
-                    .fillMaxHeight(0.25f)
-                    .fillMaxWidth(0.5f)
+                    .fillMaxHeight(0.20f)
+                    .fillMaxWidth(0.45f)
             )
         } else {
             title?.let {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1344,5 +1344,7 @@
   "quickConnectEnterCodeDescription": "Enter the code below to login",
   "showMore": "Show more",
   "itemColorsTitle": "Item colors",
-  "itemColorsDesc": "Use item's primary color to theme the details page"
+  "itemColorsDesc": "Use item's primary color to theme the details page",
+  "mediaTunnelingTitle": "Media tunneling",
+  "mediaTunnelingDesc": "Enable media tunneling for native player"
 }

--- a/lib/models/settings/arguments_model.dart
+++ b/lib/models/settings/arguments_model.dart
@@ -2,6 +2,9 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'arguments_model.freezed.dart';
 
+/// Prefer using the arguments provider over this boolean
+bool leanBackMode = false;
+
 @freezed
 abstract class ArgumentsModel with _$ArgumentsModel {
   const ArgumentsModel._();
@@ -13,6 +16,7 @@ abstract class ArgumentsModel with _$ArgumentsModel {
 
   factory ArgumentsModel.fromArguments(List<String> arguments, bool leanBackEnabled) {
     arguments = arguments.map((e) => e.trim()).toList();
+    leanBackMode = leanBackEnabled;
     return ArgumentsModel(
       htpcMode: arguments.contains('--htpc') || leanBackEnabled,
       leanBackMode: leanBackEnabled,

--- a/lib/models/settings/video_player_settings.freezed.dart
+++ b/lib/models/settings/video_player_settings.freezed.dart
@@ -19,6 +19,7 @@ mixin _$VideoPlayerSettingsModel implements DiagnosticableTreeMixin {
   bool get fillScreen;
   bool get hardwareAccel;
   bool get useLibass;
+  bool get enableTunneling;
   int get bufferSize;
   PlayerOptions? get playerOptions;
   double get internalVolume;
@@ -50,6 +51,7 @@ mixin _$VideoPlayerSettingsModel implements DiagnosticableTreeMixin {
       ..add(DiagnosticsProperty('fillScreen', fillScreen))
       ..add(DiagnosticsProperty('hardwareAccel', hardwareAccel))
       ..add(DiagnosticsProperty('useLibass', useLibass))
+      ..add(DiagnosticsProperty('enableTunneling', enableTunneling))
       ..add(DiagnosticsProperty('bufferSize', bufferSize))
       ..add(DiagnosticsProperty('playerOptions', playerOptions))
       ..add(DiagnosticsProperty('internalVolume', internalVolume))
@@ -64,7 +66,7 @@ mixin _$VideoPlayerSettingsModel implements DiagnosticableTreeMixin {
 
   @override
   String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
-    return 'VideoPlayerSettingsModel(screenBrightness: $screenBrightness, videoFit: $videoFit, fillScreen: $fillScreen, hardwareAccel: $hardwareAccel, useLibass: $useLibass, bufferSize: $bufferSize, playerOptions: $playerOptions, internalVolume: $internalVolume, allowedOrientations: $allowedOrientations, nextVideoType: $nextVideoType, maxHomeBitrate: $maxHomeBitrate, maxInternetBitrate: $maxInternetBitrate, audioDevice: $audioDevice, segmentSkipSettings: $segmentSkipSettings, hotKeys: $hotKeys)';
+    return 'VideoPlayerSettingsModel(screenBrightness: $screenBrightness, videoFit: $videoFit, fillScreen: $fillScreen, hardwareAccel: $hardwareAccel, useLibass: $useLibass, enableTunneling: $enableTunneling, bufferSize: $bufferSize, playerOptions: $playerOptions, internalVolume: $internalVolume, allowedOrientations: $allowedOrientations, nextVideoType: $nextVideoType, maxHomeBitrate: $maxHomeBitrate, maxInternetBitrate: $maxInternetBitrate, audioDevice: $audioDevice, segmentSkipSettings: $segmentSkipSettings, hotKeys: $hotKeys)';
   }
 }
 
@@ -80,6 +82,7 @@ abstract mixin class $VideoPlayerSettingsModelCopyWith<$Res> {
       bool fillScreen,
       bool hardwareAccel,
       bool useLibass,
+      bool enableTunneling,
       int bufferSize,
       PlayerOptions? playerOptions,
       double internalVolume,
@@ -110,6 +113,7 @@ class _$VideoPlayerSettingsModelCopyWithImpl<$Res>
     Object? fillScreen = null,
     Object? hardwareAccel = null,
     Object? useLibass = null,
+    Object? enableTunneling = null,
     Object? bufferSize = null,
     Object? playerOptions = freezed,
     Object? internalVolume = null,
@@ -141,6 +145,10 @@ class _$VideoPlayerSettingsModelCopyWithImpl<$Res>
       useLibass: null == useLibass
           ? _self.useLibass
           : useLibass // ignore: cast_nullable_to_non_nullable
+              as bool,
+      enableTunneling: null == enableTunneling
+          ? _self.enableTunneling
+          : enableTunneling // ignore: cast_nullable_to_non_nullable
               as bool,
       bufferSize: null == bufferSize
           ? _self.bufferSize
@@ -285,6 +293,7 @@ extension VideoPlayerSettingsModelPatterns on VideoPlayerSettingsModel {
             bool fillScreen,
             bool hardwareAccel,
             bool useLibass,
+            bool enableTunneling,
             int bufferSize,
             PlayerOptions? playerOptions,
             double internalVolume,
@@ -307,6 +316,7 @@ extension VideoPlayerSettingsModelPatterns on VideoPlayerSettingsModel {
             _that.fillScreen,
             _that.hardwareAccel,
             _that.useLibass,
+            _that.enableTunneling,
             _that.bufferSize,
             _that.playerOptions,
             _that.internalVolume,
@@ -343,6 +353,7 @@ extension VideoPlayerSettingsModelPatterns on VideoPlayerSettingsModel {
             bool fillScreen,
             bool hardwareAccel,
             bool useLibass,
+            bool enableTunneling,
             int bufferSize,
             PlayerOptions? playerOptions,
             double internalVolume,
@@ -364,6 +375,7 @@ extension VideoPlayerSettingsModelPatterns on VideoPlayerSettingsModel {
             _that.fillScreen,
             _that.hardwareAccel,
             _that.useLibass,
+            _that.enableTunneling,
             _that.bufferSize,
             _that.playerOptions,
             _that.internalVolume,
@@ -399,6 +411,7 @@ extension VideoPlayerSettingsModelPatterns on VideoPlayerSettingsModel {
             bool fillScreen,
             bool hardwareAccel,
             bool useLibass,
+            bool enableTunneling,
             int bufferSize,
             PlayerOptions? playerOptions,
             double internalVolume,
@@ -420,6 +433,7 @@ extension VideoPlayerSettingsModelPatterns on VideoPlayerSettingsModel {
             _that.fillScreen,
             _that.hardwareAccel,
             _that.useLibass,
+            _that.enableTunneling,
             _that.bufferSize,
             _that.playerOptions,
             _that.internalVolume,
@@ -446,6 +460,7 @@ class _VideoPlayerSettingsModel extends VideoPlayerSettingsModel
       this.fillScreen = false,
       this.hardwareAccel = true,
       this.useLibass = false,
+      this.enableTunneling = false,
       this.bufferSize = 32,
       this.playerOptions,
       this.internalVolume = 100,
@@ -478,6 +493,9 @@ class _VideoPlayerSettingsModel extends VideoPlayerSettingsModel
   @override
   @JsonKey()
   final bool useLibass;
+  @override
+  @JsonKey()
+  final bool enableTunneling;
   @override
   @JsonKey()
   final int bufferSize;
@@ -552,6 +570,7 @@ class _VideoPlayerSettingsModel extends VideoPlayerSettingsModel
       ..add(DiagnosticsProperty('fillScreen', fillScreen))
       ..add(DiagnosticsProperty('hardwareAccel', hardwareAccel))
       ..add(DiagnosticsProperty('useLibass', useLibass))
+      ..add(DiagnosticsProperty('enableTunneling', enableTunneling))
       ..add(DiagnosticsProperty('bufferSize', bufferSize))
       ..add(DiagnosticsProperty('playerOptions', playerOptions))
       ..add(DiagnosticsProperty('internalVolume', internalVolume))
@@ -566,7 +585,7 @@ class _VideoPlayerSettingsModel extends VideoPlayerSettingsModel
 
   @override
   String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
-    return 'VideoPlayerSettingsModel(screenBrightness: $screenBrightness, videoFit: $videoFit, fillScreen: $fillScreen, hardwareAccel: $hardwareAccel, useLibass: $useLibass, bufferSize: $bufferSize, playerOptions: $playerOptions, internalVolume: $internalVolume, allowedOrientations: $allowedOrientations, nextVideoType: $nextVideoType, maxHomeBitrate: $maxHomeBitrate, maxInternetBitrate: $maxInternetBitrate, audioDevice: $audioDevice, segmentSkipSettings: $segmentSkipSettings, hotKeys: $hotKeys)';
+    return 'VideoPlayerSettingsModel(screenBrightness: $screenBrightness, videoFit: $videoFit, fillScreen: $fillScreen, hardwareAccel: $hardwareAccel, useLibass: $useLibass, enableTunneling: $enableTunneling, bufferSize: $bufferSize, playerOptions: $playerOptions, internalVolume: $internalVolume, allowedOrientations: $allowedOrientations, nextVideoType: $nextVideoType, maxHomeBitrate: $maxHomeBitrate, maxInternetBitrate: $maxInternetBitrate, audioDevice: $audioDevice, segmentSkipSettings: $segmentSkipSettings, hotKeys: $hotKeys)';
   }
 }
 
@@ -584,6 +603,7 @@ abstract mixin class _$VideoPlayerSettingsModelCopyWith<$Res>
       bool fillScreen,
       bool hardwareAccel,
       bool useLibass,
+      bool enableTunneling,
       int bufferSize,
       PlayerOptions? playerOptions,
       double internalVolume,
@@ -614,6 +634,7 @@ class __$VideoPlayerSettingsModelCopyWithImpl<$Res>
     Object? fillScreen = null,
     Object? hardwareAccel = null,
     Object? useLibass = null,
+    Object? enableTunneling = null,
     Object? bufferSize = null,
     Object? playerOptions = freezed,
     Object? internalVolume = null,
@@ -645,6 +666,10 @@ class __$VideoPlayerSettingsModelCopyWithImpl<$Res>
       useLibass: null == useLibass
           ? _self.useLibass
           : useLibass // ignore: cast_nullable_to_non_nullable
+              as bool,
+      enableTunneling: null == enableTunneling
+          ? _self.enableTunneling
+          : enableTunneling // ignore: cast_nullable_to_non_nullable
               as bool,
       bufferSize: null == bufferSize
           ? _self.bufferSize

--- a/lib/models/settings/video_player_settings.g.dart
+++ b/lib/models/settings/video_player_settings.g.dart
@@ -15,6 +15,7 @@ _VideoPlayerSettingsModel _$VideoPlayerSettingsModelFromJson(
       fillScreen: json['fillScreen'] as bool? ?? false,
       hardwareAccel: json['hardwareAccel'] as bool? ?? true,
       useLibass: json['useLibass'] as bool? ?? false,
+      enableTunneling: json['enableTunneling'] as bool? ?? false,
       bufferSize: (json['bufferSize'] as num?)?.toInt() ?? 32,
       playerOptions:
           $enumDecodeNullable(_$PlayerOptionsEnumMap, json['playerOptions']),
@@ -53,6 +54,7 @@ Map<String, dynamic> _$VideoPlayerSettingsModelToJson(
       'fillScreen': instance.fillScreen,
       'hardwareAccel': instance.hardwareAccel,
       'useLibass': instance.useLibass,
+      'enableTunneling': instance.enableTunneling,
       'bufferSize': instance.bufferSize,
       'playerOptions': _$PlayerOptionsEnumMap[instance.playerOptions],
       'internalVolume': instance.internalVolume,

--- a/lib/providers/settings/video_player_settings_provider.dart
+++ b/lib/providers/settings/video_player_settings_provider.dart
@@ -36,6 +36,7 @@ class VideoPlayerSettingsProviderNotifier extends StateNotifier<VideoPlayerSetti
     final userData = ref.read(userProvider);
     pigeon.PlayerSettingsPigeon().sendPlayerSettings(
       pigeon.PlayerSettings(
+        enableTunneling: value.enableTunneling,
         skipTypes: value.segmentSkipSettings.map(
           (key, value) => MapEntry(
             switch (key) {
@@ -82,6 +83,7 @@ class VideoPlayerSettingsProviderNotifier extends StateNotifier<VideoPlayerSetti
 
   void setHardwareAccel(bool? value) => state = state.copyWith(hardwareAccel: value ?? true);
   void setUseLibass(bool? value) => state = state.copyWith(useLibass: value ?? false);
+  void setMediaTunneling(bool? value) => state = state.copyWith(enableTunneling: value ?? false);
   void setBufferSize(int? value) => state = state.copyWith(bufferSize: value ?? 32);
   void setFitType(BoxFit? value) => state = state.copyWith(videoFit: value ?? BoxFit.contain);
 

--- a/lib/screens/details_screens/components/overview_header.dart
+++ b/lib/screens/details_screens/components/overview_header.dart
@@ -171,7 +171,7 @@ class OverviewHeader extends ConsumerWidget {
                 ].addInBetween(const SizedBox(height: 10)),
               ),
             ),
-            if (AdaptiveLayout.viewSizeOf(context) == ViewSize.phone) ...[
+            if (AdaptiveLayout.viewSizeOf(context) <= ViewSize.phone) ...[
               if (playButton != null) playButton!,
               if (centerButtons != null) centerButtons!,
             ] else

--- a/lib/screens/photo_viewer/simple_video_player.dart
+++ b/lib/screens/photo_viewer/simple_video_player.dart
@@ -32,7 +32,7 @@ class SimpleVideoPlayer extends ConsumerStatefulWidget {
 }
 
 class _SimpleVideoPlayerState extends ConsumerState<SimpleVideoPlayer> with WindowListener, WidgetsBindingObserver {
-  late final BasePlayer player = switch (ref.read(videoPlayerSettingsProvider.select((value) => value.wantedPlayer))) {
+  late final BasePlayer player = switch (ref.read(videoPlayerSettingsProvider).wantedPlayer) {
     PlayerOptions.libMDK => LibMDK(),
     PlayerOptions.libMPV => LibMPV(),
     _ => LibMDK(),

--- a/lib/screens/shared/media/components/media_play_button.dart
+++ b/lib/screens/shared/media/components/media_play_button.dart
@@ -62,7 +62,7 @@ class MediaPlayButton extends ConsumerWidget {
       child: onPressed == null
           ? const SizedBox.shrink(key: ValueKey('empty'))
           : Row(
-              spacing: 2,
+              spacing: 4,
               children: [
                 FocusButton(
                   onTap: () => onPressed?.call(false),
@@ -76,38 +76,35 @@ class MediaPlayButton extends ConsumerWidget {
                       );
                     }
                   },
-                  child: Padding(
-                    padding: EdgeInsets.all(padding),
-                    child: Stack(
-                      alignment: Alignment.center,
-                      children: [
-                        // Progress background
-                        Positioned.fill(
+                  child: Stack(
+                    alignment: Alignment.center,
+                    children: [
+                      // Progress background
+                      Positioned.fill(
+                        child: DecoratedBox(
+                          decoration: BoxDecoration(
+                            color: theme.colorScheme.primaryContainer,
+                            borderRadius: radius,
+                          ),
+                        ),
+                      ),
+                      // Button content
+                      buttonTitle(theme.colorScheme.onPrimaryContainer),
+                      Positioned.fill(
+                        child: ClipRect(
+                          clipper: _ProgressClipper(
+                            progress,
+                          ),
                           child: DecoratedBox(
                             decoration: BoxDecoration(
-                              color: theme.colorScheme.primaryContainer,
+                              color: theme.colorScheme.primary,
                               borderRadius: radius,
                             ),
+                            child: buttonTitle(theme.colorScheme.onPrimary),
                           ),
                         ),
-                        // Button content
-                        buttonTitle(theme.colorScheme.onPrimaryContainer),
-                        Positioned.fill(
-                          child: ClipRect(
-                            clipper: _ProgressClipper(
-                              progress,
-                            ),
-                            child: DecoratedBox(
-                              decoration: BoxDecoration(
-                                color: theme.colorScheme.primary,
-                                borderRadius: radius,
-                              ),
-                              child: buttonTitle(theme.colorScheme.onPrimary),
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
+                      ),
+                    ],
                   ),
                 ),
                 if (progress != 0)

--- a/lib/src/player_settings_helper.g.dart
+++ b/lib/src/player_settings_helper.g.dart
@@ -45,10 +45,13 @@ enum SegmentSkip {
 
 class PlayerSettings {
   PlayerSettings({
+    required this.enableTunneling,
     required this.skipTypes,
     required this.skipForward,
     required this.skipBackward,
   });
+
+  bool enableTunneling;
 
   Map<SegmentType, SegmentSkip> skipTypes;
 
@@ -58,6 +61,7 @@ class PlayerSettings {
 
   List<Object?> _toList() {
     return <Object?>[
+      enableTunneling,
       skipTypes,
       skipForward,
       skipBackward,
@@ -70,9 +74,10 @@ class PlayerSettings {
   static PlayerSettings decode(Object result) {
     result as List<Object?>;
     return PlayerSettings(
-      skipTypes: (result[0] as Map<Object?, Object?>?)!.cast<SegmentType, SegmentSkip>(),
-      skipForward: result[1]! as int,
-      skipBackward: result[2]! as int,
+      enableTunneling: result[0]! as bool,
+      skipTypes: (result[1] as Map<Object?, Object?>?)!.cast<SegmentType, SegmentSkip>(),
+      skipForward: result[2]! as int,
+      skipBackward: result[3]! as int,
     );
   }
 

--- a/lib/wrappers/media_control_wrapper.dart
+++ b/lib/wrappers/media_control_wrapper.dart
@@ -14,7 +14,6 @@ import 'package:fladder/models/items/media_streams_model.dart';
 import 'package:fladder/models/media_playback_model.dart';
 import 'package:fladder/models/playback/playback_model.dart';
 import 'package:fladder/models/settings/video_player_settings.dart';
-import 'package:fladder/providers/arguments_provider.dart';
 import 'package:fladder/providers/settings/client_settings_provider.dart';
 import 'package:fladder/providers/settings/video_player_settings_provider.dart';
 import 'package:fladder/providers/video_player_provider.dart';
@@ -73,13 +72,11 @@ class MediaControlsWrapper extends BaseAudioHandler implements VideoPlayerContro
       );
     }
 
-    final player = ref.read(argumentsStateProvider).leanBackMode
-        ? NativePlayer()
-        : switch (ref.read(videoPlayerSettingsProvider.select((value) => value.wantedPlayer))) {
-            PlayerOptions.libMDK => LibMDK(),
-            PlayerOptions.libMPV => LibMPV(),
-            PlayerOptions.nativePlayer => NativePlayer(),
-          };
+    final player = switch (ref.read(videoPlayerSettingsProvider).wantedPlayer) {
+      PlayerOptions.libMDK => LibMDK(),
+      PlayerOptions.libMPV => LibMPV(),
+      PlayerOptions.nativePlayer => NativePlayer(),
+    };
 
     setup(player);
   }

--- a/pigeons/player_settings_pigeon.dart
+++ b/pigeons/player_settings_pigeon.dart
@@ -12,11 +12,13 @@ import 'package:pigeon/pigeon.dart';
   ),
 )
 class PlayerSettings {
+  final bool enableTunneling;
   final Map<SegmentType, SegmentSkip> skipTypes;
-    final int skipForward;
+  final int skipForward;
   final int skipBackward;
 
   const PlayerSettings({
+    required this.enableTunneling,
     required this.skipTypes,
     required this.skipForward,
     required this.skipBackward,


### PR DESCRIPTION
## Pull Request Description

Disabling media tunneling by default makes the ffmpeg fallback work as expected. All codecs supported by the device now work.
Left in the option to enable tunneling for improved power saving/performance at the expense of some codecs no longer working.

Resolves #513 

