### PR TITLE
feat: Add support for custom headers in Seerr authentication

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2116,6 +2116,12 @@
       }
     }
   },
+  "seerrCustomHeaders": "Custom headers",
+  "@seerrCustomHeaders": {},
+  "seerrHeader": "Header",
+  "@seerrHeader": {},
+  "seerrHeaderValue": "Value",
+  "@seerrHeaderValue": {},
   "emailUsername": "Email/Username",
   "@emailUsername": {},
   "discover": "Discover",

--- a/lib/models/seerr_credentials_model.dart
+++ b/lib/models/seerr_credentials_model.dart
@@ -13,6 +13,7 @@ abstract class SeerrCredentialsModel with _$SeerrCredentialsModel {
     @Default("") String serverUrl,
     @Default("") String apiKey,
     @Default("") String sessionCookie,
+    @Default({}) Map<String, String> customHeaders,
   }) = _SeerrCredentialsModel;
 
   bool get isConfigured {

--- a/lib/models/seerr_credentials_model.freezed.dart
+++ b/lib/models/seerr_credentials_model.freezed.dart
@@ -17,6 +17,7 @@ mixin _$SeerrCredentialsModel {
   String get serverUrl;
   String get apiKey;
   String get sessionCookie;
+  Map<String, String> get customHeaders;
 
   /// Create a copy of SeerrCredentialsModel
   /// with the given fields replaced by the non-null parameter values.
@@ -31,7 +32,7 @@ mixin _$SeerrCredentialsModel {
 
   @override
   String toString() {
-    return 'SeerrCredentialsModel(serverUrl: $serverUrl, apiKey: $apiKey, sessionCookie: $sessionCookie)';
+    return 'SeerrCredentialsModel(serverUrl: $serverUrl, apiKey: $apiKey, sessionCookie: $sessionCookie, customHeaders: $customHeaders)';
   }
 }
 
@@ -41,7 +42,11 @@ abstract mixin class $SeerrCredentialsModelCopyWith<$Res> {
           $Res Function(SeerrCredentialsModel) _then) =
       _$SeerrCredentialsModelCopyWithImpl;
   @useResult
-  $Res call({String serverUrl, String apiKey, String sessionCookie});
+  $Res call(
+      {String serverUrl,
+      String apiKey,
+      String sessionCookie,
+      Map<String, String> customHeaders});
 }
 
 /// @nodoc
@@ -60,6 +65,7 @@ class _$SeerrCredentialsModelCopyWithImpl<$Res>
     Object? serverUrl = null,
     Object? apiKey = null,
     Object? sessionCookie = null,
+    Object? customHeaders = null,
   }) {
     return _then(_self.copyWith(
       serverUrl: null == serverUrl
@@ -74,6 +80,10 @@ class _$SeerrCredentialsModelCopyWithImpl<$Res>
           ? _self.sessionCookie
           : sessionCookie // ignore: cast_nullable_to_non_nullable
               as String,
+      customHeaders: null == customHeaders
+          ? _self.customHeaders
+          : customHeaders // ignore: cast_nullable_to_non_nullable
+              as Map<String, String>,
     ));
   }
 }
