### PR TITLE
fix: Library screen causing server to go down because of api calls

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -240,6 +240,7 @@ class _MainState extends ConsumerState<Main> with WindowListener, WidgetsBinding
 
       windowManager.waitUntilReadyToShow(windowOptions, () async {
         await windowManager.show();
+
         await windowManager.focus();
         final startupArguments = ref.read(argumentsStateProvider);
         if (startupArguments.htpcMode && !(await windowManager.isFullScreen())) {

--- a/lib/providers/library_screen_provider.dart
+++ b/lib/providers/library_screen_provider.dart
@@ -84,9 +84,15 @@ class LibraryScreen extends _$LibraryScreen {
   }
 
   Future<Response?> loadLibrary(ViewModel viewModel) async {
-    await loadRecommendations(viewModel);
-    await loadGenres(viewModel);
-    await loadFavourites(viewModel);
+    if (state.viewType.contains(LibraryViewType.recommended)) {
+      await loadRecommendations(viewModel);
+    }
+    if (state.viewType.contains(LibraryViewType.favourites)) {
+      await loadFavourites(viewModel);
+    }
+    if (state.viewType.contains(LibraryViewType.genres)) {
+      await loadGenres(viewModel);
+    }
     return null;
   }
 
@@ -97,7 +103,7 @@ class LibraryScreen extends _$LibraryScreen {
 
     final resume = await api.usersUserIdItemsResumeGet(
       parentId: viewModel.id,
-      limit: 14,
+      limit: 9,
       enableUserData: true,
       enableImageTypes: [
         ImageType.primary,
@@ -120,7 +126,7 @@ class LibraryScreen extends _$LibraryScreen {
       final response = await api.moviesRecommendationsGet(
         parentId: viewModel.id,
         categoryLimit: 6,
-        itemLimit: 14,
+        itemLimit: 9,
         fields: [ItemFields.mediasourcecount],
       );
       newRecommendations = [
@@ -133,7 +139,7 @@ class LibraryScreen extends _$LibraryScreen {
     } else {
       final nextUp = await api.showsNextUpGet(
         parentId: viewModel.id,
-        limit: 14,
+        limit: 9,
         imageTypeLimit: 1,
         fields: [ItemFields.mediasourcecount, ItemFields.primaryimageaspectratio],
       );
@@ -157,7 +163,7 @@ class LibraryScreen extends _$LibraryScreen {
 
     final latest = await api.usersUserIdItemsLatestGet(
       parentId: viewModel.id,
-      limit: 14,
+      limit: 9,
       imageTypeLimit: 1,
       includeItemTypes: viewModel.collectionType.itemKinds.map((e) => e.dtoKind).toList(),
     );
@@ -180,7 +186,7 @@ class LibraryScreen extends _$LibraryScreen {
       parentId: viewModel.id,
       isFavorite: true,
       recursive: true,
-      limit: 14,
+      limit: 9,
       includeItemTypes: viewModel.collectionType.itemKinds.map((e) => e.dtoKind).toList(),
       enableImageTypes: [ImageType.primary],
       fields: [
@@ -211,11 +217,13 @@ class LibraryScreen extends _$LibraryScreen {
 
     if (filteredGenres.isEmpty) return null;
 
-    final results = await Future.wait(filteredGenres.map((genre) async {
-      final response = await api.itemsGet(
+    final futures = filteredGenres.map((genre) {
+      return api
+          .itemsGet(
         parentId: viewModel.id,
         genreIds: [genre.id],
-        limit: 14,
+        limit: 9,
+        recursive: true,
         includeItemTypes: viewModel.collectionType.itemKinds.map((e) => e.dtoKind).toList(),
         enableImageTypes: [ImageType.primary],
         fields: [
@@ -226,14 +234,17 @@ class LibraryScreen extends _$LibraryScreen {
         enableTotalRecordCount: false,
         imageTypeLimit: 1,
         sortOrder: [SortOrder.ascending],
-      );
+      )
+          .then((response) {
+        final items = response.body?.items;
+        if (items != null && items.isNotEmpty) {
+          return RecommendedModel(name: Other(genre.name), posters: items);
+        }
+        return null;
+      });
+    }).toList();
 
-      final items = response.body?.items;
-      if (items != null && items.isNotEmpty) {
-        return RecommendedModel(name: Other(genre.name), posters: items);
-      }
-      return null;
-    }));
+    final results = await Future.wait(futures);
 
     state = state.copyWith(
       genres: results.whereType<RecommendedModel>().toList(),


### PR DESCRIPTION
## Pull Request Description

The latest Jellyfin update (10.11.x) has caused some strange side effects using certain API calls. This tries to improve on the load times and aligns them more with how the Jellyfin web frontend handles these calls.

## Issue Being Fixed

Resolves #590 
