### PR TITLE
fix: prefered filter not restored

### DIFF
--- a/lib/providers/library_search_provider.dart
+++ b/lib/providers/library_search_provider.dart
@@ -75,14 +75,14 @@ class LibrarySearchNotifier extends StateNotifier<LibrarySearchModel> {
 
     if (!wasInitialized) {
       wasInitialized = true;
-      state = state.copyWith(
-        filters: state.filters.copyWith(
-          types: state.filters.types.replaceMap(filters.types, enabledOnly: true),
-          genres: state.filters.genres.replaceMap(filters.genres, enabledOnly: true),
-          recursive: filters.recursive ?? true,
-          favourites: filters.favourites ?? false,
-        ),
-      );
+      final findFavouriteFilter = ref
+          .read(libraryFiltersProvider(state.views.included.map((e) => e.id).toList()))
+          .firstWhereOrNull((element) => element.isFavourite);
+      if (findFavouriteFilter != null) {
+        state = state.copyWith(
+          filters: findFavouriteFilter.filter,
+        );
+      }
     }
 
     await loadMore(init: true);


### PR DESCRIPTION
## Pull Request Description

I’ve fixed an issue where the preferred filter was being overwritten by the default filter. This is my first time working on a Flutter application, so if there is a better way to handle this, please let me know. I’m happy to make any necessary changes.  
Thanks again for your amazing work!

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Resolves #696 

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [x] Check that any changes are related to the issue at hand.
