### PR TITLE
feat: copy QuickConnect code to clipboard on tap

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
       - "v*"
     branches:
       - master
+      - test/qc-copy-to-clipboard
   pull_request:
     paths:
       - pubspec.yaml
@@ -34,6 +35,8 @@ concurrency:
 
 env:
   NIGHTLY_TAG: nightly
+  # Pin mdk-sdk to a stable release to avoid broken nightly builds from SourceForge
+  FVP_DEPS_URL: https://github.com/wang-bin/mdk-sdk/releases/download/v0.35.1
 
 jobs:
   # Check if workflow should run based on trigger conditions
@@ -173,11 +176,20 @@ jobs:
         run: |
           flutter build apk --debug --build-number=${{github.run_number}} --flavor production
 
-      - name: Build Android APK and AAB
-        if: needs.fetch-info.outputs.build_type != 'development'
+      - name: Build Android APK and AAB (signed release)
+        if: needs.fetch-info.outputs.build_type != 'development' && env.ENCODED_STRING != ''
+        env:
+          ENCODED_STRING: ${{ secrets.KEYSTORE_BASE_64 }}
         run: |
           flutter build apk --release --build-number=${{github.run_number}} --flavor production
           flutter build appbundle --release --build-number=${{github.run_number}} --flavor production
+
+      - name: Build Android APK (fallback debug)
+        if: needs.fetch-info.outputs.build_type != 'development' && env.ENCODED_STRING == ''
+        env:
+          ENCODED_STRING: ${{ secrets.KEYSTORE_BASE_64 }}
+        run: |
+          flutter build apk --debug --build-number=${{github.run_number}} --flavor production
 
       - name: Rename APK for PR
         if: needs.fetch-info.outputs.build_type == 'development'
@@ -185,12 +197,22 @@ jobs:
           mkdir -p build/app/outputs/android_artifacts
           mv build/app/outputs/flutter-apk/app-production-debug.apk "build/app/outputs/android_artifacts/${{ env.ARTIFACT_SUFFIX }}.apk"
 
-      - name: Rename APK and AAB
-        if: needs.fetch-info.outputs.build_type != 'development'
+      - name: Rename APK and AAB (signed release)
+        if: needs.fetch-info.outputs.build_type != 'development' && env.ENCODED_STRING != ''
+        env:
+          ENCODED_STRING: ${{ secrets.KEYSTORE_BASE_64 }}
         run: |
           mkdir -p build/app/outputs/android_artifacts
           mv build/app/outputs/flutter-apk/app-production-release.apk "build/app/outputs/android_artifacts/${{ env.ARTIFACT_SUFFIX }}.apk"
           mv build/app/outputs/bundle/productionRelease/app-production-release.aab "build/app/outputs/android_artifacts/${{ env.ARTIFACT_SUFFIX }}.aab"
+
+      - name: Rename APK (fallback debug)
+        if: needs.fetch-info.outputs.build_type != 'development' && env.ENCODED_STRING == ''
+        env:
+          ENCODED_STRING: ${{ secrets.KEYSTORE_BASE_64 }}
+        run: |
+          mkdir -p build/app/outputs/android_artifacts
+          mv build/app/outputs/flutter-apk/app-production-debug.apk "build/app/outputs/android_artifacts/${{ env.ARTIFACT_SUFFIX }}.apk"
 
       - name: Archive Android artifacts
         uses: actions/upload-artifact@v4.0.0
@@ -697,9 +719,10 @@ jobs:
     name: Release Web
     needs:
       - fetch-info
+      - build-web
       - create_release
     runs-on: ubuntu-latest
-    if: needs.fetch-info.outputs.build_type == 'release'
+    if: always() && !failure() && !cancelled() && (needs.fetch-info.outputs.build_type == 'release' || needs.fetch-info.outputs.build_type == 'development')
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4.1.1
@@ -714,7 +737,8 @@ jobs:
         uses: mr-smithers-excellent/docker-build-push@v6
         with:
           image: fladder
