### PR TITLE
fix: Remove MPV backend from android tv's

### DIFF
--- a/lib/models/settings/video_player_settings.dart
+++ b/lib/models/settings/video_player_settings.dart
@@ -140,7 +140,7 @@ enum PlayerOptions {
   const PlayerOptions();
 
   static Iterable<PlayerOptions> get available => leanBackMode
-      ? {PlayerOptions.nativePlayer, PlayerOptions.libMPV}
+      ? {PlayerOptions.nativePlayer}
       : kIsWeb
           ? {PlayerOptions.libMPV}
           : switch (defaultTargetPlatform) {


### PR DESCRIPTION
## Pull Request Description

Removes the MPV player from being a option on Android TV devices.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Resolves #616 