### PR TITLE
feat: Use mouse side button to go back

### DIFF
--- a/lib/widgets/shared/back_intent_dpad.dart
+++ b/lib/widgets/shared/back_intent_dpad.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/gestures.dart';
 
 import 'package:auto_route/auto_route.dart';
 
@@ -15,25 +16,34 @@ class BackIntentDpad extends StatelessWidget {
     if (AdaptiveLayout.inputDeviceOf(context) == InputDevice.touch) {
       return child;
     }
-    return Focus(
-      canRequestFocus: false,
-      onKeyEvent: (FocusNode node, KeyEvent event) {
-        if (event is! KeyDownEvent) {
-          return KeyEventResult.ignored;
-        }
-
-        if (event.logicalKey == LogicalKeyboardKey.backspace) {
-          if (isEditableTextFocused()) {
-            return KeyEventResult.ignored;
-          } else {
+    return Listener(
+      onPointerDown: (event) {
+        if ((event.buttons & kBackMouseButton) != 0) {
+          if (!isEditableTextFocused()) {
             context.maybePop();
-            return KeyEventResult.handled;
+          }
+        }
+      },
+      child: Focus(
+        canRequestFocus: false,
+        onKeyEvent: (FocusNode node, KeyEvent event) {
+          if (event is! KeyDownEvent) {
+            return KeyEventResult.ignored;
+          }
+
+          if (event.logicalKey == LogicalKeyboardKey.backspace) {
+            if (isEditableTextFocused()) {
+              return KeyEventResult.ignored;
+          } else {
+              context.maybePop();
+              return KeyEventResult.handled;
           }
         }
 
-        return KeyEventResult.ignored;
-      },
-      child: child,
+          return KeyEventResult.ignored;
+        },
+        child: child,
+      ),
     );
   }
 }


### PR DESCRIPTION
## Pull Request Description

This makes it so the back mouse button (button on side of mouse that can go back to a previous window in a browser, etc.) can go back to the previous screen like the backspace key does.

## Issue Being Fixed

I didn't create a feature request for this since it's very minor.

## Checklist

Confirmed working on Linux, but should work on macOS and Windows too.