-          addLatest: true
+          tags: test-qc-copy-to-clipboard
+          addLatest: false
           multiPlatform: true
           platform: linux/amd64,linux/arm64,linux/arm/v7
           registry: ghcr.io
@@ -726,7 +750,8 @@ jobs:
         with:
           dockerfile: Dockerfile-rootless
           image: fladder-rootless
-          addLatest: true
+          tags: test-qc-copy-to-clipboard
+          addLatest: false
           multiPlatform: true
           platform: linux/amd64,linux/arm64,linux/arm/v7
           registry: ghcr.io
@@ -734,15 +759,18 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Clean builds folder
+        if: needs.fetch-info.outputs.build_type == 'release'
         run: rm -rf build/web
 
       - name: Download Artifacts Web
+        if: needs.fetch-info.outputs.build_type == 'release'
         uses: actions/download-artifact@v4
         with:
           name: fladder-web-pages
           path: build/web
 
       - name: Deploy to GitHub Pages
+        if: needs.fetch-info.outputs.build_type == 'release'
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,6 @@ on:
       - "v*"
     branches:
       - master
-      - test/qc-copy-to-clipboard
   pull_request:
     paths:
       - pubspec.yaml
@@ -35,8 +34,6 @@ concurrency:
 
 env:
   NIGHTLY_TAG: nightly
-  # Pin mdk-sdk to a stable release to avoid broken nightly builds from SourceForge
-  FVP_DEPS_URL: https://github.com/wang-bin/mdk-sdk/releases/download/v0.35.1
 
 jobs:
   # Check if workflow should run based on trigger conditions
@@ -176,20 +173,11 @@ jobs:
         run: |
           flutter build apk --debug --build-number=${{github.run_number}} --flavor production
 
-      - name: Build Android APK and AAB (signed release)
-        if: needs.fetch-info.outputs.build_type != 'development' && env.ENCODED_STRING != ''
-        env:
-          ENCODED_STRING: ${{ secrets.KEYSTORE_BASE_64 }}
+      - name: Build Android APK and AAB
+        if: needs.fetch-info.outputs.build_type != 'development'
         run: |
           flutter build apk --release --build-number=${{github.run_number}} --flavor production
           flutter build appbundle --release --build-number=${{github.run_number}} --flavor production
-
-      - name: Build Android APK (fallback debug)
-        if: needs.fetch-info.outputs.build_type != 'development' && env.ENCODED_STRING == ''
-        env:
-          ENCODED_STRING: ${{ secrets.KEYSTORE_BASE_64 }}
-        run: |
-          flutter build apk --debug --build-number=${{github.run_number}} --flavor production
 
       - name: Rename APK for PR
         if: needs.fetch-info.outputs.build_type == 'development'
@@ -197,22 +185,12 @@ jobs:
           mkdir -p build/app/outputs/android_artifacts
           mv build/app/outputs/flutter-apk/app-production-debug.apk "build/app/outputs/android_artifacts/${{ env.ARTIFACT_SUFFIX }}.apk"
 
-      - name: Rename APK and AAB (signed release)
-        if: needs.fetch-info.outputs.build_type != 'development' && env.ENCODED_STRING != ''
-        env:
-          ENCODED_STRING: ${{ secrets.KEYSTORE_BASE_64 }}
+      - name: Rename APK and AAB
+        if: needs.fetch-info.outputs.build_type != 'development'
         run: |
           mkdir -p build/app/outputs/android_artifacts
           mv build/app/outputs/flutter-apk/app-production-release.apk "build/app/outputs/android_artifacts/${{ env.ARTIFACT_SUFFIX }}.apk"
           mv build/app/outputs/bundle/productionRelease/app-production-release.aab "build/app/outputs/android_artifacts/${{ env.ARTIFACT_SUFFIX }}.aab"
