### PR TITLE
fix: Sync basename parsing for different hosts

### DIFF
--- a/lib/providers/sync_provider.dart
+++ b/lib/providers/sync_provider.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:developer';
 import 'dart:io';
 
+import 'package:fladder/util/string_extensions.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart' hide ConnectionState;
 
@@ -503,19 +504,11 @@ class SyncNotifier extends StateNotifier<SyncSettingsModel> {
         await ref.read(backgroundDownloaderProvider).cancelTaskWithId(currentTask.id);
       }
       if (!skipDownload) {
-        // Sanitize filename to avoid path separators causing ArgumentError.
-        final rawFilename = syncItem.videoFileName;
-        final safeFilename = path.basename(rawFilename ?? 'unknown').replaceAll(RegExp(r'[\\/]+'), '_');
-        if (safeFilename != rawFilename) {
-          // Update syncItem expectation so completion detection (videoFile.existsSync) matches saved file.
-          syncItem = syncItem.copyWith(videoFileName: safeFilename);
-          await updateItem(syncItem); // persist new filename
-        }
         final downloadTask = DownloadTask(
           taskId: syncItem.id,
           url: Uri.parse(downloadUrl).toString(),
           directory: syncItem.directory.path,
-          filename: safeFilename,
+          filename: syncItem.videoFileName,
           updates: Updates.statusAndProgress,
           baseDirectory: BaseDirectory.root,
           urlQueryParameters: {"api_key": user.credentials.token},
@@ -628,11 +621,11 @@ extension SyncNotifierHelpers on SyncNotifier {
     if (parent == null) {
       await _db.insertItem(syncItem);
     }
-
+    
     return syncItem.copyWith(
       fileSize: response.mediaSources?.firstOrNull?.size ?? 0,
       syncing: false,
-      videoFileName: response.path?.split('/').lastOrNull ?? "",
+      videoFileName: response.path?.universalBasename ?? "",
     );
   }
 

--- a/lib/util/string_extensions.dart
+++ b/lib/util/string_extensions.dart
@@ -1,4 +1,5 @@
 import 'package:fladder/models/items/item_shared_models.dart';
+import 'package:path/path.dart' as path;
 
 extension StringExtensions on String {
   String capitalize() {
@@ -48,6 +49,13 @@ extension StringExtensions on String {
     }
 
     return result;
+  }
+
+  /// Supports both Linux and Windows server path separators as referenced in [path.separator].
+  /// Instead of the [path.basename] method, which returns the last part of the path for the current client platform.
+  String get universalBasename {
+    final parts = split(RegExp(r'[\\/]+'));
+    return parts.where((s)=>s.isNotEmpty).lastOrNull ?? '';
   }
 }
 


### PR DESCRIPTION
## Pull Request Description

I tested the latest release of 8.0 and saw that this issue still hasn't been resolved, so I thought I would take a whirl at it.

Fixes the issue with malformed filename where it seems there are slashes in the file's name, this sanitizes it if for some reason it has occurred.

It updates and persists the name and includes it in the download task.

I've tested and confirmed the fix on the windows development build (unfortunately I don't have the environment setup to test android)

## Issue Being Fixed

This fixes the issues where the files cannot be synced for some users.

Resolves #457 #451

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [ ] Check that any changes are related to the issue at hand.