@@ -171,14 +181,16 @@ extension SeerrCredentialsModelPatterns on SeerrCredentialsModel {
 
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>(
-    TResult Function(String serverUrl, String apiKey, String sessionCookie)?
+    TResult Function(String serverUrl, String apiKey, String sessionCookie,
+            Map<String, String> customHeaders)?
         $default, {
     required TResult orElse(),
   }) {
     final _that = this;
     switch (_that) {
       case _SeerrCredentialsModel() when $default != null:
-        return $default(_that.serverUrl, _that.apiKey, _that.sessionCookie);
+        return $default(_that.serverUrl, _that.apiKey, _that.sessionCookie,
+            _that.customHeaders);
       case _:
         return orElse();
     }
@@ -199,13 +211,15 @@ extension SeerrCredentialsModelPatterns on SeerrCredentialsModel {
 
   @optionalTypeArgs
   TResult when<TResult extends Object?>(
-    TResult Function(String serverUrl, String apiKey, String sessionCookie)
+    TResult Function(String serverUrl, String apiKey, String sessionCookie,
+            Map<String, String> customHeaders)
         $default,
   ) {
     final _that = this;
     switch (_that) {
       case _SeerrCredentialsModel():
-        return $default(_that.serverUrl, _that.apiKey, _that.sessionCookie);
+        return $default(_that.serverUrl, _that.apiKey, _that.sessionCookie,
+            _that.customHeaders);
       case _:
         throw StateError('Unexpected subclass');
     }
@@ -225,13 +239,15 @@ extension SeerrCredentialsModelPatterns on SeerrCredentialsModel {
 
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(String serverUrl, String apiKey, String sessionCookie)?
+    TResult? Function(String serverUrl, String apiKey, String sessionCookie,
+            Map<String, String> customHeaders)?
         $default,
   ) {
     final _that = this;
     switch (_that) {
       case _SeerrCredentialsModel() when $default != null:
-        return $default(_that.serverUrl, _that.apiKey, _that.sessionCookie);
+        return $default(_that.serverUrl, _that.apiKey, _that.sessionCookie,
+            _that.customHeaders);
       case _:
         return null;
     }
@@ -242,8 +258,12 @@ extension SeerrCredentialsModelPatterns on SeerrCredentialsModel {
 @JsonSerializable()
 class _SeerrCredentialsModel extends SeerrCredentialsModel {
   const _SeerrCredentialsModel(
-      {this.serverUrl = "", this.apiKey = "", this.sessionCookie = ""})
-      : super._();
+      {this.serverUrl = "",
+      this.apiKey = "",
+      this.sessionCookie = "",
+      final Map<String, String> customHeaders = const {}})
+      : _customHeaders = customHeaders,
+        super._();
   factory _SeerrCredentialsModel.fromJson(Map<String, dynamic> json) =>
       _$SeerrCredentialsModelFromJson(json);
 
@@ -256,6 +276,14 @@ class _SeerrCredentialsModel extends SeerrCredentialsModel {
   @override
   @JsonKey()
   final String sessionCookie;
+  final Map<String, String> _customHeaders;
+  @override
+  @JsonKey()
+  Map<String, String> get customHeaders {
+    if (_customHeaders is EqualUnmodifiableMapView) return _customHeaders;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableMapView(_customHeaders);
+  }
 
   /// Create a copy of SeerrCredentialsModel
   /// with the given fields replaced by the non-null parameter values.
@@ -275,7 +303,7 @@ class _SeerrCredentialsModel extends SeerrCredentialsModel {
 
   @override
   String toString() {
-    return 'SeerrCredentialsModel(serverUrl: $serverUrl, apiKey: $apiKey, sessionCookie: $sessionCookie)';
+    return 'SeerrCredentialsModel(serverUrl: $serverUrl, apiKey: $apiKey, sessionCookie: $sessionCookie, customHeaders: $customHeaders)';
   }
 }
 
@@ -287,7 +315,11 @@ abstract mixin class _$SeerrCredentialsModelCopyWith<$Res>
       __$SeerrCredentialsModelCopyWithImpl;
   @override
   @useResult
-  $Res call({String serverUrl, String apiKey, String sessionCookie});
+  $Res call(
+      {String serverUrl,
+      String apiKey,
+      String sessionCookie,
+      Map<String, String> customHeaders});
 }
 
 /// @nodoc
@@ -306,6 +338,7 @@ class __$SeerrCredentialsModelCopyWithImpl<$Res>
     Object? serverUrl = null,
     Object? apiKey = null,
     Object? sessionCookie = null,
+    Object? customHeaders = null,
   }) {
     return _then(_SeerrCredentialsModel(
       serverUrl: null == serverUrl
@@ -320,6 +353,10 @@ class __$SeerrCredentialsModelCopyWithImpl<$Res>
           ? _self.sessionCookie
           : sessionCookie // ignore: cast_nullable_to_non_nullable
               as String,
+      customHeaders: null == customHeaders
+          ? _self._customHeaders
+          : customHeaders // ignore: cast_nullable_to_non_nullable
+              as Map<String, String>,
     ));
   }
 }

--- a/lib/models/seerr_credentials_model.g.dart
+++ b/lib/models/seerr_credentials_model.g.dart
@@ -12,6 +12,10 @@ _SeerrCredentialsModel _$SeerrCredentialsModelFromJson(
       serverUrl: json['serverUrl'] as String? ?? "",
       apiKey: json['apiKey'] as String? ?? "",
       sessionCookie: json['sessionCookie'] as String? ?? "",
+      customHeaders: (json['customHeaders'] as Map<String, dynamic>?)?.map(
+            (k, e) => MapEntry(k, e as String),
+          ) ??
+          const {},
     );
 
 Map<String, dynamic> _$SeerrCredentialsModelToJson(
@@ -20,4 +24,5 @@ Map<String, dynamic> _$SeerrCredentialsModelToJson(
       'serverUrl': instance.serverUrl,
       'apiKey': instance.apiKey,
       'sessionCookie': instance.sessionCookie,
+      'customHeaders': instance.customHeaders,
     };

--- a/lib/providers/seerr_api_provider.dart
+++ b/lib/providers/seerr_api_provider.dart
@@ -53,7 +53,9 @@ class SeerrRequest implements Interceptor {
     final apiKey = creds?.apiKey.trim() ?? '';
     final cookie = creds?.sessionCookie.trim() ?? '';
 
-    final headers = _authHeaders(apiKey: apiKey, cookie: cookie);
+    final authHeaders = _authHeaders(apiKey: apiKey, cookie: cookie);
+    final customHeaders = creds?.customHeaders ?? <String, String>{};
+    final headers = {...authHeaders, ...customHeaders};
     final apiBaseUri = Uri.parse(serverUrl);
 
     Uri resolvedRequestUri;

--- a/lib/providers/seerr_service_provider.dart
+++ b/lib/providers/seerr_service_provider.dart
@@ -632,9 +632,10 @@ class SeerrService {
 
   SeerrDashboardPosterModel? posterFromDiscoverItem(SeerrDiscoverItem item) => _posterFromDiscoverItem(item);
 
-  Future<String> authenticateLocal({required String email, required String password}) async {
+  Future<String> authenticateLocal({required String email, required String password, Map<String, String>? headers}) async {
     final response = await _api.authenticateLocal(
       SeerrAuthLocalBody(email: email, password: password),
+      headers: headers,
     );
     if (!response.isSuccessful) {
       throw HttpException('Local authentication failed (${response.statusCode})');
@@ -646,16 +647,17 @@ class SeerrService {
     return cookie;
   }
 
-  Future<String> authenticateJellyfin({required String username, required String password}) async {
-    final response = await _authenticateJellyfin(username: username, password: password);
+  Future<String> authenticateJellyfin({required String username, required String password, Map<String, String>? headers}) async {
+    final response = await _authenticateJellyfin(username: username, password: password, headers: headers);
     return _requireSessionCookie(response, label: 'Jellyfin');
   }
 
   Future<void> logout() async => await _api.logout();
 
-  Future<Response<dynamic>> _authenticateJellyfin({required String username, required String password}) async {
+  Future<Response<dynamic>> _authenticateJellyfin({required String username, required String password, Map<String, String>? headers}) async {
     var response = await _api.authenticateJellyfin(
       SeerrAuthJellyfinBody(username: username, password: password),
+      headers: headers,
     );
 
     if (!response.isSuccessful && _shouldRetryWithHostname(response)) {
@@ -665,6 +667,7 @@ class SeerrService {
           password: password,
           hostname: Platform.localHostname,
         ),
+        headers: headers,
       );
     }
 

--- a/lib/providers/seerr_user_provider.dart
+++ b/lib/providers/seerr_user_provider.dart
@@ -16,17 +16,17 @@ class SeerrUser extends _$SeerrUser {
   Future<void> _fetchUser() async {
     final api = ref.read(seerrApiProvider);
     final response = await api.me();
-    if (response.isSuccessful && response.body != null) {
-      state = response.body;
+    if (response.isSuccessful && response.body is SeerrUserModel) {
+      state = response.body as SeerrUserModel;
     }
   }
 
   Future<SeerrUserModel?> refreshUser() async {
     final api = ref.read(seerrApiProvider);
     final response = await api.me();
-    if (response.isSuccessful) {
-      state = response.body;
-      return response.body;
+    if (response.isSuccessful && response.body is SeerrUserModel) {
+      state = response.body as SeerrUserModel;
+      return response.body as SeerrUserModel;
     }
     return null;
   }

--- a/lib/providers/seerr_user_provider.g.dart
+++ b/lib/providers/seerr_user_provider.g.dart
@@ -6,7 +6,7 @@ part of 'seerr_user_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$seerrUserHash() => r'5d3dcff37c7375b54dfb40c343a60904ee9dd454';
+String _$seerrUserHash() => r'99fd98d6e4f32a4d7eda0567f970714f32023896';
 
 /// See also [SeerrUser].
 @ProviderFor(SeerrUser)

--- a/lib/providers/user_provider.dart
+++ b/lib/providers/user_provider.dart
@@ -229,6 +229,24 @@ class User extends _$User {
     userState = user.copyWith(seerrCredentials: updated);
   }
 
+  void setSeerrCustomHeaders(Map<String, String> headers) {
+    final user = state;
+    if (user == null) return;
+    final updated = (user.seerrCredentials ?? const SeerrCredentialsModel()).copyWith(
+      customHeaders: headers,
+    );
+    userState = user.copyWith(seerrCredentials: updated);
+  }
+
+  void clearSeerrCustomHeaders() {
+    final user = state;
+    if (user == null) return;
+    final updated = (user.seerrCredentials ?? const SeerrCredentialsModel()).copyWith(
+      customHeaders: {},
+    );
+    userState = user.copyWith(seerrCredentials: updated);
+  }
+
   void addSearchQuery(String value) {
     if (value.isEmpty) return;
     final newList = state?.searchQueryHistory.toList() ?? [];

--- a/lib/providers/user_provider.g.dart
+++ b/lib/providers/user_provider.g.dart
@@ -24,7 +24,7 @@ final showSyncButtonProviderProvider = AutoDisposeProvider<bool>.internal(
 @Deprecated('Will be removed in 3.0. Use Ref instead')
 // ignore: unused_element
 typedef ShowSyncButtonProviderRef = AutoDisposeProviderRef<bool>;
-String _$userHash() => r'd212410e4738a7e63955714ec2e4ad68efb5b6af';
+String _$userHash() => r'730e21dfff1e4cbe24c0c47d701ce51de38c303e';
 
 /// See also [User].
 @ProviderFor(User)

--- a/lib/screens/settings/widgets/seerr_connection_dialog.dart
+++ b/lib/screens/settings/widgets/seerr_connection_dialog.dart
@@ -398,7 +398,7 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 4),
               child: Text(
-                'Custom headers',
+                context.localized.seerrCustomHeaders,
                 style: Theme.of(context).textTheme.bodySmall,
               ),
             ),
@@ -407,7 +407,7 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
                 Expanded(
                   flex: 3,
                   child: OutlinedTextField(
-                    label: 'Header',
+                    label: context.localized.seerrHeader,
                     controller: headerKeyController,
                     textInputAction: TextInputAction.next,
                   ),
@@ -416,7 +416,7 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
                 Expanded(
                   flex: 4,
                   child: OutlinedTextField(
-                    label: 'Value',
+                    label: context.localized.seerrHeaderValue,
                     controller: headerValueController,
                     textInputAction: TextInputAction.done,
                     onSubmitted: (_) => _addHeader(),

--- a/lib/screens/settings/widgets/seerr_connection_dialog.dart
+++ b/lib/screens/settings/widgets/seerr_connection_dialog.dart
@@ -49,6 +49,8 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
   late final TextEditingController localPasswordController;
   late final TextEditingController jfUsernameController;
   late final TextEditingController jfPasswordController;
+  late final TextEditingController headerKeyController;
+  late final TextEditingController headerValueController;
 
   SeerrAuthTab selectedTab = SeerrAuthTab.jellyfin;
   SeerrUserModel? seerrUser;
@@ -66,6 +68,9 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
     localPasswordController = TextEditingController();
     jfUsernameController = TextEditingController();
     jfPasswordController = TextEditingController();
+    headerKeyController = TextEditingController();
+    headerValueController = TextEditingController();
+    customHeaders.addAll(creds?.customHeaders ?? {});
     Future.microtask(_refreshSession);
   }
 
@@ -77,7 +82,30 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
     localPasswordController.dispose();
     jfUsernameController.dispose();
     jfPasswordController.dispose();
+    headerKeyController.dispose();
+    headerValueController.dispose();
     super.dispose();
+  }
+
+  final Map<String, String> customHeaders = {};
+
+  void _addHeader() {
+    final key = headerKeyController.text.trim();
+    final value = headerValueController.text.trim();
+    if (key.isEmpty) return;
+    setState(() {
+      customHeaders[key] = value;
+      headerKeyController.text = '';
+      headerValueController.text = '';
+    });
+    ref.read(userProvider.notifier).setSeerrCustomHeaders(customHeaders);
+  }
+
+  void _removeHeader(String key) {
+    setState(() {
+      customHeaders.remove(key);
+    });
+    ref.read(userProvider.notifier).setSeerrCustomHeaders(customHeaders);
   }
 
   Future<void> _refreshSession() async {
@@ -176,8 +204,9 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
 
     try {
       final cookie = await ref.read(seerrApiProvider).authenticateLocal(
-            email: localEmailController.text.trim(),
-            password: localPasswordController.text,
+        email: localEmailController.text.trim(),
+        password: localPasswordController.text,
+        headers: customHeaders.isEmpty ? null : customHeaders,
           );
       ref.read(userProvider.notifier).setSeerrSessionCookie(cookie);
       ref.read(userProvider.notifier).setSeerrApiKey('');
@@ -209,8 +238,9 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
 
     try {
       final cookie = await ref.read(seerrApiProvider).authenticateJellyfin(
-            username: jfUsernameController.text.trim(),
-            password: jfPasswordController.text,
+        username: jfUsernameController.text.trim(),
+        password: jfPasswordController.text,
+        headers: customHeaders.isEmpty ? null : customHeaders,
           );
       ref.read(userProvider.notifier).setSeerrSessionCookie(cookie);
       ref.read(userProvider.notifier).setSeerrApiKey('');
@@ -360,6 +390,57 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
             _applyServerUrl();
             _refreshSession();
           },
+        ),
+        const SizedBox(height: 8),
+        Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 4),
+              child: Text(
+                'Custom headers',
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+            ),
+            Row(
+              children: [
+                Expanded(
+                  flex: 3,
+                  child: OutlinedTextField(
+                    label: 'Header',
+                    controller: headerKeyController,
+                    textInputAction: TextInputAction.next,
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  flex: 4,
+                  child: OutlinedTextField(
+                    label: 'Value',
+                    controller: headerValueController,
+                    textInputAction: TextInputAction.done,
+                    onSubmitted: (_) => _addHeader(),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                IconButton(onPressed: _addHeader, icon: const Icon(IconsaxPlusBold.add_circle)),
+              ],
+            ),
+            const SizedBox(height: 8),
+            if (customHeaders.isNotEmpty)
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: customHeaders.entries
+                    .map(
+                      (e) => InputChip(
+                        label: Text('${e.key}: ${e.value}'),
+                        onDeleted: () => _removeHeader(e.key),
+                      ),
+                    )
+                    .toList(),
+              ),
+          ],
         ),
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 8),

--- a/lib/seerr/seerr_chopper_service.chopper.dart
+++ b/lib/seerr/seerr_chopper_service.chopper.dart
@@ -41,7 +41,10 @@ final class _$SeerrChopperService extends SeerrChopperService {
   }
 
   @override
-  Future<Response<SeerrUserModel>> authenticateLocal(SeerrAuthLocalBody body) {
+  Future<Response<SeerrUserModel>> authenticateLocal(
+    SeerrAuthLocalBody body, {
+    Map<String, String>? headers,
+  }) {
     final Uri $url = Uri.parse('/api/v1/auth/local');
     final $body = body;
     final Request $request = Request(
@@ -55,7 +58,9 @@ final class _$SeerrChopperService extends SeerrChopperService {
 
   @override
   Future<Response<SeerrUserModel>> authenticateJellyfin(
-      SeerrAuthJellyfinBody body) {
+    SeerrAuthJellyfinBody body, {
+    Map<String, String>? headers,
+  }) {
     final Uri $url = Uri.parse('/api/v1/auth/jellyfin');
     final $body = body;
     final Request $request = Request(

--- a/lib/seerr/seerr_chopper_service.dart
+++ b/lib/seerr/seerr_chopper_service.dart
@@ -17,10 +17,16 @@ abstract class SeerrChopperService extends ChopperService {
   Future<Response<SeerrUserModel>> getMe();
 
   @POST(path: '/auth/local')
-  Future<Response<SeerrUserModel>> authenticateLocal(@Body() SeerrAuthLocalBody body);
+  Future<Response<SeerrUserModel>> authenticateLocal(
+    @Body() SeerrAuthLocalBody body, {
+    Map<String, String>? headers,
+  });
 
   @POST(path: '/auth/jellyfin')
-  Future<Response<SeerrUserModel>> authenticateJellyfin(@Body() SeerrAuthJellyfinBody body);
+  Future<Response<SeerrUserModel>> authenticateJellyfin(
+    @Body() SeerrAuthJellyfinBody body, {
+    Map<String, String>? headers,
+  });
 
   @POST(path: '/auth/logout')
   Future<Response<dynamic>> logout();

--- a/lib/seerr/seerr_models.dart
+++ b/lib/seerr/seerr_models.dart
@@ -1401,12 +1401,14 @@ class SeerrAuthLocalBody {
 class SeerrAuthJellyfinBody {
   final String username;
   final String password;
+  final Map<String, String>? customHeaders;
   @JsonKey(includeIfNull: false)
   final String? hostname;
 
   SeerrAuthJellyfinBody({
     required this.username,
     required this.password,
+    this.customHeaders,
     this.hostname,
   });
 

--- a/lib/seerr/seerr_models.g.dart
+++ b/lib/seerr/seerr_models.g.dart
@@ -825,6 +825,9 @@ SeerrAuthJellyfinBody _$SeerrAuthJellyfinBodyFromJson(
     SeerrAuthJellyfinBody(
       username: json['username'] as String,
       password: json['password'] as String,
+      customHeaders: (json['customHeaders'] as Map<String, dynamic>?)?.map(
+        (k, e) => MapEntry(k, e as String),
+      ),
       hostname: json['hostname'] as String?,
     );
 
@@ -833,6 +836,7 @@ Map<String, dynamic> _$SeerrAuthJellyfinBodyToJson(
     <String, dynamic>{
       'username': instance.username,
       'password': instance.password,
+      if (instance.customHeaders case final value?) 'customHeaders': value,
       if (instance.hostname case final value?) 'hostname': value,
     };
 


### PR DESCRIPTION
## Pull Request Description

Adds support for custom headers in Seerr/Jellyseerr authentication, enabling users to configure additional HTTP headers when connecting to their Seerr instance.

Changes include:
- Added customHeaders field to SeerrCredentialsModel to store custom header configurations
- Updated the Seerr Chopper service to include custom headers in all API requests
- Added a custom headers field to the Seerr connection dialog
- Modified authentication and API provider logic to handle custom headers throughout the request lifecycle

## Checklist

- [x] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [x] Check that any changes are related to the issue at hand.
