### PR TITLE
feat: Allow shortcuts with D-Pad controls

### DIFF
--- a/lib/screens/settings/client_settings_page.dart
+++ b/lib/screens/settings/client_settings_page.dart
@@ -62,7 +62,7 @@ class _ClientSettingsPageState extends ConsumerState<ClientSettingsPage> {
             },
           ),
         ]),
-        if (AdaptiveLayout.inputDeviceOf(context) == InputDevice.pointer) ...[
+        if (AdaptiveLayout.inputDeviceOf(context) != InputDevice.touch) ...[
           const SizedBox(height: 12),
           ...buildClientSettingsShortCuts(context, ref),
         ],

--- a/lib/screens/settings/player_settings_page.dart
+++ b/lib/screens/settings/player_settings_page.dart
@@ -203,7 +203,7 @@ class _PlayerSettingsPageState extends ConsumerState<PlayerSettingsPage> {
                     },
                   )),
             ),
-            if (AdaptiveLayout.inputDeviceOf(context) == InputDevice.pointer)
+            if (AdaptiveLayout.inputDeviceOf(context) != InputDevice.touch)
               ExpansionTile(
                 title: Text(
                   context.localized.keyboardShortCuts,


### PR DESCRIPTION
## Pull Request Description

Allow editing/viewing shortcuts with d-pad navigation.

Probably a better way but for now this allows AndroidTVs with bluetooth keyboards to use shortcuts as well.