-
-      - name: Rename APK (fallback debug)
-        if: needs.fetch-info.outputs.build_type != 'development' && env.ENCODED_STRING == ''
-        env:
-          ENCODED_STRING: ${{ secrets.KEYSTORE_BASE_64 }}
-        run: |
-          mkdir -p build/app/outputs/android_artifacts
-          mv build/app/outputs/flutter-apk/app-production-debug.apk "build/app/outputs/android_artifacts/${{ env.ARTIFACT_SUFFIX }}.apk"
 
       - name: Archive Android artifacts
         uses: actions/upload-artifact@v4.0.0
@@ -719,10 +697,9 @@ jobs:
     name: Release Web
     needs:
       - fetch-info
-      - build-web
       - create_release
     runs-on: ubuntu-latest
-    if: always() && !failure() && !cancelled() && (needs.fetch-info.outputs.build_type == 'release' || needs.fetch-info.outputs.build_type == 'development')
+    if: needs.fetch-info.outputs.build_type == 'release'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4.1.1
@@ -737,8 +714,7 @@ jobs:
         uses: mr-smithers-excellent/docker-build-push@v6
         with:
           image: fladder
-          tags: test-qc-copy-to-clipboard
-          addLatest: false
+          addLatest: true
           multiPlatform: true
           platform: linux/amd64,linux/arm64,linux/arm/v7
           registry: ghcr.io
@@ -750,8 +726,7 @@ jobs:
         with:
           dockerfile: Dockerfile-rootless
           image: fladder-rootless
-          tags: test-qc-copy-to-clipboard
-          addLatest: false
+          addLatest: true
           multiPlatform: true
           platform: linux/amd64,linux/arm64,linux/arm/v7
           registry: ghcr.io
@@ -759,18 +734,15 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Clean builds folder
-        if: needs.fetch-info.outputs.build_type == 'release'
         run: rm -rf build/web
 
       - name: Download Artifacts Web
-        if: needs.fetch-info.outputs.build_type == 'release'
         uses: actions/download-artifact@v4
         with:
           name: fladder-web-pages
           path: build/web
 
       - name: Deploy to GitHub Pages
