### PR TITLE
Add option to remove title bar in Linux and Windows

### DIFF
--- a/lib/models/settings/arguments_model.dart
+++ b/lib/models/settings/arguments_model.dart
@@ -11,6 +11,7 @@ abstract class ArgumentsModel with _$ArgumentsModel {
 
   factory ArgumentsModel({
     @Default(false) bool htpcMode,
+    @Default(false) bool noTitleBar,
     @Default(false) bool leanBackMode,
     @Default(false) bool newWindow,
   }) = _ArgumentsModel;
@@ -21,6 +22,7 @@ abstract class ArgumentsModel with _$ArgumentsModel {
     final parsedWindowArgs = windowArguments.split(',');
     return ArgumentsModel(
       htpcMode: arguments.contains('--htpc') || leanBackEnabled,
+      noTitleBar: arguments.contains('--no-titlebar'),
       leanBackMode: leanBackEnabled,
       newWindow: parsedWindowArgs.contains('--newWindow'),
     );

--- a/lib/models/settings/arguments_model.freezed.dart
+++ b/lib/models/settings/arguments_model.freezed.dart
@@ -15,12 +15,13 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$ArgumentsModel {
   bool get htpcMode;
+  bool get noTitleBar;
   bool get leanBackMode;
   bool get newWindow;
 
   @override
   String toString() {
-    return 'ArgumentsModel(htpcMode: $htpcMode, leanBackMode: $leanBackMode, newWindow: $newWindow)';
+    return 'ArgumentsModel(htpcMode: $htpcMode, noTitleBar: $noTitleBar, leanBackMode: $leanBackMode, newWindow: $newWindow)';
   }
 }
 
@@ -117,14 +118,16 @@ extension ArgumentsModelPatterns on ArgumentsModel {
 
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>(
-    TResult Function(bool htpcMode, bool leanBackMode, bool newWindow)?
+    TResult Function(
+            bool htpcMode, bool noTitleBar, bool leanBackMode, bool newWindow)?
         $default, {
     required TResult orElse(),
   }) {
     final _that = this;
     switch (_that) {
       case _ArgumentsModel() when $default != null:
-        return $default(_that.htpcMode, _that.leanBackMode, _that.newWindow);
+        return $default(_that.htpcMode, _that.noTitleBar, _that.leanBackMode,
+            _that.newWindow);
       case _:
         return orElse();
     }
@@ -145,12 +148,15 @@ extension ArgumentsModelPatterns on ArgumentsModel {
 
   @optionalTypeArgs
   TResult when<TResult extends Object?>(
-    TResult Function(bool htpcMode, bool leanBackMode, bool newWindow) $default,
+    TResult Function(
+            bool htpcMode, bool noTitleBar, bool leanBackMode, bool newWindow)
+        $default,
   ) {
     final _that = this;
     switch (_that) {
       case _ArgumentsModel():
-        return $default(_that.htpcMode, _that.leanBackMode, _that.newWindow);
+        return $default(_that.htpcMode, _that.noTitleBar, _that.leanBackMode,
+            _that.newWindow);
       case _:
         throw StateError('Unexpected subclass');
     }
@@ -170,13 +176,15 @@ extension ArgumentsModelPatterns on ArgumentsModel {
 
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(bool htpcMode, bool leanBackMode, bool newWindow)?
+    TResult? Function(
+            bool htpcMode, bool noTitleBar, bool leanBackMode, bool newWindow)?
         $default,
   ) {
     final _that = this;
     switch (_that) {
       case _ArgumentsModel() when $default != null:
-        return $default(_that.htpcMode, _that.leanBackMode, _that.newWindow);
+        return $default(_that.htpcMode, _that.noTitleBar, _that.leanBackMode,
+            _that.newWindow);
       case _:
         return null;
     }
@@ -188,6 +196,7 @@ extension ArgumentsModelPatterns on ArgumentsModel {
 class _ArgumentsModel extends ArgumentsModel {
   _ArgumentsModel(
       {this.htpcMode = false,
+      this.noTitleBar = false,
       this.leanBackMode = false,
       this.newWindow = false})
       : super._();
@@ -197,6 +206,9 @@ class _ArgumentsModel extends ArgumentsModel {
   final bool htpcMode;
   @override
   @JsonKey()
+  final bool noTitleBar;
+  @override
+  @JsonKey()
   final bool leanBackMode;
   @override
   @JsonKey()
@@ -204,7 +216,7 @@ class _ArgumentsModel extends ArgumentsModel {
 
   @override
   String toString() {
-    return 'ArgumentsModel(htpcMode: $htpcMode, leanBackMode: $leanBackMode, newWindow: $newWindow)';
+    return 'ArgumentsModel(htpcMode: $htpcMode, noTitleBar: $noTitleBar, leanBackMode: $leanBackMode, newWindow: $newWindow)';
   }
 }
 

--- a/lib/screens/shared/default_title_bar.dart
+++ b/lib/screens/shared/default_title_bar.dart
@@ -14,13 +14,20 @@ class DefaultTitleBar extends ConsumerStatefulWidget {
   final String? label;
   final double? height;
   final Brightness? brightness;
-  const DefaultTitleBar({this.height = defaultTitleBarHeight, this.label, this.brightness, super.key});
+  const DefaultTitleBar({
+    this.height = defaultTitleBarHeight,
+    this.label,
+    this.brightness,
+    super.key,
+  });
 
   @override
-  ConsumerState<ConsumerStatefulWidget> createState() => _DefaultTitleBarState();
+  ConsumerState<ConsumerStatefulWidget> createState() =>
+      _DefaultTitleBarState();
 }
 
-class _DefaultTitleBarState extends ConsumerState<DefaultTitleBar> with WindowListener {
+class _DefaultTitleBarState extends ConsumerState<DefaultTitleBar>
+    with WindowListener {
   bool hovering = false;
 
   @override
@@ -37,12 +44,21 @@ class _DefaultTitleBarState extends ConsumerState<DefaultTitleBar> with WindowLi
 
   @override
   Widget build(BuildContext context) {
-    if (ref.watch(argumentsStateProvider.select((value) => value.htpcMode))) return const SizedBox.shrink();
+    if (ref.watch(argumentsStateProvider.select((value) => value.htpcMode)))
+      return const SizedBox.shrink();
     final theme = Theme.of(context);
     final brightness = widget.brightness ?? theme.brightness;
     final iconColor = theme.colorScheme.onSurface.withValues(alpha: 0.65);
-    final isOffline = ref.watch(connectivityStatusProvider.select((value) => value == ConnectionState.offline));
+    final isOffline = ref.watch(
+      connectivityStatusProvider.select(
+        (value) => value == ConnectionState.offline,
+      ),
+    );
     final surfaceColor = theme.colorScheme.surface;
+    final noTitleBar =
+        (AdaptiveLayout.of(context).platform == TargetPlatform.linux ||
+                AdaptiveLayout.of(context).platform == TargetPlatform.windows) &&
+            ref.read(argumentsStateProvider).noTitleBar;
 
     return ExcludeFocus(
       child: MouseRegion(
@@ -51,161 +67,221 @@ class _DefaultTitleBarState extends ConsumerState<DefaultTitleBar> with WindowLi
         child: AnimatedContainer(
           duration: const Duration(milliseconds: 250),
           decoration: BoxDecoration(
-              gradient: LinearGradient(
-            colors: isOffline
-                ? [
-                    theme.colorScheme.errorContainer.withValues(alpha: 0.8),
-                    theme.colorScheme.errorContainer.withValues(alpha: 0.25),
-                  ]
-                : [
-                    surfaceColor.withValues(alpha: hovering ? 0.7 : 0),
-                    surfaceColor.withValues(alpha: 0),
-                  ],
-            begin: Alignment.topCenter,
-            end: Alignment.bottomCenter,
-          )),
+            gradient: LinearGradient(
+              colors: isOffline
+                  ? [
+                      theme.colorScheme.errorContainer.withValues(alpha: 0.8),
+                      theme.colorScheme.errorContainer.withValues(alpha: 0.25),
+                    ]
+                  : [
+                      surfaceColor.withValues(alpha: hovering ? 0.7 : 0),
+                      surfaceColor.withValues(alpha: 0),
+                    ],
+              begin: Alignment.topCenter,
+              end: Alignment.bottomCenter,
+            ),
+          ),
           height: widget.height,
           child: kIsWeb
               ? const SizedBox.shrink()
               : Stack(
                   fit: StackFit.expand,
                   children: [
-                    switch (AdaptiveLayout.of(context).platform) {
-                      TargetPlatform.android ||
-                      TargetPlatform.iOS =>
-                        SizedBox(height: MediaQuery.paddingOf(context).top),
-                      TargetPlatform.windows || TargetPlatform.linux => Container(
-                          child: Row(
-                            children: [
-                              Expanded(
-                                child: Container(
-                                  color: Colors.black.withValues(alpha: 0),
-                                  child: DragToMoveArea(
-                                    child: Row(
-                                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                                      mainAxisSize: MainAxisSize.max,
-                                      children: [
-                                        Container(
-                                          padding: const EdgeInsets.only(left: 16),
-                                          child: DefaultTextStyle(
-                                            style: TextStyle(
-                                              color: iconColor,
-                                              fontSize: 14,
-                                            ),
-                                            child: Text(widget.label ?? ""),
-                                          ),
-                                        ),
-                                      ],
-                                    ),
-                                  ),
-                                ),
+                    noTitleBar
+                        ? const SizedBox.expand()
+                        : switch (AdaptiveLayout.of(context).platform) {
+                            TargetPlatform.android ||
+                            TargetPlatform.iOS =>
+                              SizedBox(
+                                height: MediaQuery.paddingOf(context).top,
                               ),
+                            TargetPlatform.windows ||
+                            TargetPlatform.linux =>
                               Container(
-                                decoration: BoxDecoration(boxShadow: [
-                                  BoxShadow(
-                                    color: surfaceColor.withValues(alpha: isOffline ? 0 : 0.5),
-                                    blurRadius: 32,
-                                    spreadRadius: 10,
-                                    offset: const Offset(8, -6),
-                                  ),
-                                ]),
                                 child: Row(
                                   children: [
-                                    FutureBuilder<List<bool>>(future: Future.microtask(() async {
-                                      final isMinimized = await windowManager.isMinimized();
-                                      return [isMinimized];
-                                    }), builder: (context, snapshot) {
-                                      final isMinimized = snapshot.data?.firstOrNull ?? false;
-                                      return IconButton(
-                                        style: IconButton.styleFrom(
-                                            hoverColor: brightness == Brightness.light
-                                                ? Colors.black.withValues(alpha: 0.1)
-                                                : Colors.white.withValues(alpha: 0.2),
-                                            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(2))),
-                                        onPressed: () async {
-                                          fullScreenHelper.closeFullScreen(ref);
-                                          if (isMinimized) {
-                                            windowManager.restore();
-                                          } else {
-                                            windowManager.minimize();
-                                          }
-                                        },
-                                        icon: Transform.translate(
-                                          offset: const Offset(0, -2),
-                                          child: Icon(
-                                            Icons.minimize_rounded,
-                                            color: iconColor,
-                                            size: 20,
+                                    Expanded(
+                                      child: Container(
+                                        color:
+                                            Colors.black.withValues(alpha: 0),
+                                        child: DragToMoveArea(
+                                          child: Row(
+                                            crossAxisAlignment:
+                                                CrossAxisAlignment.stretch,
+                                            mainAxisSize: MainAxisSize.max,
+                                            children: [
+                                              Container(
+                                                padding: const EdgeInsets.only(
+                                                  left: 16,
+                                                ),
+                                                child: DefaultTextStyle(
+                                                  style: TextStyle(
+                                                    color: iconColor,
+                                                    fontSize: 14,
+                                                  ),
+                                                  child:
+                                                      Text(widget.label ?? ""),
+                                                ),
+                                              ),
+                                            ],
                                           ),
-                                        ),
-                                      );
-                                    }),
-                                    FutureBuilder<List<bool>>(
-                                      future: Future.microtask(() async {
-                                        final isMaximized = await windowManager.isMaximized();
-                                        return [isMaximized];
-                                      }),
-                                      builder: (BuildContext context, AsyncSnapshot<List<bool>> snapshot) {
-                                        final maximized = snapshot.data?.firstOrNull ?? false;
-                                        return IconButton(
-                                          style: IconButton.styleFrom(
-                                            hoverColor: brightness == Brightness.light
-                                                ? Colors.black.withValues(alpha: 0.1)
-                                                : Colors.white.withValues(alpha: 0.2),
-                                            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(2)),
-                                          ),
-                                          onPressed: () async {
-                                            fullScreenHelper.closeFullScreen(ref);
-                                            if (maximized) {
-                                              await windowManager.unmaximize();
-                                              return;
-                                            }
-                                            if (!maximized) {
-                                              await windowManager.maximize();
-                                            } else {
-                                              await windowManager.unmaximize();
-                                            }
-                                          },
-                                          icon: Transform.translate(
-                                            offset: const Offset(0, 0),
-                                            child: Icon(
-                                              maximized ? Icons.maximize_rounded : Icons.crop_square_rounded,
-                                              color: iconColor,
-                                              size: 19,
-                                            ),
-                                          ),
-                                        );
-                                      },
-                                    ),
-                                    IconButton(
-                                      style: IconButton.styleFrom(
-                                        hoverColor: Colors.red,
-                                        shape: RoundedRectangleBorder(
-                                          borderRadius: BorderRadius.circular(2),
                                         ),
                                       ),
-                                      onPressed: () async {
-                                        windowManager.close();
-                                      },
-                                      icon: Transform.translate(
-                                        offset: const Offset(0, -2),
-                                        child: Icon(
-                                          Icons.close_rounded,
-                                          color: iconColor,
-                                          size: 23,
-                                        ),
+                                    ),
+                                    Container(
+                                      decoration: BoxDecoration(
+                                        boxShadow: [
+                                          BoxShadow(
+                                            color: surfaceColor.withValues(
+                                              alpha: isOffline ? 0 : 0.5,
+                                            ),
+                                            blurRadius: 32,
+                                            spreadRadius: 10,
+                                            offset: const Offset(8, -6),
+                                          ),
+                                        ],
+                                      ),
+                                      child: Row(
+                                        children: [
+                                          FutureBuilder<List<bool>>(
+                                            future: Future.microtask(() async {
+                                              final isMinimized =
+                                                  await windowManager
+                                                      .isMinimized();
+                                              return [isMinimized];
+                                            }),
+                                            builder: (context, snapshot) {
+                                              final isMinimized =
+                                                  snapshot.data?.firstOrNull ??
+                                                      false;
+                                              return IconButton(
+                                                style: IconButton.styleFrom(
+                                                  hoverColor: brightness ==
+                                                          Brightness.light
+                                                      ? Colors.black.withValues(
+                                                          alpha: 0.1,
+                                                        )
+                                                      : Colors.white.withValues(
+                                                          alpha: 0.2,
+                                                        ),
+                                                  shape: RoundedRectangleBorder(
+                                                    borderRadius:
+                                                        BorderRadius.circular(
+                                                            2),
+                                                  ),
+                                                ),
+                                                onPressed: () async {
+                                                  fullScreenHelper
+                                                      .closeFullScreen(ref);
+                                                  if (isMinimized) {
+                                                    windowManager.restore();
+                                                  } else {
+                                                    windowManager.minimize();
+                                                  }
+                                                },
+                                                icon: Transform.translate(
+                                                  offset: const Offset(0, -2),
+                                                  child: Icon(
+                                                    Icons.minimize_rounded,
+                                                    color: iconColor,
+                                                    size: 20,
+                                                  ),
+                                                ),
+                                              );
+                                            },
+                                          ),
+                                          FutureBuilder<List<bool>>(
+                                            future: Future.microtask(() async {
+                                              final isMaximized =
+                                                  await windowManager
+                                                      .isMaximized();
+                                              return [isMaximized];
+                                            }),
+                                            builder: (
+                                              BuildContext context,
+                                              AsyncSnapshot<List<bool>>
+                                                  snapshot,
+                                            ) {
+                                              final maximized =
+                                                  snapshot.data?.firstOrNull ??
+                                                      false;
+                                              return IconButton(
+                                                style: IconButton.styleFrom(
+                                                  hoverColor: brightness ==
+                                                          Brightness.light
+                                                      ? Colors.black.withValues(
+                                                          alpha: 0.1,
+                                                        )
+                                                      : Colors.white.withValues(
+                                                          alpha: 0.2,
+                                                        ),
+                                                  shape: RoundedRectangleBorder(
+                                                    borderRadius:
+                                                        BorderRadius.circular(
+                                                      2,
+                                                    ),
+                                                  ),
+                                                ),
+                                                onPressed: () async {
+                                                  fullScreenHelper
+                                                      .closeFullScreen(ref);
+                                                  if (maximized) {
+                                                    await windowManager
+                                                        .unmaximize();
+                                                    return;
+                                                  }
+                                                  if (!maximized) {
+                                                    await windowManager
+                                                        .maximize();
+                                                  } else {
+                                                    await windowManager
+                                                        .unmaximize();
+                                                  }
+                                                },
+                                                icon: Transform.translate(
+                                                  offset: const Offset(0, 0),
+                                                  child: Icon(
+                                                    maximized
+                                                        ? Icons.maximize_rounded
+                                                        : Icons
+                                                            .crop_square_rounded,
+                                                    color: iconColor,
+                                                    size: 19,
+                                                  ),
+                                                ),
+                                              );
+                                            },
+                                          ),
+                                          IconButton(
+                                            style: IconButton.styleFrom(
+                                              hoverColor: Colors.red,
+                                              shape: RoundedRectangleBorder(
+                                                borderRadius:
+                                                    BorderRadius.circular(2),
+                                              ),
+                                            ),
+                                            onPressed: () async {
+                                              windowManager.close();
+                                            },
+                                            icon: Transform.translate(
+                                              offset: const Offset(0, -2),
+                                              child: Icon(
+                                                Icons.close_rounded,
+                                                color: iconColor,
+                                                size: 23,
+                                              ),
+                                            ),
+                                          ),
+                                        ],
                                       ),
                                     ),
                                   ],
                                 ),
                               ),
-                            ],
-                          ),
-                        ),
-                      TargetPlatform.macOS => const SizedBox.expand(),
-                      _ => Text(widget.label ?? "Fladder"),
-                    },
-                    const OfflineBanner()
+                            TargetPlatform.macOS => const SizedBox.expand(),
+                            _ => Text(widget.label ?? "Fladder"),
+                          },
+                    const OfflineBanner(),
                   ],
                 ),
         ),


### PR DESCRIPTION
## Pull Request Description

Added a startup flag (--no-titlebar) to disable the title bar in Linux and Windows. This flag is ignored on macOS.

## Issue Being Fixed

This addresses this discussion:
https://github.com/DonutWare/Fladder/discussions/726

## Screenshots / Recordings

Here's a screenshot of Fladder in regular windowed mode (not htpc) without a title bar.
<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/97ef3df7-dbdf-4ee5-a3b7-4b73385f8c60" />

## Checklist

I've confirmed these changes work as expected on Linux.
