### PR TITLE
fix: System bars contiuously showing on Android video player

### DIFF
--- a/android/app/src/main/kotlin/nl/jknaapen/fladder/utility/ImmersiveSystemBars.kt
+++ b/android/app/src/main/kotlin/nl/jknaapen/fladder/utility/ImmersiveSystemBars.kt
@@ -28,7 +28,6 @@ fun ImmersiveSystemBars(isImmersive: Boolean) {
         }
 
         onDispose {
-            // Restore system bars when leaving immersive mode
             controller?.show(androidx.core.view.WindowInsetsCompat.Type.systemBars())
         }
     }

--- a/lib/screens/video_player/video_player_controls.dart
+++ b/lib/screens/video_player/video_player_controls.dart
@@ -626,23 +626,23 @@ class _DesktopControlsState extends ConsumerState<DesktopControls> {
     if (showOverlay == (value ?? !showOverlay)) return;
     setState(() => showOverlay = (value ?? !showOverlay));
     resetTimer();
-    
-    // Determine the desired SystemUiMode based on overlay state
+
     final desiredMode = showOverlay ? SystemUiMode.edgeToEdge : SystemUiMode.immersiveSticky;
-    
-    // Only update SystemUiMode if it's actually changing
+
     if (_currentSystemUiMode != desiredMode) {
       _currentSystemUiMode = desiredMode;
       SystemChrome.setEnabledSystemUIMode(desiredMode, overlays: []);
     }
-    
+
     SystemChrome.setSystemUIOverlayStyle(const SystemUiOverlayStyle(
       statusBarColor: Colors.transparent,
       systemNavigationBarColor: Colors.transparent,
       statusBarIconBrightness: Brightness.light,
       systemNavigationBarDividerColor: Colors.transparent,
     ));
-  }  void minimizePlayer(BuildContext context) {
+  }
+
+  void minimizePlayer(BuildContext context) {
     clearOverlaySettings();
     ref.read(mediaPlaybackProvider.notifier).update((state) => state.copyWith(state: VideoPlayerState.minimized));
     Navigator.of(context).pop();


### PR DESCRIPTION
## Pull Request Description

I noticed an issue on Android, specifically the mobile version, where when you are in the video player, you check the notification area and then go back out, the system bars stay there unless you press to show and hide the video player controls.

This PR fixes that so that the system bars get removed after that without needing to press anything else

## Issue Being Fixed

System bars showing continuously after viewing notification area on Android

## Screenshots / Recordings

Before:


https://github.com/user-attachments/assets/73581a5d-6095-46b4-a430-94a7fe25b781

After:


https://github.com/user-attachments/assets/22be5ccc-c300-40ed-b63d-4c43e9d963ae


## Checklist

- [ ] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [ ] Check that any changes are related to the issue at hand.
