### PR TITLE
fix: Use episode rating for details screen

### DIFF
--- a/lib/screens/details_screens/episode_detail_screen.dart
+++ b/lib/screens/details_screens/episode_detail_screen.dart
@@ -157,8 +157,8 @@ class _ItemDetailScreenState extends ConsumerState<EpisodeDetailScreen> {
                     runTime: details.episode?.overview.runTime,
                     studios: details.series?.overview.studios ?? [],
                     genres: details.series?.overview.genreItems ?? [],
-                    officialRating: details.series?.overview.parentalRating,
-                    communityRating: details.series?.overview.communityRating,
+                    officialRating: details.episode?.overview.parentalRating,
+                    communityRating: details.episode?.overview.communityRating,
                     mediaStreamHelper: details.episode?.mediaStreams != null
                         ? MediaStreamHelper(
                             mediaStream: details.episode!.mediaStreams,

--- a/lib/screens/details_screens/series_detail_screen.dart
+++ b/lib/screens/details_screens/series_detail_screen.dart
@@ -223,7 +223,10 @@ class _SeriesDetailScreenState extends ConsumerState<SeriesDetailScreen> {
                         specialFeatures: details.specialFeatures ?? []),
                   if (details.related.isNotEmpty)
                     PosterRow(
-                        posters: details.related, contentPadding: padding, label: detailsContext.localized.related),
+                      posters: details.related,
+                      contentPadding: padding,
+                      label: detailsContext.localized.related,
+                    ),
                   if (details.seerrRecommended.isNotEmpty)
                     SeerrPosterRow(
                       posters: details.seerrRecommended,

--- a/lib/screens/shared/media/episode_posters.dart
+++ b/lib/screens/shared/media/episode_posters.dart
@@ -17,6 +17,7 @@ import 'package:fladder/util/item_base_model/item_base_model_extensions.dart';
 import 'package:fladder/util/list_padding.dart';
 import 'package:fladder/util/localization_helper.dart';
 import 'package:fladder/util/refresh_state.dart';
+import 'package:fladder/widgets/shared/ensure_visible.dart';
 import 'package:fladder/widgets/shared/enum_selection.dart';
 import 'package:fladder/widgets/shared/focus_row.dart';
 import 'package:fladder/widgets/shared/horizontal_list.dart';
@@ -103,6 +104,11 @@ class _EpisodePosterState extends ConsumerState<EpisodePosters> {
           titleActionsPosition: widget.titleActionsPosition,
           onFocused: (index) {
             widget.onFocused?.call(episodes[index]);
+          },
+          onFocusChange: (value) {
+            if (value) {
+              context.ensureVisible();
+            }
           },
           titleActions: [
             if (!isDPad && hasSeasons) ...{


### PR DESCRIPTION
## Pull Request Description

Use episode ratings instead of parent (series) ratings

## Issue Being Fixed

Resolve #793
