### PR TITLE
fix: Seerr login browser cookie handling on container deployment

### DIFF
--- a/lib/providers/seerr_api_provider.dart
+++ b/lib/providers/seerr_api_provider.dart
@@ -11,6 +11,8 @@ import 'package:fladder/providers/user_provider.dart';
 import 'package:fladder/seerr/seerr_chopper_service.dart';
 import 'package:fladder/seerr/seerr_json_converter.dart';
 import 'package:fladder/util/fladder_config.dart';
+import 'package:fladder/util/seerr_http_client.dart'
+    if (dart.library.html) 'package:fladder/util/seerr_http_client_web.dart';
 
 part 'seerr_api_provider.g.dart';
 
@@ -21,6 +23,7 @@ class SeerrApi extends _$SeerrApi {
     ref.watch(userProvider.select((u) => u?.seerrCredentials));
 
     final chopperClient = ChopperClient(
+      client: createSeerrHttpClient(),
       converter: const SeerrJsonConverter(),
       interceptors: [
         SeerrRequest(ref),
@@ -89,7 +92,8 @@ class SeerrRequest implements Interceptor {
 
 Map<String, String> _authHeaders({required String apiKey, required String cookie}) {
   if (apiKey.isNotEmpty) return {'X-Api-Key': apiKey};
-  if (cookie.isNotEmpty) return {'Cookie': cookie};
+  if (cookie.isNotEmpty && cookie != kBrowserManagedCookie) return {'Cookie': cookie};
+  if (cookie == kBrowserManagedCookie) return const {};
   return const {};
 }
 

--- a/lib/providers/seerr_service_provider.dart
+++ b/lib/providers/seerr_service_provider.dart
@@ -634,7 +634,8 @@ class SeerrService {
 
   SeerrDashboardPosterModel? posterFromDiscoverItem(SeerrDiscoverItem item) => _posterFromDiscoverItem(item);
 
-  Future<String> authenticateLocal({required String email, required String password, Map<String, String>? headers}) async {
+  Future<String> authenticateLocal(
+      {required String email, required String password, Map<String, String>? headers}) async {
     final response = await _api.authenticateLocal(
       SeerrAuthLocalBody(email: email, password: password),
       headers: headers,
@@ -649,14 +650,16 @@ class SeerrService {
     return cookie;
   }
 
-  Future<String> authenticateJellyfin({required String username, required String password, Map<String, String>? headers}) async {
+  Future<String> authenticateJellyfin(
+      {required String username, required String password, Map<String, String>? headers}) async {
     final response = await _authenticateJellyfin(username: username, password: password, headers: headers);
     return _requireSessionCookie(response, label: 'Jellyfin');
   }
 
   Future<void> logout() async => await _api.logout();
 
-  Future<Response<dynamic>> _authenticateJellyfin({required String username, required String password, Map<String, String>? headers}) async {
+  Future<Response<dynamic>> _authenticateJellyfin(
+      {required String username, required String password, Map<String, String>? headers}) async {
     var response = await _api.authenticateJellyfin(
       SeerrAuthJellyfinBody(username: username, password: password),
       headers: headers,

--- a/lib/providers/seerr_service_provider.dart
+++ b/lib/providers/seerr_service_provider.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:chopper/chopper.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:fladder/models/items/images_models.dart';
@@ -11,6 +12,7 @@ import 'package:fladder/seerr/seerr_chopper_service.dart';
 import 'package:fladder/seerr/seerr_models.dart';
 
 const tmbdUrl = 'https://image.tmdb.org/t/p/original';
+const kBrowserManagedCookie = '__browser_managed__';
 
 class SeerrService {
   SeerrService(this.ref, this._api);
@@ -697,7 +699,9 @@ class SeerrService {
 
   String? _extractSessionCookie(Response<dynamic> response) {
     final setCookie = response.base.headers['set-cookie'];
-    if (setCookie == null || setCookie.isEmpty) return null;
+    if (setCookie == null || setCookie.isEmpty) {
+      return kIsWeb ? kBrowserManagedCookie : null;
+    }
     return setCookie.split(';').first.trim();
   }
 }

--- a/lib/util/seerr_http_client.dart
+++ b/lib/util/seerr_http_client.dart
@@ -1,0 +1,3 @@
+import 'package:http/http.dart' as http;
+
+http.Client createSeerrHttpClient() => http.Client();

--- a/lib/util/seerr_http_client_web.dart
+++ b/lib/util/seerr_http_client_web.dart
@@ -1,0 +1,6 @@
+import 'package:http/browser_client.dart';
+import 'package:http/http.dart' as http;
+
+http.Client createSeerrHttpClient() {
+  return BrowserClient()..withCredentials = true;
+}


### PR DESCRIPTION
## Pull Request Description
- Seerr connection fails on container deploymenth with _No session cookie returned by server._
- Browsers process the `set-cookie` response header internally but never expose it to JavaScript. Fladder can't capture the session cookie and treats login as failed. Much better described by @Wunderharke: https://github.com/DonutWare/Fladder/issues/710#issuecomment-4012345931

- This fix uses a conditional-import `BrowserClient` with `withCredentials: true` so the browser manages session cookies on its own. Since Fladder can't see whether a cookie was set, a `__browser_managed__` sentinel is stored on web instead,
  and `_authHeaders` skips the manual Cookie header since the browser should already attach it.
- This feature was part of PR #812

_NOTE: Cross-origin setups still require CORS headers on the Seerr side_

## Testing Build
```
ghcr.io/v3djg6gl/fladder:test-seerr-web-login-fix
```

## Issue Being Fixed

- https://github.com/DonutWare/Fladder/issues/710#issuecomment-4012345931


## Screenshots / Recordings

N/A

## Notes
### AI Disclosure
*Developed with assistance from Claude Code (Opus 4.6). The AI helped me identify the related files, code parts and proposed possible code modifications and fixes.*
*I've manually reviewed, cleaned, refactored and hardened the code the best I could, but since my Dart capabilities are not that good, I see this PR more as a proposal/idea.*
***A Proper code review is required in any case...***

## Checklist

- [ ] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [ ] Check that any changes are related to the issue at hand.
