### PR TITLE
Fix/disable brightness desktop

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,6 +15,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:macos_window_utils/window_manipulator.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:path_provider/path_provider.dart';
+import 'package:screen_brightness/screen_brightness.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:smtc_windows/smtc_windows.dart' if (dart.library.html) 'package:fladder/stubs/web/smtc_web.dart';
 import 'package:universal_html/html.dart' as html;
@@ -83,6 +84,12 @@ void main(List<String> args) async {
 
   if (!kIsWeb && defaultTargetPlatform == TargetPlatform.windows) {
     await SMTCWindows.initialize();
+  }
+
+  // Disable auto-reset on desktop to prevent the screen_brightness plugin from
+  // changing the system monitor brightness when the app loses focus.
+  if (_isDesktop) {
+    await ScreenBrightness().setAutoReset(false);
   }
 
   if (kIsWeb) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -86,8 +86,6 @@ void main(List<String> args) async {
     await SMTCWindows.initialize();
   }
 
-  // Disable auto-reset on desktop to prevent the screen_brightness plugin from
-  // changing the system monitor brightness when the app loses focus.
   if (_isDesktop) {
     await ScreenBrightness().setAutoReset(false);
   }

--- a/lib/providers/settings/book_viewer_settings_provider.dart
+++ b/lib/providers/settings/book_viewer_settings_provider.dart
@@ -3,6 +3,8 @@ import 'dart:convert';
 import 'package:flutter/widgets.dart';
 
 import 'package:collection/collection.dart';
+import 'package:flutter/foundation.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:screen_brightness/screen_brightness.dart';
 
@@ -120,10 +122,16 @@ class BookViewerSettingsNotifier extends StateNotifier<BookViewerSettingsModel> 
     super.state = value;
   }
 
+  static bool get _canControlBrightness =>
+      !kIsWeb &&
+      (defaultTargetPlatform == TargetPlatform.android ||
+          defaultTargetPlatform == TargetPlatform.iOS);
+
   void setScreenBrightness(double? value) async {
     state = state.copyWith(
       screenBrightness: () => value,
     );
+    if (!_canControlBrightness) return;
     if (state.screenBrightness != null) {
       ScreenBrightness().setApplicationScreenBrightness(state.screenBrightness!);
     } else {
@@ -132,6 +140,7 @@ class BookViewerSettingsNotifier extends StateNotifier<BookViewerSettingsModel> 
   }
 
   void setSavedBrightness() {
+    if (!_canControlBrightness) return;
     if (state.screenBrightness != null) {
       ScreenBrightness().setApplicationScreenBrightness(state.screenBrightness!);
     }

--- a/lib/providers/settings/book_viewer_settings_provider.dart
+++ b/lib/providers/settings/book_viewer_settings_provider.dart
@@ -1,7 +1,5 @@
 import 'dart:convert';
 
-import 'package:flutter/widgets.dart';
-
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 

--- a/lib/providers/settings/video_player_settings_provider.dart
+++ b/lib/providers/settings/video_player_settings_provider.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -32,7 +33,13 @@ class VideoPlayerSettingsProviderNotifier extends StateNotifier<VideoPlayerSetti
     }
   }
 
+  static bool get _canControlBrightness =>
+      !kIsWeb &&
+      (defaultTargetPlatform == TargetPlatform.android ||
+          defaultTargetPlatform == TargetPlatform.iOS);
+
   void setScreenBrightness(double? value) async {
+    if (!_canControlBrightness) return;
     state = state.copyWith(
       screenBrightness: value,
     );
@@ -44,6 +51,7 @@ class VideoPlayerSettingsProviderNotifier extends StateNotifier<VideoPlayerSetti
   }
 
   void setSavedBrightness() {
+    if (!_canControlBrightness) return;
     if (state.screenBrightness != null) {
       ScreenBrightness().setApplicationScreenBrightness(state.screenBrightness!);
     }

--- a/lib/screens/book_viewer/book_viewer_controls.dart
+++ b/lib/screens/book_viewer/book_viewer_controls.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -82,7 +83,10 @@ class _BookViewerControlsState extends ConsumerState<BookViewerControls> {
   @override
   void dispose() {
     WakelockPlus.disable();
-    ScreenBrightness().resetApplicationScreenBrightness();
+    if (!kIsWeb &&
+        (defaultTargetPlatform == TargetPlatform.android || defaultTargetPlatform == TargetPlatform.iOS)) {
+      ScreenBrightness().resetApplicationScreenBrightness();
+    }
     SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge, overlays: []);
     SystemChrome.setSystemUIOverlayStyle(const SystemUiOverlayStyle(
       statusBarColor: Colors.transparent,

--- a/lib/screens/video_player/components/video_player_next_wrapper.dart
+++ b/lib/screens/video_player/components/video_player_next_wrapper.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -129,7 +130,10 @@ class _VideoPlayerNextWrapperState extends ConsumerState<VideoPlayerNextWrapper>
 
   Future<void> clearOverlaySettings() async {
     if (AdaptiveLayout.inputDeviceOf(context) != InputDevice.pointer) {
-      ScreenBrightness().resetApplicationScreenBrightness();
+      if (!kIsWeb &&
+          (defaultTargetPlatform == TargetPlatform.android || defaultTargetPlatform == TargetPlatform.iOS)) {
+        ScreenBrightness().resetApplicationScreenBrightness();
+      }
     } else {
       fullScreenHelper.closeFullScreen(ref);
     }

--- a/lib/screens/video_player/tv_player_controls.dart
+++ b/lib/screens/video_player/tv_player_controls.dart
@@ -644,7 +644,10 @@ class _TvPlayerControlsState extends ConsumerState<TvPlayerControls> {
   Future<void> clearOverlaySettings() async {
     toggleOverlay(value: true);
     if (initInputDevice != InputDevice.pointer) {
-      ScreenBrightness().resetApplicationScreenBrightness();
+      if (!kIsWeb &&
+          (defaultTargetPlatform == TargetPlatform.android || defaultTargetPlatform == TargetPlatform.iOS)) {
+        ScreenBrightness().resetApplicationScreenBrightness();
+      }
     } else {
       disableFullScreen();
     }

--- a/lib/screens/video_player/video_player_controls.dart
+++ b/lib/screens/video_player/video_player_controls.dart
@@ -717,7 +717,10 @@ class _DesktopControlsState extends ConsumerState<DesktopControls> {
   Future<void> clearOverlaySettings() async {
     toggleOverlay(value: true);
     if (initInputDevice != InputDevice.pointer) {
-      ScreenBrightness().resetApplicationScreenBrightness();
+      if (!kIsWeb &&
+          (defaultTargetPlatform == TargetPlatform.android || defaultTargetPlatform == TargetPlatform.iOS)) {
+        ScreenBrightness().resetApplicationScreenBrightness();
+      }
     } else {
       disableFullScreen();
     }


### PR DESCRIPTION
## Pull Request Description
If the screen supports software-based brightness control, the desktop application automatically sets the brightness to minimum when the application loses focus.

As it seem unused, i remove the brightness control on desktop
## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

## Checklist

- [x] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [x] Check that any changes are related to the issue at hand.
