### PR TITLE
chore: Update Categories in desktop entries

### DIFF
--- a/flatpak/Fladder.desktop
+++ b/flatpak/Fladder.desktop
@@ -6,4 +6,4 @@ Exec=Fladder
 Icon=nl.jknaapen.fladder
 Terminal=false
 Type=Application
-Categories=Entertainment;
+Categories=AudioVideo;Video;Player;

--- a/snap/gui/app_icon.desktop
+++ b/snap/gui/app_icon.desktop
@@ -5,4 +5,4 @@ Exec=app_icon
 Icon=app_icon.png
 Terminal=false
 Type=Application
-Categories=Entertainment;
+Categories=AudioVideo;Video;Player;


### PR DESCRIPTION
## Pull Request Description

The current category of `Entertainment` is not a valid category, causing build failures in flathub: https://github.com/flathub-infra/vorarbeiter/actions/runs/22258034716/job/64391834236

Categories have now been updated as per documentation: https://specifications.freedesktop.org/menu/latest/category-registry.html (Player is one of the 'Additional Categories')

## Issue Being Fixed

https://github.com/flathub-infra/vorarbeiter/actions/runs/22258034716/job/64391834236

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [ ] Check that any changes are related to the issue at hand.
