### PR TITLE
feat: support seerr base url

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,10 @@ FROM nginx:alpine
 EXPOSE 80
 
 ENV BASE_URL=""
+ENV BASE_URL_SEERR=""
 
 COPY build/web /usr/share/nginx/html
 
-RUN echo '{"baseUrl": "${BASE_URL}"}' > /usr/share/nginx/html/assets/config/config.json
+RUN echo '{"baseUrl": "${BASE_URL}", "baseUrlSeerr": "${BASE_URL_SEERR}"}' > /usr/share/nginx/html/assets/config/config.json
 
-CMD /bin/sh -c 'sed -i "s|\${BASE_URL}|${BASE_URL}|g" /usr/share/nginx/html/assets/config/config.json && nginx -g "daemon off;"'
+CMD /bin/sh -c 'sed -i "s|\${BASE_URL}|${BASE_URL}|g" /usr/share/nginx/html/assets/config/config.json && sed -i "s|\${BASE_URL_SEERR}|${BASE_URL_SEERR}|g" /usr/share/nginx/html/assets/config/config.json && nginx -g "daemon off;"'

--- a/Dockerfile-rootless
+++ b/Dockerfile-rootless
@@ -3,6 +3,7 @@ FROM ghcr.io/nginxinc/nginx-unprivileged:stable-alpine-slim
 EXPOSE 8080
 
 ENV BASE_URL=""
+ENV BASE_URL_SEERR=""
 
 USER root
 COPY build/web /usr/share/nginx/html
@@ -10,7 +11,7 @@ RUN chown -R nginx:nginx /usr/share/nginx/html
 
 USER nginx
 RUN mkdir -p /usr/share/nginx/html/assets/config && \
-    echo '{"baseUrl": "${BASE_URL}"}' > /usr/share/nginx/html/assets/config/config.json
+    echo '{"baseUrl": "${BASE_URL}", "baseUrlSeerr": "${BASE_URL_SEERR}"}' > /usr/share/nginx/html/assets/config/config.json
 
 USER root
-CMD /bin/sh -c 'sed -i "s|\${BASE_URL}|${BASE_URL}|g" /usr/share/nginx/html/assets/config/config.json && nginx -g "daemon off;"'
+CMD /bin/sh -c 'sed -i "s|\${BASE_URL}|${BASE_URL}|g" /usr/share/nginx/html/assets/config/config.json && sed -i "s|\${BASE_URL_SEERR}|${BASE_URL_SEERR}|g" /usr/share/nginx/html/assets/config/config.json && nginx -g "daemon off;"'

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -141,6 +141,9 @@ Run `docker-compose up -d` to start the container. It will be available on `http
 > [!TIP]
 > We recommend changing the `BASE_URL` environment variable to the URL you use to access Jellyfin, as this will skip entering it when you load the web UI.
 
+> [!TIP]
+> You can set the `BASE_URL_SEERR` environment variable to pre-fill the Jellyseerr server URL on the login page.
+
 ## Web
 
 You can also manually copy the web .zip build to any static file server such as Nginx, Caddy, or Apache

--- a/config/config.json
+++ b/config/config.json
@@ -1,3 +1,4 @@
 {
-	"baseUrl": null
+	"baseUrl": null,
+	"baseUrlSeerr": null
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,3 +5,4 @@ services:
       - 80:80
     environment:
       - BASE_URL=https://server-url #OPTIONAL: Locks the Fladder front-end to a certain jellyfin server
+      - BASE_URL_SEERR= #OPTIONAL: Pre-fills the Jellyseerr server URL on the login page

--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -50,6 +50,9 @@ class AuthNotifier extends StateNotifier<LoginScreenModel> {
         await setServer(url);
       }
     }
+    if (FladderConfig.baseUrlSeerr != null) {
+      setTempSeerrUrl(FladderConfig.baseUrlSeerr);
+    }
     state = state.copyWith(
       accounts: currentAccounts,
       screen: currentAccounts.isEmpty ? LoginScreenType.login : LoginScreenType.users,

--- a/lib/util/fladder_config.dart
+++ b/lib/util/fladder_config.dart
@@ -6,12 +6,18 @@ class FladderConfig {
   static set baseUrl(String? value) => _instance._baseUrl = value;
   String? _baseUrl;
 
+  static String? get baseUrlSeerr => _instance._baseUrlSeerr;
+  static set baseUrlSeerr(String? value) => _instance._baseUrlSeerr = value;
+  String? _baseUrlSeerr;
+
   static void fromJson(Map<String, dynamic> json) => _instance = FladderConfig._fromJson(json);
 
   factory FladderConfig._fromJson(Map<String, dynamic> json) {
     final config = FladderConfig._();
     final newUrl = json['baseUrl'] as String?;
     config._baseUrl = newUrl?.isEmpty == true ? null : newUrl;
+    final newSeerrBaseUrl = json['baseUrlSeerr'] as String?;
+    config._baseUrlSeerr = newSeerrBaseUrl?.isEmpty == true ? null : newSeerrBaseUrl;
     return config;
   }
 }


### PR DESCRIPTION
## Pull Request Description

Add support for env variable to define jellyseerr base url.
Using the env variable `BASE_URL_SEERR` we can pre-fill the jellyseerr server address.
<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Resolves #issue-number

## Screenshots / Recordings

```bash
docker run  --rm --name fladder-test -e BASE_URL=http://localhost:1234 -e BASE_URL_SEERR=http://localhost:5678 -p 8080:8080 localhost/fladder-rootless:test
```

<img width="1341" height="566" alt="image" src="https://github.com/user-attachments/assets/70120097-d936-44a6-ba3f-30ddf038a72b" />


<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [x] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [x] Check that any changes are related to the issue at hand.
