### PR TITLE
Remove duplicate play button

### DIFF
--- a/lib/screens/video_player/video_player_controls.dart
+++ b/lib/screens/video_player/video_player_controls.dart
@@ -336,6 +336,7 @@ class _DesktopControlsState extends ConsumerState<DesktopControls> {
                     icon: Icon(
                       mediaPlayback.playing ? IconsaxPlusBold.pause : IconsaxPlusBold.play,
                     ),
+                    tooltip: mediaPlayback.playing ? "Pause video" : "Resume video",
                   ),
                   seekForwardButton(ref),
                   nextVideoButton,


### PR DESCRIPTION
## Pull Request Description

Removes the big desktop-only play button in the middle of the screen that persists regardless of mouse panning.
There's already a play/pause button at the bottom control bar, so now it has tooltips depending on the playback state (Pause video and Resume video).

## Issue Being Fixed

I haven't created an issue for it yet, but will if needed.

## Screenshots / Recordings
<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/880c904f-f234-4eea-81a3-42fc467401f0" />

## Checklist
- Tested on Linux, but this should work on macOS and Windows too