-        if: needs.fetch-info.outputs.build_type == 'release'
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/lib/screens/login/login_code_dialog.dart
+++ b/lib/screens/login/login_code_dialog.dart
@@ -111,12 +111,14 @@ class _LoginCodeDialogState extends ConsumerState<LoginCodeDialog> {
                           padding: const EdgeInsets.all(12.0),
                           child: Text(
                             code,
-                            style:
-                                Theme.of(context).textTheme.titleLarge?.copyWith(
-                                      fontWeight: FontWeight.bold,
-                                      wordSpacing: 8,
-                                      letterSpacing: 8,
-                                    ),
+                            style: Theme.of(context)
+                                .textTheme
+                                .titleLarge
+                                ?.copyWith(
+                                  fontWeight: FontWeight.bold,
+                                  wordSpacing: 8,
+                                  letterSpacing: 8,
+                                ),
                             textAlign: TextAlign.center,
                             semanticsLabel: code,
                           ),

--- a/lib/screens/login/login_code_dialog.dart
+++ b/lib/screens/login/login_code_dialog.dart
@@ -4,6 +4,7 @@ import 'package:async/async.dart';
 import 'package:fladder/jellyfin/jellyfin_open_api.swagger.dart';
 import 'package:fladder/providers/api_provider.dart';
 import 'package:fladder/providers/auth_provider.dart';
+import 'package:fladder/util/clipboard_helper.dart';
 import 'package:fladder/util/list_padding.dart';
 import 'package:fladder/util/localization_helper.dart';
 import 'package:flutter/material.dart';
@@ -102,20 +103,23 @@ class _LoginCodeDialogState extends ConsumerState<LoginCodeDialog> {
                     style: Theme.of(context).textTheme.bodyLarge,
                     textAlign: TextAlign.center,
                   ),
-                  IntrinsicWidth(
-                    child: Card(
-                      child: Padding(
-                        padding: const EdgeInsets.all(12.0),
-                        child: Text(
-                          code,
-                          style:
-                              Theme.of(context).textTheme.titleLarge?.copyWith(
-                                    fontWeight: FontWeight.bold,
-                                    wordSpacing: 8,
-                                    letterSpacing: 8,
-                                  ),
-                          textAlign: TextAlign.center,
-                          semanticsLabel: code,
+                  GestureDetector(
+                    onTap: () => context.copyToClipboard(code),
+                    child: IntrinsicWidth(
+                      child: Card(
+                        child: Padding(
+                          padding: const EdgeInsets.all(12.0),
+                          child: Text(
+                            code,
+                            style:
+                                Theme.of(context).textTheme.titleLarge?.copyWith(
+                                      fontWeight: FontWeight.bold,
+                                      wordSpacing: 8,
+                                      letterSpacing: 8,
+                                    ),
+                            textAlign: TextAlign.center,
+                            semanticsLabel: code,
+                          ),
                         ),
                       ),
                     ),

--- a/lib/screens/login/login_code_dialog.dart
+++ b/lib/screens/login/login_code_dialog.dart
@@ -61,9 +61,7 @@ class _LoginCodeDialogState extends ConsumerState<LoginCodeDialog> {
             secret: quickConnectInfo.secret,
           );
       final newSecret = result.body?.secret;
-      if (result.isSuccessful &&
-          result.body?.authenticated == true &&
-          newSecret != null) {
+      if (result.isSuccessful && result.body?.authenticated == true && newSecret != null) {
         widget.onAuthenticated.call(context, newSecret);
       } else {
         timer?.reset();
@@ -74,8 +72,7 @@ class _LoginCodeDialogState extends ConsumerState<LoginCodeDialog> {
   @override
   Widget build(BuildContext context) {
     final code = quickConnectInfo.code;
-    final serverName = ref.watch(authProvider
-        .select((value) => value.serverLoginModel?.tempCredentials.serverName));
+    final serverName = ref.watch(authProvider.select((value) => value.serverLoginModel?.tempCredentials.serverName));
     return Dialog(
       constraints: const BoxConstraints(
         maxWidth: 500,
@@ -111,10 +108,7 @@ class _LoginCodeDialogState extends ConsumerState<LoginCodeDialog> {
                           padding: const EdgeInsets.all(12.0),
                           child: Text(
                             code,
-                            style: Theme.of(context)
-                                .textTheme
-                                .titleLarge
-                                ?.copyWith(
+                            style: Theme.of(context).textTheme.titleLarge?.copyWith(
                                   fontWeight: FontWeight.bold,
                                   wordSpacing: 8,
                                   letterSpacing: 8,
@@ -129,8 +123,7 @@ class _LoginCodeDialogState extends ConsumerState<LoginCodeDialog> {
                 ],
                 FilledButton(
                   onPressed: () async {
-                    final response =
-                        await ref.read(jellyApiProvider).quickConnectInitiate();
+                    final response = await ref.read(jellyApiProvider).quickConnectInitiate();
                     if (response.isSuccessful && response.body != null) {
                       setState(() {
                         quickConnectInfo = response.body!;


### PR DESCRIPTION
## Pull Request Description

Tapping the QuickConnect code copies it to the clipboard. This makes logging in much more convenient, especially when logging into Fladder on a device where a Jellyfin client is already set up :)
- This feature was part of PR #812

## Testing Build
```
ghcr.io/v3djg6gl/fladder:test-qc-copy-to-clipboard
```

## Issue Being Fixed

- Addresses #653

## Screenshots / Recordings

N/A

## Notes
### AI Disclosure
*Developed with assistance from Claude Code (Opus 4.6). The AI helped me identify the related files, code parts and proposed possible code modifications and fixes.*
*I've manually reviewed, cleaned, refactored and hardened the code the best I could, but since my Dart capabilities are not that good, I see this PR more as a proposal/idea.*
***A Proper code review is required in any case...***

## Checklist

- [ ] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [ ] Check that any changes are related to the issue at hand.
