### PR TITLE
Add German translations for screenshot and local URL

### DIFF
--- a/l10n.yaml
+++ b/l10n.yaml
@@ -3,3 +3,4 @@ template-arb-file: app_en.arb
 output-localization-file: app_localizations.dart
 nullable-getter: false
 output-dir: lib/l10n/generated
+untranslated-messages-file: untranslated_de_messages.json

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1527,6 +1527,12 @@
             }
         }
     },
+    "takeScreenshot": "Screenshot aufnehmen",
+    "takeScreenshotClean": "Screenshot aufnehmen (ohne Untertitel)",
+    "screenshots": "Screenshots",
+    "screenshotTaken": "Screenshot gespeichert!",
+    "screenshotCleanTaken": "Screenshot ohne Untertitel gespeichert!",
+    "errorTakingScreenshot": "Beim Aufnehmen des Screenshots ist ein Fehler aufgetreten",
     "openImeKeyboard": "IME Tastatur öffnen",
     "@openImeKeyboard": {},
     "playerSettingsScreensaverDesc": "Wähle einen Bildschirmschoner aus, der bei Inaktivität angezeigt wird",
@@ -1540,5 +1546,8 @@
     "screensaverBlack": "Schwarz",
     "@screensaverBlack": {},
     "playerSettingsScreensaverTitle": "Bildschirmschoner",
-    "@playerSettingsScreensaverTitle": {}
+    "@playerSettingsScreensaverTitle": {},
+    "settingsLocalUrlTitle": "Lokale Server-URL",
+    "settingsLocalUrlSetTitle": "Lokale URL konfigurieren",
+    "settingsLocalUrlSetDesc": "Gib die lokale Serveradresse an. Fladder verwendet diese URL automatisch, wenn sich dein Gerät im selben Netzwerk befindet."
 }


### PR DESCRIPTION
Added new German localization strings for screenshot-related actions and local server URL configuration. Updated l10n.yaml to specify a file for untranslated messages.

## Pull Request Description

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Resolves #issue-number

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [ ] Check that any changes are related to the issue at hand.
