### PR TITLE
fix: Winget workflow max-versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -527,9 +527,9 @@ jobs:
 
           ---
 
-          📅 **Build Date:** $(date -u "+%Y-%m-%d %H:%M:%S UTC")  
-          🔧 **Build Number:** ${{ github.run_number }}  
-          📝 **Commit:** ${{ github.sha }}  
+          📅 **Build Date:** $(date -u "+%Y-%m-%d %H:%M:%S UTC")
+          🔧 **Build Number:** ${{ github.run_number }}
+          📝 **Commit:** ${{ github.sha }}
           🌿 **Branch:** develop
           EOF
 
@@ -752,7 +752,7 @@ jobs:
         include:
           - build_type: release
             identifier: DonutWare.Fladder
-            max_versions: ""
+            max_versions: "0"
           - build_type: nightly
             identifier: DonutWare.Fladder.Nightly
             max_versions: "1"


### PR DESCRIPTION
## Pull Request Description

Fixes issue since max versions was not set, it is now set to 0 to keep all versions

I have already created a PR for the new release on the winget-pkgs repo, but this resolves the issue for next time.

## Issue Being Fixed

Workflow failure due to max-versions not be set for winget-submit

Screenshot:

<img width="807" height="124" alt="Screenshot 2025-11-01 at 15 15 41" src="https://github.com/user-attachments/assets/99b54ff8-c461-477b-8acb-5e9732499e75" />

## Checklist

- [ ] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [ ] Check that any changes are related to the issue at hand.
