### PR TITLE
feat: auto-add URL scheme for Jellyfin and Seerr URLs

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2154,6 +2154,8 @@
   "@seerrUserFetchFailed": {},
   "seerrEnterServerUrlFirst": "Enter a Seerr server URL first",
   "@seerrEnterServerUrlFirst": {},
+  "seerrUrlSchemeWarning": "Could not auto-detect URL scheme. Defaulting to https://. Prefix with http:// if your server doesn't use HTTPS.",
+  "@seerrUrlSchemeWarning": {},
   "seerrApiKeySaved": "API key saved",
   "@seerrApiKeySaved": {},
   "seerrLoggedIn": "Logged in to Seerr",

--- a/lib/models/seerr/seerr_item_models.dart
+++ b/lib/models/seerr/seerr_item_models.dart
@@ -1,4 +1,5 @@
 import 'package:fladder/models/items/images_models.dart';
+import 'package:fladder/providers/api_provider.dart';
 
 const _tmdbPosterBaseUrl = 'https://image.tmdb.org/t/p/w500';
 const _tmdbBackdropBaseUrl = 'https://image.tmdb.org/t/p/w780';
@@ -7,7 +8,7 @@ String? tmdbUrl(String base, String? path) {
   if (path == null) return null;
   final trimmed = path.trim();
   if (trimmed.isEmpty) return null;
-  if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) return trimmed;
+  if (hasHttpScheme(trimmed)) return trimmed;
   return '$base$trimmed';
 }
 
@@ -18,28 +19,28 @@ String? resolveImageUrl({
 }) {
   if (path == null || path.trim().isEmpty) return path;
   final trimmed = path.trim();
-  
-  if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
+
+  if (hasHttpScheme(trimmed)) {
     return trimmed;
   }
-  
+
   final tmdb = tmdbUrl(tmdbBase, trimmed);
   if (tmdb != null) return tmdb;
-  
+
   return resolveServerUrl(path: trimmed, serverUrl: serverUrl);
 }
 
 String? resolveServerUrl({required String? path, required String? serverUrl}) {
   if (path == null || path.trim().isEmpty) return path;
   final trimmed = path.trim();
-  
-  if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
+
+  if (hasHttpScheme(trimmed)) {
     return trimmed;
   }
-  
+
   if (serverUrl == null || serverUrl.trim().isEmpty) return trimmed;
   final cleanServerUrl = serverUrl.trim();
-  
+
   final needsSlash = !cleanServerUrl.endsWith('/') && !trimmed.startsWith('/');
   return '$cleanServerUrl${needsSlash ? '/' : ''}$trimmed';
 }

--- a/lib/providers/api_provider.dart
+++ b/lib/providers/api_provider.dart
@@ -130,6 +130,23 @@ String normalizeUrl(String url) {
   }
 }
 
+/// Probes a Seerr server URL by hitting /api/v1/status.
+/// Returns the working URL (with scheme) or null.
+Future<String?> probeSeerrUrl(String baseUrl) async {
+  final client = HttpClient()..connectionTimeout = const Duration(seconds: 5);
+  try {
+    final request = await client.getUrl(Uri.parse('$baseUrl/api/v1/status'));
+    final response = await request.close();
+    if (response.statusCode >= 200 && response.statusCode < 400) {
+      return baseUrl;
+    }
+  } catch (_) {
+  } finally {
+    client.close();
+  }
+  return null;
+}
+
 Uri? tryParseServerBaseUri(String? url) {
   if (url == null) return null;
   final trimmed = url.trim();

--- a/lib/providers/api_provider.dart
+++ b/lib/providers/api_provider.dart
@@ -111,6 +111,7 @@ class JellyRequest implements Interceptor {
 }
 
 /// Whether [url] already carries an http or https scheme.
+/// Uses toLowerCase() because users may type mixed-case schemes (e.g. Https://, HTTP://).
 bool hasHttpScheme(String url) {
   final lower = url.toLowerCase();
   return lower.startsWith('http://') || lower.startsWith('https://');
@@ -140,6 +141,8 @@ String normalizeUrl(String url) {
 Future<String?> _probeUrl(String baseUrl, String endpoint) async {
   try {
     final response = await http.get(Uri.parse('$baseUrl$endpoint')).timeout(const Duration(seconds: 5));
+    // Any HTTP response (including 4xx/5xx) means the server is reachable at this URL.
+    // This only acts as scheme detection, not as health check.
     if (response.statusCode > 0) {
       return baseUrl;
     }

--- a/lib/providers/api_provider.dart
+++ b/lib/providers/api_provider.dart
@@ -140,7 +140,7 @@ String normalizeUrl(String url) {
 Future<String?> _probeUrl(String baseUrl, String endpoint) async {
   try {
     final response = await http.get(Uri.parse('$baseUrl$endpoint')).timeout(const Duration(seconds: 5));
-    if (response.statusCode >= 200 && response.statusCode < 400) {
+    if (response.statusCode > 0) {
       return baseUrl;
     }
   } catch (e) {

--- a/lib/providers/api_provider.dart
+++ b/lib/providers/api_provider.dart
@@ -143,7 +143,9 @@ Future<String?> _probeUrl(String baseUrl, String endpoint) async {
     if (response.statusCode >= 200 && response.statusCode < 400) {
       return baseUrl;
     }
-  } catch (_) {}
+  } catch (e) {
+    log('Probe failed for $baseUrl$endpoint: $e');
+  }
   return null;
 }
 

--- a/lib/providers/api_provider.dart
+++ b/lib/providers/api_provider.dart
@@ -111,7 +111,10 @@ class JellyRequest implements Interceptor {
 }
 
 /// Whether [url] already carries an http or https scheme.
-bool hasHttpScheme(String url) => url.startsWith('http://') || url.startsWith('https://');
+bool hasHttpScheme(String url) {
+  final lower = url.toLowerCase();
+  return lower.startsWith('http://') || lower.startsWith('https://');
+}
 
 String normalizeUrl(String url) {
   final trimmed = url.trim();

--- a/lib/providers/api_provider.dart
+++ b/lib/providers/api_provider.dart
@@ -16,8 +16,10 @@ part 'api_provider.g.dart';
 
 final serverUrlProvider = StateProvider<String?>((ref) {
   final localUrlAvailable = ref.watch(localConnectionAvailableProvider);
-  final userCredentials = ref.watch(userProvider.select((value) => value?.credentials));
-  final tempUrl = ref.watch(authProvider.select((value) => value.serverLoginModel?.tempCredentials.url));
+  final userCredentials =
+      ref.watch(userProvider.select((value) => value?.credentials));
+  final tempUrl = ref.watch(authProvider
+      .select((value) => value.serverLoginModel?.tempCredentials.url));
   String? newUrl;
 
   if (localUrlAvailable && userCredentials?.localUrl?.isNotEmpty == true) {
@@ -48,7 +50,8 @@ class JellyApi extends _$JellyApi {
       );
 }
 
-JellyfinOpenApi createJellyfinApiForAccount(Ref ref, String baseUrl, Map<String, String> headers) {
+JellyfinOpenApi createJellyfinApiForAccount(
+    Ref ref, String baseUrl, Map<String, String> headers) {
   return JellyfinOpenApi.create(
     interceptors: [
       _TempJellyRequest(baseUrl: baseUrl, headers: headers),
@@ -65,10 +68,13 @@ class _TempJellyRequest implements Interceptor {
   final Map<String, String> headers;
 
   @override
-  FutureOr<Response<BodyType>> intercept<BodyType>(Chain<BodyType> chain) async {
-    if (baseUrl.isEmpty) throw const HttpException('No server URL provided for temp request');
+  FutureOr<Response<BodyType>> intercept<BodyType>(
+      Chain<BodyType> chain) async {
+    if (baseUrl.isEmpty)
+      throw const HttpException('No server URL provided for temp request');
 
-    final request = applyHeaders(chain.request.copyWith(baseUri: Uri.parse(baseUrl)), headers);
+    final request = applyHeaders(
+        chain.request.copyWith(baseUri: Uri.parse(baseUrl)), headers);
     return chain.proceed(request);
   }
 }
@@ -79,15 +85,18 @@ class JellyRequest implements Interceptor {
   final Ref ref;
 
   @override
-  FutureOr<Response<BodyType>> intercept<BodyType>(Chain<BodyType> chain) async {
+  FutureOr<Response<BodyType>> intercept<BodyType>(
+      Chain<BodyType> chain) async {
     final connectivityNotifier = ref.read(connectivityStatusProvider.notifier);
     String? serverUrl = ref.read(serverUrlProvider);
 
     try {
-      if (serverUrl?.isEmpty == true || serverUrl == null) throw const HttpException("Failed to connect");
+      if (serverUrl?.isEmpty == true || serverUrl == null)
+        throw const HttpException("Failed to connect");
 
       //Use current logged in user otherwise use the authProvider
-      var loginModel = ref.read(userProvider)?.credentials ?? ref.read(authProvider).serverLoginModel?.tempCredentials;
+      var loginModel = ref.read(userProvider)?.credentials ??
+          ref.read(authProvider).serverLoginModel?.tempCredentials;
 
       if (loginModel == null) throw UnimplementedError();
 
@@ -113,7 +122,10 @@ String normalizeUrl(String url) {
   final trimmed = url.trim();
   if (trimmed.isEmpty) return '';
 
-  final withScheme = (trimmed.startsWith('http://') || trimmed.startsWith('https://')) ? trimmed : 'http://$trimmed';
+  final withScheme =
+      (trimmed.startsWith('http://') || trimmed.startsWith('https://'))
+          ? trimmed
+          : 'http://$trimmed';
   final parsed = Uri.parse(withScheme);
 
   // Only punycode non-ASCII hostnames. IP addresses are always ASCII, so no special handling needed.
@@ -153,11 +165,13 @@ Uri? tryParseServerBaseUri(String? url) {
   if (trimmed.isEmpty) return null;
 
   final parsed = Uri.tryParse(trimmed);
-  if (parsed == null || parsed.scheme.isEmpty || parsed.host.isEmpty) return null;
+  if (parsed == null || parsed.scheme.isEmpty || parsed.host.isEmpty)
+    return null;
   return parsed;
 }
 
-Uri? serverBaseUri(Ref ref) => tryParseServerBaseUri(ref.read(serverUrlProvider));
+Uri? serverBaseUri(Ref ref) =>
+    tryParseServerBaseUri(ref.read(serverUrlProvider));
 
 Uri? buildServerUriFromBase(
   String baseUrl, {
@@ -177,11 +191,19 @@ Uri? buildServerUriFromBase(
     return relative;
   }
 
-  final baseSegments = base.pathSegments.where((s) => s.isNotEmpty).toList(growable: false);
-  final relSegments = (relative?.pathSegments ?? const <String>[]).where((s) => s.isNotEmpty).toList(growable: false);
-  final extraSegments = pathSegments.where((s) => s.isNotEmpty).toList(growable: false);
+  final baseSegments =
+      base.pathSegments.where((s) => s.isNotEmpty).toList(growable: false);
+  final relSegments = (relative?.pathSegments ?? const <String>[])
+      .where((s) => s.isNotEmpty)
+      .toList(growable: false);
+  final extraSegments =
+      pathSegments.where((s) => s.isNotEmpty).toList(growable: false);
 
-  final mergedSegments = <String>[...baseSegments, ...relSegments, ...extraSegments];
+  final mergedSegments = <String>[
+    ...baseSegments,
+    ...relSegments,
+    ...extraSegments
+  ];
 
   final mergedQuery = <String, String>{...?(relative?.queryParameters)};
   if (queryParameters != null) {
@@ -240,7 +262,8 @@ class JellyResponse implements Interceptor {
   final Ref ref;
 
   @override
-  FutureOr<Response<BodyType>> intercept<BodyType>(Chain<BodyType> chain) async {
+  FutureOr<Response<BodyType>> intercept<BodyType>(
+      Chain<BodyType> chain) async {
     final Response<BodyType> response = await chain.proceed(chain.request);
 
     if (!response.isSuccessful) {

--- a/lib/providers/api_provider.dart
+++ b/lib/providers/api_provider.dart
@@ -140,12 +140,10 @@ String normalizeUrl(String url) {
 
 Future<String?> _probeUrl(String baseUrl, String endpoint) async {
   try {
-    final response = await http.get(Uri.parse('$baseUrl$endpoint')).timeout(const Duration(seconds: 5));
+    await http.get(Uri.parse('$baseUrl$endpoint')).timeout(const Duration(seconds: 5));
     // Any HTTP response (including 4xx/5xx) means the server is reachable at this URL.
     // This only acts as scheme detection, not as health check.
-    if (response.statusCode > 0) {
-      return baseUrl;
-    }
+    return baseUrl;
   } catch (e) {
     log('Probe failed for $baseUrl$endpoint: $e');
   }

--- a/lib/providers/api_provider.dart
+++ b/lib/providers/api_provider.dart
@@ -150,6 +150,23 @@ Future<String?> probeSeerrUrl(String baseUrl) async {
   return null;
 }
 
+/// Probes a Jellyfin server URL by hitting /System/Info/Public.
+/// Returns the working URL (with scheme) or null.
+Future<String?> probeJellyfinUrl(String baseUrl) async {
+  final client = HttpClient()..connectionTimeout = const Duration(seconds: 5);
+  try {
+    final request = await client.getUrl(Uri.parse('$baseUrl/System/Info/Public'));
+    final response = await request.close();
+    if (response.statusCode >= 200 && response.statusCode < 400) {
+      return baseUrl;
+    }
+  } catch (_) {
+  } finally {
+    client.close();
+  }
+  return null;
+}
+
 /// Probes a Seerr URL, trying https and http in parallel if no scheme is provided.
 /// Returns the resolved (normalized) URL (preferring https), or null if both probes failed.
 /// If a scheme is already present, returns the normalized URL without probing.

--- a/lib/providers/api_provider.dart
+++ b/lib/providers/api_provider.dart
@@ -133,12 +133,10 @@ String normalizeUrl(String url) {
   }
 }
 
-/// Probes a Seerr server URL by hitting /api/v1/status.
-/// Returns the working URL (with scheme) or null.
-Future<String?> probeSeerrUrl(String baseUrl) async {
+Future<String?> _probeUrl(String baseUrl, String endpoint) async {
   final client = HttpClient()..connectionTimeout = const Duration(seconds: 5);
   try {
-    final request = await client.getUrl(Uri.parse('$baseUrl/api/v1/status'));
+    final request = await client.getUrl(Uri.parse('$baseUrl$endpoint'));
     final response = await request.close();
     if (response.statusCode >= 200 && response.statusCode < 400) {
       return baseUrl;
@@ -150,22 +148,11 @@ Future<String?> probeSeerrUrl(String baseUrl) async {
   return null;
 }
 
+/// Probes a Seerr server URL by hitting /api/v1/status.
+Future<String?> probeSeerrUrl(String baseUrl) => _probeUrl(baseUrl, '/api/v1/status');
+
 /// Probes a Jellyfin server URL by hitting /System/Info/Public.
-/// Returns the working URL (with scheme) or null.
-Future<String?> probeJellyfinUrl(String baseUrl) async {
-  final client = HttpClient()..connectionTimeout = const Duration(seconds: 5);
-  try {
-    final request = await client.getUrl(Uri.parse('$baseUrl/System/Info/Public'));
-    final response = await request.close();
-    if (response.statusCode >= 200 && response.statusCode < 400) {
-      return baseUrl;
-    }
-  } catch (_) {
-  } finally {
-    client.close();
-  }
-  return null;
-}
+Future<String?> probeJellyfinUrl(String baseUrl) => _probeUrl(baseUrl, '/System/Info/Public');
 
 /// Tries https and http in parallel using [probeFn] if no scheme is provided.
 /// Returns the resolved (normalized) URL (preferring https), or null if both probes failed.

--- a/lib/providers/api_provider.dart
+++ b/lib/providers/api_provider.dart
@@ -2,6 +2,7 @@ import 'dart:developer';
 import 'dart:io';
 
 import 'package:chopper/chopper.dart';
+import 'package:http/http.dart' as http;
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:punycoder/punycoder.dart';
@@ -134,17 +135,12 @@ String normalizeUrl(String url) {
 }
 
 Future<String?> _probeUrl(String baseUrl, String endpoint) async {
-  final client = HttpClient()..connectionTimeout = const Duration(seconds: 5);
   try {
-    final request = await client.getUrl(Uri.parse('$baseUrl$endpoint'));
-    final response = await request.close();
+    final response = await http.get(Uri.parse('$baseUrl$endpoint')).timeout(const Duration(seconds: 5));
     if (response.statusCode >= 200 && response.statusCode < 400) {
       return baseUrl;
     }
-  } catch (_) {
-  } finally {
-    client.close();
-  }
+  } catch (_) {}
   return null;
 }
 

--- a/lib/providers/api_provider.dart
+++ b/lib/providers/api_provider.dart
@@ -167,14 +167,14 @@ Future<String?> probeJellyfinUrl(String baseUrl) async {
   return null;
 }
 
-/// Probes a Seerr URL, trying https and http in parallel if no scheme is provided.
+/// Tries https and http in parallel using [probeFn] if no scheme is provided.
 /// Returns the resolved (normalized) URL (preferring https), or null if both probes failed.
 /// If a scheme is already present, returns the normalized URL without probing.
-Future<String?> probeAndNormalizeSeerrUrl(String url) async {
+Future<String?> probeAndNormalizeUrl(String url, Future<String?> Function(String) probeFn) async {
   if (!hasHttpScheme(url)) {
     final httpsUrl = normalizeUrl('https://$url');
     final httpUrl = normalizeUrl('http://$url');
-    final results = await Future.wait([probeSeerrUrl(httpsUrl), probeSeerrUrl(httpUrl)]);
+    final results = await Future.wait([probeFn(httpsUrl), probeFn(httpUrl)]);
     return results[0] ?? results[1];
   }
   return normalizeUrl(url);

--- a/lib/providers/api_provider.dart
+++ b/lib/providers/api_provider.dart
@@ -16,10 +16,8 @@ part 'api_provider.g.dart';
 
 final serverUrlProvider = StateProvider<String?>((ref) {
   final localUrlAvailable = ref.watch(localConnectionAvailableProvider);
-  final userCredentials =
-      ref.watch(userProvider.select((value) => value?.credentials));
-  final tempUrl = ref.watch(authProvider
-      .select((value) => value.serverLoginModel?.tempCredentials.url));
+  final userCredentials = ref.watch(userProvider.select((value) => value?.credentials));
+  final tempUrl = ref.watch(authProvider.select((value) => value.serverLoginModel?.tempCredentials.url));
   String? newUrl;
 
   if (localUrlAvailable && userCredentials?.localUrl?.isNotEmpty == true) {
@@ -50,8 +48,7 @@ class JellyApi extends _$JellyApi {
       );
 }
 
-JellyfinOpenApi createJellyfinApiForAccount(
-    Ref ref, String baseUrl, Map<String, String> headers) {
+JellyfinOpenApi createJellyfinApiForAccount(Ref ref, String baseUrl, Map<String, String> headers) {
   return JellyfinOpenApi.create(
     interceptors: [
       _TempJellyRequest(baseUrl: baseUrl, headers: headers),
@@ -68,13 +65,10 @@ class _TempJellyRequest implements Interceptor {
   final Map<String, String> headers;
 
   @override
-  FutureOr<Response<BodyType>> intercept<BodyType>(
-      Chain<BodyType> chain) async {
-    if (baseUrl.isEmpty)
-      throw const HttpException('No server URL provided for temp request');
+  FutureOr<Response<BodyType>> intercept<BodyType>(Chain<BodyType> chain) async {
+    if (baseUrl.isEmpty) throw const HttpException('No server URL provided for temp request');
 
-    final request = applyHeaders(
-        chain.request.copyWith(baseUri: Uri.parse(baseUrl)), headers);
+    final request = applyHeaders(chain.request.copyWith(baseUri: Uri.parse(baseUrl)), headers);
     return chain.proceed(request);
   }
 }
@@ -85,18 +79,15 @@ class JellyRequest implements Interceptor {
   final Ref ref;
 
   @override
-  FutureOr<Response<BodyType>> intercept<BodyType>(
-      Chain<BodyType> chain) async {
+  FutureOr<Response<BodyType>> intercept<BodyType>(Chain<BodyType> chain) async {
     final connectivityNotifier = ref.read(connectivityStatusProvider.notifier);
     String? serverUrl = ref.read(serverUrlProvider);
 
     try {
-      if (serverUrl?.isEmpty == true || serverUrl == null)
-        throw const HttpException("Failed to connect");
+      if (serverUrl?.isEmpty == true || serverUrl == null) throw const HttpException("Failed to connect");
 
       //Use current logged in user otherwise use the authProvider
-      var loginModel = ref.read(userProvider)?.credentials ??
-          ref.read(authProvider).serverLoginModel?.tempCredentials;
+      var loginModel = ref.read(userProvider)?.credentials ?? ref.read(authProvider).serverLoginModel?.tempCredentials;
 
       if (loginModel == null) throw UnimplementedError();
 
@@ -122,10 +113,7 @@ String normalizeUrl(String url) {
   final trimmed = url.trim();
   if (trimmed.isEmpty) return '';
 
-  final withScheme =
-      (trimmed.startsWith('http://') || trimmed.startsWith('https://'))
-          ? trimmed
-          : 'http://$trimmed';
+  final withScheme = (trimmed.startsWith('http://') || trimmed.startsWith('https://')) ? trimmed : 'http://$trimmed';
   final parsed = Uri.parse(withScheme);
 
   // Only punycode non-ASCII hostnames. IP addresses are always ASCII, so no special handling needed.
@@ -165,13 +153,11 @@ Uri? tryParseServerBaseUri(String? url) {
   if (trimmed.isEmpty) return null;
 
   final parsed = Uri.tryParse(trimmed);
-  if (parsed == null || parsed.scheme.isEmpty || parsed.host.isEmpty)
-    return null;
+  if (parsed == null || parsed.scheme.isEmpty || parsed.host.isEmpty) return null;
   return parsed;
 }
 
-Uri? serverBaseUri(Ref ref) =>
-    tryParseServerBaseUri(ref.read(serverUrlProvider));
+Uri? serverBaseUri(Ref ref) => tryParseServerBaseUri(ref.read(serverUrlProvider));
 
 Uri? buildServerUriFromBase(
   String baseUrl, {
@@ -191,19 +177,11 @@ Uri? buildServerUriFromBase(
     return relative;
   }
 
-  final baseSegments =
-      base.pathSegments.where((s) => s.isNotEmpty).toList(growable: false);
-  final relSegments = (relative?.pathSegments ?? const <String>[])
-      .where((s) => s.isNotEmpty)
-      .toList(growable: false);
-  final extraSegments =
-      pathSegments.where((s) => s.isNotEmpty).toList(growable: false);
+  final baseSegments = base.pathSegments.where((s) => s.isNotEmpty).toList(growable: false);
+  final relSegments = (relative?.pathSegments ?? const <String>[]).where((s) => s.isNotEmpty).toList(growable: false);
+  final extraSegments = pathSegments.where((s) => s.isNotEmpty).toList(growable: false);
 
-  final mergedSegments = <String>[
-    ...baseSegments,
-    ...relSegments,
-    ...extraSegments
-  ];
+  final mergedSegments = <String>[...baseSegments, ...relSegments, ...extraSegments];
 
   final mergedQuery = <String, String>{...?(relative?.queryParameters)};
   if (queryParameters != null) {
@@ -262,8 +240,7 @@ class JellyResponse implements Interceptor {
   final Ref ref;
 
   @override
-  FutureOr<Response<BodyType>> intercept<BodyType>(
-      Chain<BodyType> chain) async {
+  FutureOr<Response<BodyType>> intercept<BodyType>(Chain<BodyType> chain) async {
     final Response<BodyType> response = await chain.proceed(chain.request);
 
     if (!response.isSuccessful) {

--- a/lib/providers/api_provider.dart
+++ b/lib/providers/api_provider.dart
@@ -147,6 +147,19 @@ Future<String?> probeSeerrUrl(String baseUrl) async {
   return null;
 }
 
+/// Probes a Seerr URL, trying https first then http if no scheme is provided.
+/// Returns the resolved (normalized) URL, or null if probing failed and no scheme was given.
+/// If a scheme is already present, returns the normalized URL without probing.
+Future<String?> probeAndNormalizeSeerrUrl(String url) async {
+  final hasScheme = url.startsWith('http://') || url.startsWith('https://');
+  if (!hasScheme) {
+    final httpsUrl = normalizeUrl('https://$url');
+    final httpUrl = normalizeUrl('http://$url');
+    return await probeSeerrUrl(httpsUrl) ?? await probeSeerrUrl(httpUrl);
+  }
+  return normalizeUrl(url);
+}
+
 Uri? tryParseServerBaseUri(String? url) {
   if (url == null) return null;
   final trimmed = url.trim();

--- a/lib/providers/api_provider.dart
+++ b/lib/providers/api_provider.dart
@@ -156,17 +156,21 @@ Future<String?> probeSeerrUrl(String baseUrl) => _probeUrl(baseUrl, '/api/v1/sta
 /// Probes a Jellyfin server URL by hitting /System/Info/Public.
 Future<String?> probeJellyfinUrl(String baseUrl) => _probeUrl(baseUrl, '/System/Info/Public');
 
+/// Result of [probeAndNormalizeUrl]: the resolved URL and whether a probe succeeded.
+typedef ProbeResult = ({String url, bool probed});
+
 /// Tries https and http in parallel using [probeFn] if no scheme is provided.
-/// Returns the resolved (normalized) URL (preferring https), or null if both probes failed.
+/// Always returns a usable URL (falls back to https when both probes fail).
 /// If a scheme is already present, returns the normalized URL without probing.
-Future<String?> probeAndNormalizeUrl(String url, Future<String?> Function(String) probeFn) async {
+Future<ProbeResult> probeAndNormalizeUrl(String url, Future<String?> Function(String) probeFn) async {
   if (!hasHttpScheme(url)) {
     final httpsUrl = normalizeUrl('https://$url');
     final httpUrl = normalizeUrl('http://$url');
     final results = await Future.wait([probeFn(httpsUrl), probeFn(httpUrl)]);
-    return results[0] ?? results[1];
+    final probed = results[0] ?? results[1];
+    return (url: probed ?? httpsUrl, probed: probed != null);
   }
-  return normalizeUrl(url);
+  return (url: normalizeUrl(url), probed: true);
 }
 
 Uri? tryParseServerBaseUri(String? url) {

--- a/lib/providers/api_provider.dart
+++ b/lib/providers/api_provider.dart
@@ -109,11 +109,14 @@ class JellyRequest implements Interceptor {
   }
 }
 
+/// Whether [url] already carries an http or https scheme.
+bool hasHttpScheme(String url) => url.startsWith('http://') || url.startsWith('https://');
+
 String normalizeUrl(String url) {
   final trimmed = url.trim();
   if (trimmed.isEmpty) return '';
 
-  final withScheme = (trimmed.startsWith('http://') || trimmed.startsWith('https://')) ? trimmed : 'http://$trimmed';
+  final withScheme = hasHttpScheme(trimmed) ? trimmed : 'http://$trimmed';
   final parsed = Uri.parse(withScheme);
 
   // Only punycode non-ASCII hostnames. IP addresses are always ASCII, so no special handling needed.
@@ -151,8 +154,7 @@ Future<String?> probeSeerrUrl(String baseUrl) async {
 /// Returns the resolved (normalized) URL, or null if probing failed and no scheme was given.
 /// If a scheme is already present, returns the normalized URL without probing.
 Future<String?> probeAndNormalizeSeerrUrl(String url) async {
-  final hasScheme = url.startsWith('http://') || url.startsWith('https://');
-  if (!hasScheme) {
+  if (!hasHttpScheme(url)) {
     final httpsUrl = normalizeUrl('https://$url');
     final httpUrl = normalizeUrl('http://$url');
     return await probeSeerrUrl(httpsUrl) ?? await probeSeerrUrl(httpUrl);

--- a/lib/providers/api_provider.dart
+++ b/lib/providers/api_provider.dart
@@ -150,14 +150,15 @@ Future<String?> probeSeerrUrl(String baseUrl) async {
   return null;
 }
 
-/// Probes a Seerr URL, trying https first then http if no scheme is provided.
-/// Returns the resolved (normalized) URL, or null if probing failed and no scheme was given.
+/// Probes a Seerr URL, trying https and http in parallel if no scheme is provided.
+/// Returns the resolved (normalized) URL (preferring https), or null if both probes failed.
 /// If a scheme is already present, returns the normalized URL without probing.
 Future<String?> probeAndNormalizeSeerrUrl(String url) async {
   if (!hasHttpScheme(url)) {
     final httpsUrl = normalizeUrl('https://$url');
     final httpUrl = normalizeUrl('http://$url');
-    return await probeSeerrUrl(httpsUrl) ?? await probeSeerrUrl(httpUrl);
+    final results = await Future.wait([probeSeerrUrl(httpsUrl), probeSeerrUrl(httpUrl)]);
+    return results[0] ?? results[1];
   }
   return normalizeUrl(url);
 }

--- a/lib/providers/api_provider.dart
+++ b/lib/providers/api_provider.dart
@@ -166,9 +166,11 @@ Future<ProbeResult> probeAndNormalizeUrl(String url, Future<String?> Function(St
   if (!hasHttpScheme(url)) {
     final httpsUrl = normalizeUrl('https://$url');
     final httpUrl = normalizeUrl('http://$url');
-    final results = await Future.wait([probeFn(httpsUrl), probeFn(httpUrl)]);
-    final probed = results[0] ?? results[1];
-    return (url: probed ?? httpsUrl, probed: probed != null);
+    final httpFuture = probeFn(httpUrl);
+    final httpsResult = await probeFn(httpsUrl);
+    if (httpsResult != null) return (url: httpsResult, probed: true);
+    final httpResult = await httpFuture;
+    return (url: httpResult ?? httpsUrl, probed: httpResult != null);
   }
   return (url: normalizeUrl(url), probed: true);
 }

--- a/lib/providers/api_provider.dart
+++ b/lib/providers/api_provider.dart
@@ -140,7 +140,7 @@ String normalizeUrl(String url) {
 
 Future<String?> _probeUrl(String baseUrl, String endpoint) async {
   try {
-    await http.get(Uri.parse('$baseUrl$endpoint')).timeout(const Duration(seconds: 5));
+    await http.head(Uri.parse('$baseUrl$endpoint')).timeout(const Duration(seconds: 5));
     // Any HTTP response (including 4xx/5xx) means the server is reachable at this URL.
     // This only acts as scheme detection, not as health check.
     return baseUrl;

--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -195,8 +195,8 @@ class AuthNotifier extends StateNotifier<LoginScreenModel> {
     }
     final trimmed = server.trim();
     if (trimmed.isEmpty) return;
-    final resolved = await probeAndNormalizeUrl(trimmed, probeJellyfinUrl);
-    await _fetchServerInfo(resolved ?? normalizeUrl('https://$trimmed'));
+    final result = await probeAndNormalizeUrl(trimmed, probeJellyfinUrl);
+    await _fetchServerInfo(result.url);
   }
 
   List<AccountModel> getSavedAccounts() {

--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -189,9 +189,21 @@ class AuthNotifier extends StateNotifier<LoginScreenModel> {
   }
 
   Future<void> setServer(String server) async {
-    final url = (state.hasBaseUrl ? FladderConfig.baseUrl : server);
-    if (url == null || server.isEmpty) return;
-    await _fetchServerInfo(url);
+    if (state.hasBaseUrl) {
+      await _fetchServerInfo(FladderConfig.baseUrl!);
+      return;
+    }
+    final trimmed = server.trim();
+    if (trimmed.isEmpty) return;
+    if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
+      await _fetchServerInfo(trimmed);
+    } else {
+      // Try https first, then http
+      await _fetchServerInfo('https://$trimmed');
+      if (state.errorMessage != null) {
+        await _fetchServerInfo('http://$trimmed');
+      }
+    }
   }
 
   List<AccountModel> getSavedAccounts() {

--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -24,8 +24,7 @@ import 'package:fladder/screens/shared/fladder_notification_overlay.dart';
 import 'package:fladder/util/fladder_config.dart';
 import 'package:fladder/util/localization_helper.dart';
 
-final authProvider =
-    StateNotifierProvider<AuthNotifier, LoginScreenModel>((ref) {
+final authProvider = StateNotifierProvider<AuthNotifier, LoginScreenModel>((ref) {
   return AuthNotifier(ref);
 });
 
@@ -53,31 +52,26 @@ class AuthNotifier extends StateNotifier<LoginScreenModel> {
     }
     state = state.copyWith(
       accounts: currentAccounts,
-      screen: currentAccounts.isEmpty
-          ? LoginScreenType.login
-          : LoginScreenType.users,
+      screen: currentAccounts.isEmpty ? LoginScreenType.login : LoginScreenType.users,
     );
   }
 
   Future<void> _fetchServerInfo(String url) async {
     try {
-      final newCredentials =
-          CredentialsModel.createNewCredentials().copyWith(url: url);
+      final newCredentials = CredentialsModel.createNewCredentials().copyWith(url: url);
       final newLoginModel = ServerLoginModel(tempCredentials: newCredentials);
       state = state.copyWith(
         serverLoginModel: newLoginModel,
         loading: true,
       );
       final publicUsers = (await getPublicUsers())?.body ?? [];
-      final quickConnectStatus =
-          (await api.quickConnectEnabled()).body ?? false;
+      final quickConnectStatus = (await api.quickConnectEnabled()).body ?? false;
       final branding = await api.getBranding();
       final serverResponse = await api.systemInfoPublicGet();
       final serverId = serverResponse.body?.id ?? "";
       state = state.copyWith(
         errorMessage: null,
-        screen:
-            quickConnectStatus ? LoginScreenType.code : LoginScreenType.login,
+        screen: quickConnectStatus ? LoginScreenType.code : LoginScreenType.login,
         serverLoginModel: newLoginModel.copyWith(
           tempCredentials: newCredentials.copyWith(
             serverName: serverResponse.body?.serverName ?? "",
@@ -130,29 +124,23 @@ class AuthNotifier extends StateNotifier<LoginScreenModel> {
     return _createAccountModel(response).apiResult;
   }
 
-  Future<Response<AccountModel>?> authenticateByName(
-      String userName, String password) async {
+  Future<Response<AccountModel>?> authenticateByName(String userName, String password) async {
     clearAllProviders();
-    var response = await api.usersAuthenticateByNamePost(
-        userName: userName, password: password);
+    var response = await api.usersAuthenticateByNamePost(userName: userName, password: password);
     return _createAccountModel(response);
   }
 
-  Future<Response<AccountModel>> _createAccountModel(
-      Response<AuthenticationResult> response) async {
+  Future<Response<AccountModel>> _createAccountModel(Response<AuthenticationResult> response) async {
     CredentialsModel? credentials = state.serverLoginModel?.tempCredentials;
     if (credentials == null) return Response(response.base, null);
-    if (response.isSuccessful &&
-        (response.body?.accessToken?.isNotEmpty ?? false)) {
+    if (response.isSuccessful && (response.body?.accessToken?.isNotEmpty ?? false)) {
       var serverResponse = await api.systemInfoPublicGet();
       credentials = credentials.copyWith(
         token: response.body?.accessToken ?? "",
         serverId: response.body?.serverId ?? "",
         serverName: serverResponse.body?.serverName ?? "",
       );
-      var imageUrl = ref
-          .read(imageUtilityProvider)
-          .getUserImageUrl(response.body?.user?.id ?? "");
+      var imageUrl = ref.read(imageUtilityProvider).getUserImageUrl(response.body?.user?.id ?? "");
       AccountModel newUser = AccountModel(
         name: response.body?.user?.name ?? "",
         id: response.body?.user?.id ?? "",
@@ -162,8 +150,7 @@ class AuthNotifier extends StateNotifier<LoginScreenModel> {
       );
       ref.read(sharedUtilityProvider).addAccount(newUser);
       ref.read(userProvider.notifier).userState = newUser;
-      final currentAccounts =
-          ref.read(authProvider.notifier).getSavedAccounts();
+      final currentAccounts = ref.read(authProvider.notifier).getSavedAccounts();
 
       state = state.copyWith(
         accounts: currentAccounts,
@@ -220,8 +207,7 @@ class AuthNotifier extends StateNotifier<LoginScreenModel> {
   }
 
   List<AccountModel> getSavedAccounts() {
-    state =
-        state.copyWith(accounts: ref.read(sharedUtilityProvider).getAccounts());
+    state = state.copyWith(accounts: ref.read(sharedUtilityProvider).getAccounts());
     return state.accounts;
   }
 
@@ -254,26 +240,21 @@ class AuthNotifier extends StateNotifier<LoginScreenModel> {
     if (serverId == null || serverId.isEmpty) return null;
     final matches = state.accounts.where(
       (account) =>
-          account.credentials.serverId == serverId &&
-          (account.seerrCredentials?.serverUrl.isNotEmpty ?? false),
+          account.credentials.serverId == serverId && (account.seerrCredentials?.serverUrl.isNotEmpty ?? false),
     );
 
     if (matches.isEmpty) return null;
 
-    final sorted = matches.toList()
-      ..sort((a, b) => b.lastUsed.compareTo(a.lastUsed));
+    final sorted = matches.toList()..sort((a, b) => b.lastUsed.compareTo(a.lastUsed));
 
     return sorted.first.seerrCredentials?.serverUrl;
   }
 
   void setTempSeerrUrl(String? url) {
-    state = state.copyWith(
-        tempSeerrUrl: url?.trim().isEmpty == true ? null : url?.trim());
+    state = state.copyWith(tempSeerrUrl: url?.trim().isEmpty == true ? null : url?.trim());
   }
 
   void setTempSeerrSessionCookie(String? cookie) {
-    state = state.copyWith(
-        tempSeerrSessionCookie:
-            cookie?.trim().isEmpty == true ? null : cookie?.trim());
+    state = state.copyWith(tempSeerrSessionCookie: cookie?.trim().isEmpty == true ? null : cookie?.trim());
   }
 }

--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -195,15 +195,8 @@ class AuthNotifier extends StateNotifier<LoginScreenModel> {
     }
     final trimmed = server.trim();
     if (trimmed.isEmpty) return;
-    if (hasHttpScheme(trimmed)) {
-      await _fetchServerInfo(trimmed);
-    } else {
-      // Try https first, then http
-      await _fetchServerInfo('https://$trimmed');
-      if (state.errorMessage != null) {
-        await _fetchServerInfo('http://$trimmed');
-      }
-    }
+    final resolved = await probeAndNormalizeUrl(trimmed, probeJellyfinUrl);
+    await _fetchServerInfo(resolved ?? normalizeUrl('https://$trimmed'));
   }
 
   List<AccountModel> getSavedAccounts() {

--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -195,7 +195,7 @@ class AuthNotifier extends StateNotifier<LoginScreenModel> {
     }
     final trimmed = server.trim();
     if (trimmed.isEmpty) return;
-    if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
+    if (hasHttpScheme(trimmed)) {
       await _fetchServerInfo(trimmed);
     } else {
       // Try https first, then http

--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -24,7 +24,8 @@ import 'package:fladder/screens/shared/fladder_notification_overlay.dart';
 import 'package:fladder/util/fladder_config.dart';
 import 'package:fladder/util/localization_helper.dart';
 
-final authProvider = StateNotifierProvider<AuthNotifier, LoginScreenModel>((ref) {
+final authProvider =
+    StateNotifierProvider<AuthNotifier, LoginScreenModel>((ref) {
   return AuthNotifier(ref);
 });
 
@@ -52,26 +53,31 @@ class AuthNotifier extends StateNotifier<LoginScreenModel> {
     }
     state = state.copyWith(
       accounts: currentAccounts,
-      screen: currentAccounts.isEmpty ? LoginScreenType.login : LoginScreenType.users,
+      screen: currentAccounts.isEmpty
+          ? LoginScreenType.login
+          : LoginScreenType.users,
     );
   }
 
   Future<void> _fetchServerInfo(String url) async {
     try {
-      final newCredentials = CredentialsModel.createNewCredentials().copyWith(url: url);
+      final newCredentials =
+          CredentialsModel.createNewCredentials().copyWith(url: url);
       final newLoginModel = ServerLoginModel(tempCredentials: newCredentials);
       state = state.copyWith(
         serverLoginModel: newLoginModel,
         loading: true,
       );
       final publicUsers = (await getPublicUsers())?.body ?? [];
-      final quickConnectStatus = (await api.quickConnectEnabled()).body ?? false;
+      final quickConnectStatus =
+          (await api.quickConnectEnabled()).body ?? false;
       final branding = await api.getBranding();
       final serverResponse = await api.systemInfoPublicGet();
       final serverId = serverResponse.body?.id ?? "";
       state = state.copyWith(
         errorMessage: null,
-        screen: quickConnectStatus ? LoginScreenType.code : LoginScreenType.login,
+        screen:
+            quickConnectStatus ? LoginScreenType.code : LoginScreenType.login,
         serverLoginModel: newLoginModel.copyWith(
           tempCredentials: newCredentials.copyWith(
             serverName: serverResponse.body?.serverName ?? "",
@@ -124,23 +130,29 @@ class AuthNotifier extends StateNotifier<LoginScreenModel> {
     return _createAccountModel(response).apiResult;
   }
 
-  Future<Response<AccountModel>?> authenticateByName(String userName, String password) async {
+  Future<Response<AccountModel>?> authenticateByName(
+      String userName, String password) async {
     clearAllProviders();
-    var response = await api.usersAuthenticateByNamePost(userName: userName, password: password);
+    var response = await api.usersAuthenticateByNamePost(
+        userName: userName, password: password);
     return _createAccountModel(response);
   }
 
-  Future<Response<AccountModel>> _createAccountModel(Response<AuthenticationResult> response) async {
+  Future<Response<AccountModel>> _createAccountModel(
+      Response<AuthenticationResult> response) async {
     CredentialsModel? credentials = state.serverLoginModel?.tempCredentials;
     if (credentials == null) return Response(response.base, null);
-    if (response.isSuccessful && (response.body?.accessToken?.isNotEmpty ?? false)) {
+    if (response.isSuccessful &&
+        (response.body?.accessToken?.isNotEmpty ?? false)) {
       var serverResponse = await api.systemInfoPublicGet();
       credentials = credentials.copyWith(
         token: response.body?.accessToken ?? "",
         serverId: response.body?.serverId ?? "",
         serverName: serverResponse.body?.serverName ?? "",
       );
-      var imageUrl = ref.read(imageUtilityProvider).getUserImageUrl(response.body?.user?.id ?? "");
+      var imageUrl = ref
+          .read(imageUtilityProvider)
+          .getUserImageUrl(response.body?.user?.id ?? "");
       AccountModel newUser = AccountModel(
         name: response.body?.user?.name ?? "",
         id: response.body?.user?.id ?? "",
@@ -150,7 +162,8 @@ class AuthNotifier extends StateNotifier<LoginScreenModel> {
       );
       ref.read(sharedUtilityProvider).addAccount(newUser);
       ref.read(userProvider.notifier).userState = newUser;
-      final currentAccounts = ref.read(authProvider.notifier).getSavedAccounts();
+      final currentAccounts =
+          ref.read(authProvider.notifier).getSavedAccounts();
 
       state = state.copyWith(
         accounts: currentAccounts,
@@ -207,7 +220,8 @@ class AuthNotifier extends StateNotifier<LoginScreenModel> {
   }
 
   List<AccountModel> getSavedAccounts() {
-    state = state.copyWith(accounts: ref.read(sharedUtilityProvider).getAccounts());
+    state =
+        state.copyWith(accounts: ref.read(sharedUtilityProvider).getAccounts());
     return state.accounts;
   }
 
@@ -240,21 +254,26 @@ class AuthNotifier extends StateNotifier<LoginScreenModel> {
     if (serverId == null || serverId.isEmpty) return null;
     final matches = state.accounts.where(
       (account) =>
-          account.credentials.serverId == serverId && (account.seerrCredentials?.serverUrl.isNotEmpty ?? false),
+          account.credentials.serverId == serverId &&
+          (account.seerrCredentials?.serverUrl.isNotEmpty ?? false),
     );
 
     if (matches.isEmpty) return null;
 
-    final sorted = matches.toList()..sort((a, b) => b.lastUsed.compareTo(a.lastUsed));
+    final sorted = matches.toList()
+      ..sort((a, b) => b.lastUsed.compareTo(a.lastUsed));
 
     return sorted.first.seerrCredentials?.serverUrl;
   }
 
   void setTempSeerrUrl(String? url) {
-    state = state.copyWith(tempSeerrUrl: url?.trim().isEmpty == true ? null : url?.trim());
+    state = state.copyWith(
+        tempSeerrUrl: url?.trim().isEmpty == true ? null : url?.trim());
   }
 
   void setTempSeerrSessionCookie(String? cookie) {
-    state = state.copyWith(tempSeerrSessionCookie: cookie?.trim().isEmpty == true ? null : cookie?.trim());
+    state = state.copyWith(
+        tempSeerrSessionCookie:
+            cookie?.trim().isEmpty == true ? null : cookie?.trim());
   }
 }

--- a/lib/screens/login/widgets/advanced_login_options_dialog.dart
+++ b/lib/screens/login/widgets/advanced_login_options_dialog.dart
@@ -85,21 +85,10 @@ class _AdvancedLoginOptionsDialogState extends ConsumerState<_AdvancedLoginOptio
       Navigator.of(context).pop(url);
       return;
     }
-    final hasScheme = url.startsWith('http://') || url.startsWith('https://');
-    if (!hasScheme) {
-      setState(() => _probing = true);
-      final httpsUrl = normalizeUrl('https://$url');
-      final httpUrl = normalizeUrl('http://$url');
-      final result = await probeSeerrUrl(httpsUrl) ?? await probeSeerrUrl(httpUrl);
-      if (!mounted) return;
-      setState(() => _probing = false);
-      if (result != null) {
-        Navigator.of(context).pop(result);
-      } else {
-        Navigator.of(context).pop(normalizeUrl(url));
-      }
-    } else {
-      Navigator.of(context).pop(normalizeUrl(url));
-    }
+    setState(() => _probing = true);
+    final result = await probeAndNormalizeSeerrUrl(url);
+    if (!mounted) return;
+    setState(() => _probing = false);
+    Navigator.of(context).pop(result ?? normalizeUrl(url));
   }
 }

--- a/lib/screens/login/widgets/advanced_login_options_dialog.dart
+++ b/lib/screens/login/widgets/advanced_login_options_dialog.dart
@@ -97,8 +97,6 @@ class _AdvancedLoginOptionsDialogState extends ConsumerState<_AdvancedLoginOptio
       if (!mounted) return;
       if (result != null) {
         Navigator.of(context).pop(result);
-      } else if (hasHttpScheme(url)) {
-        Navigator.of(context).pop(normalizeUrl(url));
       } else {
         final fallback = normalizeUrl('https://$url');
         seerrUrlController.text = fallback;

--- a/lib/screens/login/widgets/advanced_login_options_dialog.dart
+++ b/lib/screens/login/widgets/advanced_login_options_dialog.dart
@@ -95,11 +95,10 @@ class _AdvancedLoginOptionsDialogState extends ConsumerState<_AdvancedLoginOptio
     try {
       final result = await probeAndNormalizeUrl(url, probeSeerrUrl);
       if (!mounted) return;
-      if (result != null) {
-        Navigator.of(context).pop(result);
+      if (result.probed) {
+        Navigator.of(context).pop(result.url);
       } else {
-        final fallback = normalizeUrl('https://$url');
-        seerrUrlController.text = fallback;
+        seerrUrlController.text = result.url;
         _warning = context.localized.seerrUrlSchemeWarning;
       }
     } finally {

--- a/lib/screens/login/widgets/advanced_login_options_dialog.dart
+++ b/lib/screens/login/widgets/advanced_login_options_dialog.dart
@@ -89,6 +89,6 @@ class _AdvancedLoginOptionsDialogState extends ConsumerState<_AdvancedLoginOptio
     final result = await probeAndNormalizeUrl(url, probeSeerrUrl);
     if (!mounted) return;
     setState(() => _probing = false);
-    Navigator.of(context).pop(result ?? normalizeUrl(url));
+    Navigator.of(context).pop(result ?? normalizeUrl('https://$url'));
   }
 }

--- a/lib/screens/login/widgets/advanced_login_options_dialog.dart
+++ b/lib/screens/login/widgets/advanced_login_options_dialog.dart
@@ -86,9 +86,12 @@ class _AdvancedLoginOptionsDialogState extends ConsumerState<_AdvancedLoginOptio
       return;
     }
     setState(() => _probing = true);
-    final result = await probeAndNormalizeUrl(url, probeSeerrUrl);
-    if (!mounted) return;
-    setState(() => _probing = false);
-    Navigator.of(context).pop(result ?? normalizeUrl('https://$url'));
+    try {
+      final result = await probeAndNormalizeUrl(url, probeSeerrUrl);
+      if (!mounted) return;
+      Navigator.of(context).pop(result ?? normalizeUrl('https://$url'));
+    } finally {
+      if (mounted) setState(() => _probing = false);
+    }
   }
 }

--- a/lib/screens/login/widgets/advanced_login_options_dialog.dart
+++ b/lib/screens/login/widgets/advanced_login_options_dialog.dart
@@ -86,7 +86,7 @@ class _AdvancedLoginOptionsDialogState extends ConsumerState<_AdvancedLoginOptio
       return;
     }
     setState(() => _probing = true);
-    final result = await probeAndNormalizeSeerrUrl(url);
+    final result = await probeAndNormalizeUrl(url, probeSeerrUrl);
     if (!mounted) return;
     setState(() => _probing = false);
     Navigator.of(context).pop(result ?? normalizeUrl(url));

--- a/lib/screens/login/widgets/advanced_login_options_dialog.dart
+++ b/lib/screens/login/widgets/advanced_login_options_dialog.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:iconsax_plus/iconsax_plus.dart';
 
 import 'package:fladder/providers/api_provider.dart';
+import 'package:fladder/screens/settings/widgets/settings_message_box.dart';
 import 'package:fladder/screens/shared/outlined_text_field.dart';
 import 'package:fladder/util/adaptive_layout/adaptive_layout.dart';
 import 'package:fladder/util/localization_helper.dart';
@@ -27,6 +28,7 @@ class _AdvancedLoginOptionsDialog extends ConsumerStatefulWidget {
 class _AdvancedLoginOptionsDialogState extends ConsumerState<_AdvancedLoginOptionsDialog> {
   late final TextEditingController seerrUrlController = TextEditingController(text: widget.initialSeerrUrl ?? '');
   bool _probing = false;
+  String? _warning;
 
   @override
   void dispose() {
@@ -51,6 +53,7 @@ class _AdvancedLoginOptionsDialogState extends ConsumerState<_AdvancedLoginOptio
           crossAxisAlignment: CrossAxisAlignment.start,
           spacing: 16,
           children: [
+            if (_warning != null) SettingsMessageBox(_warning!, messageType: MessageType.warning),
             OutlinedTextField(
               controller: seerrUrlController,
               keyboardType: TextInputType.url,
@@ -85,11 +88,22 @@ class _AdvancedLoginOptionsDialogState extends ConsumerState<_AdvancedLoginOptio
       Navigator.of(context).pop(url);
       return;
     }
-    setState(() => _probing = true);
+    setState(() {
+      _probing = true;
+      _warning = null;
+    });
     try {
       final result = await probeAndNormalizeUrl(url, probeSeerrUrl);
       if (!mounted) return;
-      Navigator.of(context).pop(result ?? normalizeUrl('https://$url'));
+      if (result != null) {
+        Navigator.of(context).pop(result);
+      } else if (hasHttpScheme(url)) {
+        Navigator.of(context).pop(normalizeUrl(url));
+      } else {
+        final fallback = normalizeUrl('https://$url');
+        seerrUrlController.text = fallback;
+        _warning = context.localized.seerrUrlSchemeWarning;
+      }
     } finally {
       if (mounted) setState(() => _probing = false);
     }

--- a/lib/screens/login/widgets/advanced_login_options_dialog.dart
+++ b/lib/screens/login/widgets/advanced_login_options_dialog.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:iconsax_plus/iconsax_plus.dart';
 
+import 'package:fladder/providers/api_provider.dart';
 import 'package:fladder/screens/shared/outlined_text_field.dart';
 import 'package:fladder/util/adaptive_layout/adaptive_layout.dart';
 import 'package:fladder/util/localization_helper.dart';
@@ -25,6 +26,7 @@ class _AdvancedLoginOptionsDialog extends ConsumerStatefulWidget {
 
 class _AdvancedLoginOptionsDialogState extends ConsumerState<_AdvancedLoginOptionsDialog> {
   late final TextEditingController seerrUrlController = TextEditingController(text: widget.initialSeerrUrl ?? '');
+  bool _probing = false;
 
   @override
   void dispose() {
@@ -68,14 +70,36 @@ class _AdvancedLoginOptionsDialogState extends ConsumerState<_AdvancedLoginOptio
           child: Text(context.localized.cancel),
         ),
         FilledButton(
-          onPressed: _save,
-          child: Text(context.localized.save),
+          onPressed: _probing ? null : _save,
+          child: _probing
+              ? const SizedBox(width: 20, height: 20, child: CircularProgressIndicator(strokeWidth: 2))
+              : Text(context.localized.save),
         ),
       ],
     );
   }
 
-  void _save() {
-    Navigator.of(context).pop(seerrUrlController.text.trim());
+  Future<void> _save() async {
+    final url = seerrUrlController.text.trim();
+    if (url.isEmpty) {
+      Navigator.of(context).pop(url);
+      return;
+    }
+    final hasScheme = url.startsWith('http://') || url.startsWith('https://');
+    if (!hasScheme) {
+      setState(() => _probing = true);
+      final httpsUrl = normalizeUrl('https://$url');
+      final httpUrl = normalizeUrl('http://$url');
+      final result = await probeSeerrUrl(httpsUrl) ?? await probeSeerrUrl(httpUrl);
+      if (!mounted) return;
+      setState(() => _probing = false);
+      if (result != null) {
+        Navigator.of(context).pop(result);
+      } else {
+        Navigator.of(context).pop(normalizeUrl(url));
+      }
+    } else {
+      Navigator.of(context).pop(normalizeUrl(url));
+    }
   }
 }

--- a/lib/screens/settings/widgets/seerr_connection_dialog.dart
+++ b/lib/screens/settings/widgets/seerr_connection_dialog.dart
@@ -247,8 +247,9 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
       }
     } catch (e) {
       if (mounted) {
-        error = e.toString();
-        FladderSnack.show(e.toString(), context: context);
+        final message = e.toString().split(RegExp(r'\n#\d')).first.trim();
+        error = message;
+        FladderSnack.show(message, context: context);
       }
     } finally {
       if (mounted) {
@@ -284,8 +285,9 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
       }
     } catch (e) {
       if (mounted) {
-        error = e.toString();
-        FladderSnack.show(e.toString(), context: context);
+        final message = e.toString().split(RegExp(r'\n#\d')).first.trim();
+        error = message;
+        FladderSnack.show(message, context: context);
       }
     } finally {
       if (mounted) {
@@ -308,8 +310,9 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
       await ref.read(seerrApiProvider).logout();
     } catch (e) {
       if (mounted) {
-        error = e.toString();
-        FladderSnack.show(e.toString(), context: context);
+        final message = e.toString().split(RegExp(r'\n#\d')).first.trim();
+        error = message;
+        FladderSnack.show(message, context: context);
       }
     } finally {
       ref.read(userProvider.notifier).logoutSeerr();
@@ -354,6 +357,8 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
           Expanded(
             child: Text(
               error!,
+              maxLines: 4,
+              overflow: TextOverflow.ellipsis,
               style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                     color: Theme.of(context).colorScheme.onErrorContainer,
                   ),

--- a/lib/screens/settings/widgets/seerr_connection_dialog.dart
+++ b/lib/screens/settings/widgets/seerr_connection_dialog.dart
@@ -169,6 +169,7 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
 
   Future<bool> _applyServerUrl({bool showError = true}) async {
     warning = null;
+    error = null;
     final rawUrl = serverController.text.trim();
     if (rawUrl.isEmpty) {
       if (showError && mounted) {

--- a/lib/screens/settings/widgets/seerr_connection_dialog.dart
+++ b/lib/screens/settings/widgets/seerr_connection_dialog.dart
@@ -292,7 +292,10 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
   }
 
   Future<void> _logout() async {
-    await _applyServerUrl(showError: false);
+    final serverUrl = serverController.text.trim();
+    if (serverUrl.isNotEmpty) {
+      ref.read(userProvider.notifier).setSeerrServerUrl(serverUrl);
+    }
     setState(() {
       processing = true;
       error = null;

--- a/lib/screens/settings/widgets/seerr_connection_dialog.dart
+++ b/lib/screens/settings/widgets/seerr_connection_dialog.dart
@@ -179,18 +179,17 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
     }
 
     final result = await probeAndNormalizeUrl(rawUrl, probeSeerrUrl);
-    final serverUrl = result ?? normalizeUrl('https://$rawUrl');
 
     if (!mounted) return false;
 
-    if (result == null && !hasHttpScheme(rawUrl)) {
+    if (!result.probed) {
       warning = context.localized.seerrUrlSchemeWarning;
     }
 
-    if (serverUrl != rawUrl) {
-      serverController.text = serverUrl;
+    if (result.url != rawUrl) {
+      serverController.text = result.url;
     }
-    ref.read(userProvider.notifier).setSeerrServerUrl(serverUrl);
+    ref.read(userProvider.notifier).setSeerrServerUrl(result.url);
     return true;
   }
 

--- a/lib/screens/settings/widgets/seerr_connection_dialog.dart
+++ b/lib/screens/settings/widgets/seerr_connection_dialog.dart
@@ -41,8 +41,7 @@ class SeerrConnectionDialog extends ConsumerStatefulWidget {
   const SeerrConnectionDialog({super.key});
 
   @override
-  ConsumerState<ConsumerStatefulWidget> createState() =>
-      _SeerrConnectionDialogState();
+  ConsumerState<ConsumerStatefulWidget> createState() => _SeerrConnectionDialogState();
 }
 
 class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
@@ -68,8 +67,7 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
     super.initState();
     final creds = ref.read(userProvider)?.seerrCredentials;
     apiKeyController = TextEditingController(text: creds?.apiKey ?? '');
-    serverController = TextEditingController(
-        text: FladderConfig.seerrBaseUrl ?? creds?.serverUrl ?? '');
+    serverController = TextEditingController(text: FladderConfig.seerrBaseUrl ?? creds?.serverUrl ?? '');
     localEmailController = TextEditingController();
     localPasswordController = TextEditingController();
     jfUsernameController = TextEditingController();
@@ -176,14 +174,12 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
     }
 
     String serverUrl;
-    final hasScheme =
-        rawUrl.startsWith('http://') || rawUrl.startsWith('https://');
+    final hasScheme = rawUrl.startsWith('http://') || rawUrl.startsWith('https://');
     if (!hasScheme) {
       // Probe https first, then http
       final httpsUrl = normalizeUrl('https://$rawUrl');
       final httpUrl = normalizeUrl('http://$rawUrl');
-      final result =
-          await probeSeerrUrl(httpsUrl) ?? await probeSeerrUrl(httpUrl);
+      final result = await probeSeerrUrl(httpsUrl) ?? await probeSeerrUrl(httpUrl);
       if (result == null) {
         if (showError && mounted) {
           setState(() {
@@ -351,8 +347,7 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
       ),
       child: Row(
         children: [
-          Icon(IconsaxPlusLinear.warning_2,
-              color: Theme.of(context).colorScheme.onErrorContainer),
+          Icon(IconsaxPlusLinear.warning_2, color: Theme.of(context).colorScheme.onErrorContainer),
           const SizedBox(width: 8),
           Expanded(
             child: Text(
@@ -369,10 +364,8 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
 
   Widget _loggedInContent() {
     final serverUrl = ref.read(userProvider)?.seerrCredentials?.serverUrl ?? '';
-    final displayName = seerrUser?.displayName ??
-        seerrUser?.username ??
-        seerrUser?.email ??
-        context.localized.seerrUnknownUser;
+    final displayName =
+        seerrUser?.displayName ?? seerrUser?.username ?? seerrUser?.email ?? context.localized.seerrUnknownUser;
     return Column(
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -390,8 +383,7 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
           spacing: 8,
           children: [
             seerrUser?.avatar != null && seerrUser!.avatar!.isNotEmpty
-                ? CircleAvatar(
-                    backgroundImage: NetworkImage(seerrUser!.avatar!))
+                ? CircleAvatar(backgroundImage: NetworkImage(seerrUser!.avatar!))
                 : CircleAvatar(child: Icon(FladderItemType.person.icon)),
             Column(
               crossAxisAlignment: CrossAxisAlignment.start,
@@ -532,10 +524,7 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
                 FilledButton(
                   onPressed: processing ? null : _useApiKey,
                   child: processing
-                      ? const SizedBox(
-                          width: 20,
-                          height: 20,
-                          child: CircularProgressIndicator())
+                      ? const SizedBox(width: 20, height: 20, child: CircularProgressIndicator())
                       : Text(context.localized.save),
                 ),
               ],
@@ -574,10 +563,7 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
                 FilledButton(
                   onPressed: processing ? null : _loginLocal,
                   child: processing
-                      ? const SizedBox(
-                          width: 20,
-                          height: 20,
-                          child: CircularProgressIndicator())
+                      ? const SizedBox(width: 20, height: 20, child: CircularProgressIndicator())
                       : Text(context.localized.login),
                 ),
               ],
@@ -615,10 +601,7 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
                 FilledButton(
                   onPressed: processing ? null : _loginJellyfin,
                   child: processing
-                      ? const SizedBox(
-                          width: 20,
-                          height: 20,
-                          child: CircularProgressIndicator())
+                      ? const SizedBox(width: 20, height: 20, child: CircularProgressIndicator())
                       : Text(context.localized.login),
                 ),
               ],
@@ -648,9 +631,7 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
                 child: CircularProgressIndicator(strokeCap: StrokeCap.round),
               )
             else
-              AnimatedFadeSize(
-                  child:
-                      seerrUser != null ? _loggedInContent() : _authContent()),
+              AnimatedFadeSize(child: seerrUser != null ? _loggedInContent() : _authContent()),
           ],
         ),
       ),

--- a/lib/screens/settings/widgets/seerr_connection_dialog.dart
+++ b/lib/screens/settings/widgets/seerr_connection_dialog.dart
@@ -179,15 +179,7 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
     if (rawUrl == _lastProbedUrl) return true;
 
     final result = await probeAndNormalizeUrl(rawUrl, probeSeerrUrl);
-    if (result == null) {
-      if (showError && mounted) {
-        setState(() {
-          error = context.localized.unableToConnectHost;
-        });
-      }
-      return false;
-    }
-    final serverUrl = result;
+    final serverUrl = result ?? normalizeUrl('https://$rawUrl');
     _lastProbedUrl = serverUrl;
 
     if (!mounted) return false;

--- a/lib/screens/settings/widgets/seerr_connection_dialog.dart
+++ b/lib/screens/settings/widgets/seerr_connection_dialog.dart
@@ -192,6 +192,7 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
       serverController.text = result.url;
     }
     ref.read(userProvider.notifier).setSeerrServerUrl(result.url);
+    if (mounted) setState(() {});
     return true;
   }
 

--- a/lib/screens/settings/widgets/seerr_connection_dialog.dart
+++ b/lib/screens/settings/widgets/seerr_connection_dialog.dart
@@ -173,25 +173,16 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
       return false;
     }
 
-    String serverUrl;
-    final hasScheme = rawUrl.startsWith('http://') || rawUrl.startsWith('https://');
-    if (!hasScheme) {
-      // Probe https first, then http
-      final httpsUrl = normalizeUrl('https://$rawUrl');
-      final httpUrl = normalizeUrl('http://$rawUrl');
-      final result = await probeSeerrUrl(httpsUrl) ?? await probeSeerrUrl(httpUrl);
-      if (result == null) {
-        if (showError && mounted) {
-          setState(() {
-            error = context.localized.seerrEnterServerUrlFirst;
-          });
-        }
-        return false;
+    final result = await probeAndNormalizeSeerrUrl(rawUrl);
+    if (result == null) {
+      if (showError && mounted) {
+        setState(() {
+          error = context.localized.seerrEnterServerUrlFirst;
+        });
       }
-      serverUrl = result;
-    } else {
-      serverUrl = normalizeUrl(rawUrl);
+      return false;
     }
+    final serverUrl = result;
 
     if (serverUrl != rawUrl) {
       serverController.text = serverUrl;

--- a/lib/screens/settings/widgets/seerr_connection_dialog.dart
+++ b/lib/screens/settings/widgets/seerr_connection_dialog.dart
@@ -168,6 +168,7 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
   }
 
   Future<bool> _applyServerUrl({bool showError = true}) async {
+    warning = null;
     final rawUrl = serverController.text.trim();
     if (rawUrl.isEmpty) {
       if (showError && mounted) {

--- a/lib/screens/settings/widgets/seerr_connection_dialog.dart
+++ b/lib/screens/settings/widgets/seerr_connection_dialog.dart
@@ -412,7 +412,7 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
           enabled: !_hasPresetSeerrBaseUrl,
           onSubmitted: (_) async {
             await _applyServerUrl();
-            _refreshSession();
+            await _refreshSession();
           },
         ),
         const SizedBox(height: 8),

--- a/lib/screens/settings/widgets/seerr_connection_dialog.dart
+++ b/lib/screens/settings/widgets/seerr_connection_dialog.dart
@@ -9,6 +9,7 @@ import 'package:fladder/providers/seerr_api_provider.dart';
 import 'package:fladder/providers/seerr_dashboard_provider.dart';
 import 'package:fladder/providers/seerr_user_provider.dart';
 import 'package:fladder/providers/user_provider.dart';
+import 'package:fladder/screens/settings/widgets/settings_message_box.dart';
 import 'package:fladder/screens/shared/adaptive_dialog.dart';
 import 'package:fladder/screens/shared/animated_fade_size.dart';
 import 'package:fladder/screens/shared/fladder_notification_overlay.dart';
@@ -61,6 +62,7 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
   bool loading = true;
   bool processing = false;
   String? error;
+  String? warning;
   String? _lastProbedUrl;
 
   bool get _hasPresetSeerrBaseUrl => FladderConfig.seerrBaseUrl?.isNotEmpty == true;
@@ -184,6 +186,10 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
 
     if (!mounted) return false;
 
+    if (result == null && !hasHttpScheme(rawUrl)) {
+      warning = context.localized.seerrUrlSchemeWarning;
+    }
+
     if (serverUrl != rawUrl) {
       serverController.text = serverUrl;
     }
@@ -195,6 +201,7 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
     setState(() {
       processing = true;
       error = null;
+      warning = null;
     });
     if (!await _applyServerUrl()) {
       if (mounted) setState(() => processing = false);
@@ -368,6 +375,7 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
       spacing: 12,
       children: [
         if (error != null) _errorBanner(),
+        if (warning != null) SettingsMessageBox(warning!, messageType: MessageType.warning),
         if (serverUrl.isNotEmpty)
           Flexible(
             child: Text(
@@ -409,6 +417,7 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
       spacing: 12,
       children: [
         if (error != null) _errorBanner(),
+        if (warning != null) SettingsMessageBox(warning!, messageType: MessageType.warning),
         FocusedOutlinedTextField(
           label: context.localized.seerrServer,
           controller: serverController,

--- a/lib/screens/settings/widgets/seerr_connection_dialog.dart
+++ b/lib/screens/settings/widgets/seerr_connection_dialog.dart
@@ -61,6 +61,7 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
   bool loading = true;
   bool processing = false;
   String? error;
+  String? _lastProbedUrl;
 
   bool get _hasPresetSeerrBaseUrl => FladderConfig.seerrBaseUrl?.isNotEmpty == true;
 
@@ -175,6 +176,8 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
       return false;
     }
 
+    if (rawUrl == _lastProbedUrl) return true;
+
     final result = await probeAndNormalizeUrl(rawUrl, probeSeerrUrl);
     if (result == null) {
       if (showError && mounted) {
@@ -185,6 +188,7 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
       return false;
     }
     final serverUrl = result;
+    _lastProbedUrl = serverUrl;
 
     if (!mounted) return false;
 
@@ -420,6 +424,7 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
           textInputAction: TextInputAction.next,
           enabled: !_hasPresetSeerrBaseUrl,
           onSubmitted: (_) async {
+            _lastProbedUrl = null;
             await _applyServerUrl();
             await _refreshSession();
           },

--- a/lib/screens/settings/widgets/seerr_connection_dialog.dart
+++ b/lib/screens/settings/widgets/seerr_connection_dialog.dart
@@ -20,7 +20,11 @@ import 'package:fladder/util/fladder_config.dart';
 import 'package:fladder/util/localization_helper.dart';
 
 final _stackTracePattern = RegExp(r'\n#\d');
-String _sanitizeErrorMessage(Object error) => error.toString().split(_stackTracePattern).first.trim();
+String _sanitizeErrorMessage(Object error) {
+  final str = error.toString();
+  final match = _stackTracePattern.firstMatch(str);
+  return match != null ? str.substring(0, match.start).trim() : str;
+}
 
 Future<void> showSeerrConnectionDialog(BuildContext context) {
   return showDialogAdaptive(

--- a/lib/screens/settings/widgets/seerr_connection_dialog.dart
+++ b/lib/screens/settings/widgets/seerr_connection_dialog.dart
@@ -41,7 +41,8 @@ class SeerrConnectionDialog extends ConsumerStatefulWidget {
   const SeerrConnectionDialog({super.key});
 
   @override
-  ConsumerState<ConsumerStatefulWidget> createState() => _SeerrConnectionDialogState();
+  ConsumerState<ConsumerStatefulWidget> createState() =>
+      _SeerrConnectionDialogState();
 }
 
 class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
@@ -67,7 +68,8 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
     super.initState();
     final creds = ref.read(userProvider)?.seerrCredentials;
     apiKeyController = TextEditingController(text: creds?.apiKey ?? '');
-    serverController = TextEditingController(text: FladderConfig.seerrBaseUrl ?? creds?.serverUrl ?? '');
+    serverController = TextEditingController(
+        text: FladderConfig.seerrBaseUrl ?? creds?.serverUrl ?? '');
     localEmailController = TextEditingController();
     localPasswordController = TextEditingController();
     jfUsernameController = TextEditingController();
@@ -174,12 +176,14 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
     }
 
     String serverUrl;
-    final hasScheme = rawUrl.startsWith('http://') || rawUrl.startsWith('https://');
+    final hasScheme =
+        rawUrl.startsWith('http://') || rawUrl.startsWith('https://');
     if (!hasScheme) {
       // Probe https first, then http
       final httpsUrl = normalizeUrl('https://$rawUrl');
       final httpUrl = normalizeUrl('http://$rawUrl');
-      final result = await probeSeerrUrl(httpsUrl) ?? await probeSeerrUrl(httpUrl);
+      final result =
+          await probeSeerrUrl(httpsUrl) ?? await probeSeerrUrl(httpUrl);
       if (result == null) {
         if (showError && mounted) {
           setState(() {
@@ -347,7 +351,8 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
       ),
       child: Row(
         children: [
-          Icon(IconsaxPlusLinear.warning_2, color: Theme.of(context).colorScheme.onErrorContainer),
+          Icon(IconsaxPlusLinear.warning_2,
+              color: Theme.of(context).colorScheme.onErrorContainer),
           const SizedBox(width: 8),
           Expanded(
             child: Text(
@@ -364,8 +369,10 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
 
   Widget _loggedInContent() {
     final serverUrl = ref.read(userProvider)?.seerrCredentials?.serverUrl ?? '';
-    final displayName =
-        seerrUser?.displayName ?? seerrUser?.username ?? seerrUser?.email ?? context.localized.seerrUnknownUser;
+    final displayName = seerrUser?.displayName ??
+        seerrUser?.username ??
+        seerrUser?.email ??
+        context.localized.seerrUnknownUser;
     return Column(
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -383,7 +390,8 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
           spacing: 8,
           children: [
             seerrUser?.avatar != null && seerrUser!.avatar!.isNotEmpty
-                ? CircleAvatar(backgroundImage: NetworkImage(seerrUser!.avatar!))
+                ? CircleAvatar(
+                    backgroundImage: NetworkImage(seerrUser!.avatar!))
                 : CircleAvatar(child: Icon(FladderItemType.person.icon)),
             Column(
               crossAxisAlignment: CrossAxisAlignment.start,
@@ -524,7 +532,10 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
                 FilledButton(
                   onPressed: processing ? null : _useApiKey,
                   child: processing
-                      ? const SizedBox(width: 20, height: 20, child: CircularProgressIndicator())
+                      ? const SizedBox(
+                          width: 20,
+                          height: 20,
+                          child: CircularProgressIndicator())
                       : Text(context.localized.save),
                 ),
               ],
@@ -563,7 +574,10 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
                 FilledButton(
                   onPressed: processing ? null : _loginLocal,
                   child: processing
-                      ? const SizedBox(width: 20, height: 20, child: CircularProgressIndicator())
+                      ? const SizedBox(
+                          width: 20,
+                          height: 20,
+                          child: CircularProgressIndicator())
                       : Text(context.localized.login),
                 ),
               ],
@@ -601,7 +615,10 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
                 FilledButton(
                   onPressed: processing ? null : _loginJellyfin,
                   child: processing
-                      ? const SizedBox(width: 20, height: 20, child: CircularProgressIndicator())
+                      ? const SizedBox(
+                          width: 20,
+                          height: 20,
+                          child: CircularProgressIndicator())
                       : Text(context.localized.login),
                 ),
               ],
@@ -631,7 +648,9 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
                 child: CircularProgressIndicator(strokeCap: StrokeCap.round),
               )
             else
-              AnimatedFadeSize(child: seerrUser != null ? _loggedInContent() : _authContent()),
+              AnimatedFadeSize(
+                  child:
+                      seerrUser != null ? _loggedInContent() : _authContent()),
           ],
         ),
       ),

--- a/lib/screens/settings/widgets/seerr_connection_dialog.dart
+++ b/lib/screens/settings/widgets/seerr_connection_dialog.dart
@@ -184,6 +184,8 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
     }
     final serverUrl = result;
 
+    if (!mounted) return false;
+
     if (serverUrl != rawUrl) {
       serverController.text = serverUrl;
     }

--- a/lib/screens/settings/widgets/seerr_connection_dialog.dart
+++ b/lib/screens/settings/widgets/seerr_connection_dialog.dart
@@ -195,15 +195,20 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
     return true;
   }
 
-  Future<void> _useApiKey() async {
+  Future<bool> _beginProcessing() async {
     setState(() {
       processing = true;
       error = null;
     });
     if (!await _applyServerUrl()) {
       if (mounted) setState(() => processing = false);
-      return;
+      return false;
     }
+    return true;
+  }
+
+  Future<void> _useApiKey() async {
+    if (!await _beginProcessing()) return;
 
     final apiKey = apiKeyController.text.trim();
     ref.read(userProvider.notifier).setSeerrApiKey(apiKey);
@@ -226,14 +231,7 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
   }
 
   Future<void> _loginLocal() async {
-    setState(() {
-      processing = true;
-      error = null;
-    });
-    if (!await _applyServerUrl()) {
-      if (mounted) setState(() => processing = false);
-      return;
-    }
+    if (!await _beginProcessing()) return;
 
     try {
       final cookie = await ref.read(seerrApiProvider).authenticateLocal(
@@ -264,14 +262,7 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
   }
 
   Future<void> _loginJellyfin() async {
-    setState(() {
-      processing = true;
-      error = null;
-    });
-    if (!await _applyServerUrl()) {
-      if (mounted) setState(() => processing = false);
-      return;
-    }
+    if (!await _beginProcessing()) return;
 
     try {
       final cookie = await ref.read(seerrApiProvider).authenticateJellyfin(

--- a/lib/screens/settings/widgets/seerr_connection_dialog.dart
+++ b/lib/screens/settings/widgets/seerr_connection_dialog.dart
@@ -192,11 +192,14 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
   }
 
   Future<void> _useApiKey() async {
-    if (!await _applyServerUrl()) return;
     setState(() {
       processing = true;
       error = null;
     });
+    if (!await _applyServerUrl()) {
+      if (mounted) setState(() => processing = false);
+      return;
+    }
 
     final apiKey = apiKeyController.text.trim();
     ref.read(userProvider.notifier).setSeerrApiKey(apiKey);
@@ -219,11 +222,14 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
   }
 
   Future<void> _loginLocal() async {
-    if (!await _applyServerUrl()) return;
     setState(() {
       processing = true;
       error = null;
     });
+    if (!await _applyServerUrl()) {
+      if (mounted) setState(() => processing = false);
+      return;
+    }
 
     try {
       final cookie = await ref.read(seerrApiProvider).authenticateLocal(
@@ -253,11 +259,14 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
   }
 
   Future<void> _loginJellyfin() async {
-    if (!await _applyServerUrl()) return;
     setState(() {
       processing = true;
       error = null;
     });
+    if (!await _applyServerUrl()) {
+      if (mounted) setState(() => processing = false);
+      return;
+    }
 
     try {
       final cookie = await ref.read(seerrApiProvider).authenticateJellyfin(

--- a/lib/screens/settings/widgets/seerr_connection_dialog.dart
+++ b/lib/screens/settings/widgets/seerr_connection_dialog.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:iconsax_plus/iconsax_plus.dart';
 
 import 'package:fladder/models/item_base_model.dart';
+import 'package:fladder/providers/api_provider.dart';
 import 'package:fladder/providers/seerr_api_provider.dart';
 import 'package:fladder/providers/seerr_dashboard_provider.dart';
 import 'package:fladder/providers/seerr_user_provider.dart';
@@ -161,9 +162,9 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
     }
   }
 
-  bool _applyServerUrl({bool showError = true}) {
-    final serverUrl = serverController.text.trim();
-    if (serverUrl.isEmpty) {
+  Future<bool> _applyServerUrl({bool showError = true}) async {
+    final rawUrl = serverController.text.trim();
+    if (rawUrl.isEmpty) {
       if (showError && mounted) {
         setState(() {
           error = context.localized.seerrEnterServerUrlFirst;
@@ -171,12 +172,36 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
       }
       return false;
     }
+
+    String serverUrl;
+    final hasScheme = rawUrl.startsWith('http://') || rawUrl.startsWith('https://');
+    if (!hasScheme) {
+      // Probe https first, then http
+      final httpsUrl = normalizeUrl('https://$rawUrl');
+      final httpUrl = normalizeUrl('http://$rawUrl');
+      final result = await probeSeerrUrl(httpsUrl) ?? await probeSeerrUrl(httpUrl);
+      if (result == null) {
+        if (showError && mounted) {
+          setState(() {
+            error = context.localized.seerrEnterServerUrlFirst;
+          });
+        }
+        return false;
+      }
+      serverUrl = result;
+    } else {
+      serverUrl = normalizeUrl(rawUrl);
+    }
+
+    if (serverUrl != rawUrl) {
+      serverController.text = serverUrl;
+    }
     ref.read(userProvider.notifier).setSeerrServerUrl(serverUrl);
     return true;
   }
 
   Future<void> _useApiKey() async {
-    if (!_applyServerUrl()) return;
+    if (!await _applyServerUrl()) return;
     setState(() {
       processing = true;
       error = null;
@@ -203,7 +228,7 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
   }
 
   Future<void> _loginLocal() async {
-    if (!_applyServerUrl()) return;
+    if (!await _applyServerUrl()) return;
     setState(() {
       processing = true;
       error = null;
@@ -237,7 +262,7 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
   }
 
   Future<void> _loginJellyfin() async {
-    if (!_applyServerUrl()) return;
+    if (!await _applyServerUrl()) return;
     setState(() {
       processing = true;
       error = null;
@@ -271,7 +296,7 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
   }
 
   Future<void> _logout() async {
-    _applyServerUrl(showError: false);
+    await _applyServerUrl(showError: false);
     setState(() {
       processing = true;
       error = null;
@@ -394,8 +419,8 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
           keyboardType: TextInputType.url,
           textInputAction: TextInputAction.next,
           enabled: !_hasPresetSeerrBaseUrl,
-          onSubmitted: (_) {
-            _applyServerUrl();
+          onSubmitted: (_) async {
+            await _applyServerUrl();
             _refreshSession();
           },
         ),

--- a/lib/screens/settings/widgets/seerr_connection_dialog.dart
+++ b/lib/screens/settings/widgets/seerr_connection_dialog.dart
@@ -175,7 +175,7 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
       return false;
     }
 
-    final result = await probeAndNormalizeSeerrUrl(rawUrl);
+    final result = await probeAndNormalizeUrl(rawUrl, probeSeerrUrl);
     if (result == null) {
       if (showError && mounted) {
         setState(() {

--- a/lib/screens/settings/widgets/seerr_connection_dialog.dart
+++ b/lib/screens/settings/widgets/seerr_connection_dialog.dart
@@ -18,6 +18,8 @@ import 'package:fladder/seerr/seerr_models.dart';
 import 'package:fladder/util/fladder_config.dart';
 import 'package:fladder/util/localization_helper.dart';
 
+String _sanitizeErrorMessage(Object error) => error.toString().split(RegExp(r'\n#\d')).first.trim();
+
 Future<void> showSeerrConnectionDialog(BuildContext context) {
   return showDialogAdaptive(
     context: context,
@@ -247,7 +249,7 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
       }
     } catch (e) {
       if (mounted) {
-        final message = e.toString().split(RegExp(r'\n#\d')).first.trim();
+        final message = _sanitizeErrorMessage(e);
         error = message;
         FladderSnack.show(message, context: context);
       }
@@ -285,7 +287,7 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
       }
     } catch (e) {
       if (mounted) {
-        final message = e.toString().split(RegExp(r'\n#\d')).first.trim();
+        final message = _sanitizeErrorMessage(e);
         error = message;
         FladderSnack.show(message, context: context);
       }
@@ -310,7 +312,7 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
       await ref.read(seerrApiProvider).logout();
     } catch (e) {
       if (mounted) {
-        final message = e.toString().split(RegExp(r'\n#\d')).first.trim();
+        final message = _sanitizeErrorMessage(e);
         error = message;
         FladderSnack.show(message, context: context);
       }

--- a/lib/screens/settings/widgets/seerr_connection_dialog.dart
+++ b/lib/screens/settings/widgets/seerr_connection_dialog.dart
@@ -171,12 +171,12 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
     }
   }
 
-  Future<bool> _applyServerUrl({bool showError = true}) async {
+  Future<bool> _applyServerUrl() async {
     warning = null;
     error = null;
     final rawUrl = serverController.text.trim();
     if (rawUrl.isEmpty) {
-      if (showError && mounted) {
+      if (mounted) {
         setState(() {
           error = context.localized.seerrEnterServerUrlFirst;
         });

--- a/lib/screens/settings/widgets/seerr_connection_dialog.dart
+++ b/lib/screens/settings/widgets/seerr_connection_dialog.dart
@@ -177,7 +177,7 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
     if (result == null) {
       if (showError && mounted) {
         setState(() {
-          error = context.localized.seerrEnterServerUrlFirst;
+          error = context.localized.unableToConnectHost;
         });
       }
       return false;

--- a/lib/screens/settings/widgets/seerr_connection_dialog.dart
+++ b/lib/screens/settings/widgets/seerr_connection_dialog.dart
@@ -63,7 +63,6 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
   bool processing = false;
   String? error;
   String? warning;
-  String? _lastProbedUrl;
 
   bool get _hasPresetSeerrBaseUrl => FladderConfig.seerrBaseUrl?.isNotEmpty == true;
 
@@ -178,11 +177,8 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
       return false;
     }
 
-    if (rawUrl == _lastProbedUrl) return true;
-
     final result = await probeAndNormalizeUrl(rawUrl, probeSeerrUrl);
     final serverUrl = result ?? normalizeUrl('https://$rawUrl');
-    _lastProbedUrl = serverUrl;
 
     if (!mounted) return false;
 
@@ -425,7 +421,6 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
           textInputAction: TextInputAction.next,
           enabled: !_hasPresetSeerrBaseUrl,
           onSubmitted: (_) async {
-            _lastProbedUrl = null;
             await _applyServerUrl();
             await _refreshSession();
           },

--- a/lib/screens/settings/widgets/seerr_connection_dialog.dart
+++ b/lib/screens/settings/widgets/seerr_connection_dialog.dart
@@ -19,7 +19,8 @@ import 'package:fladder/seerr/seerr_models.dart';
 import 'package:fladder/util/fladder_config.dart';
 import 'package:fladder/util/localization_helper.dart';
 
-String _sanitizeErrorMessage(Object error) => error.toString().split(RegExp(r'\n#\d')).first.trim();
+final _stackTracePattern = RegExp(r'\n#\d');
+String _sanitizeErrorMessage(Object error) => error.toString().split(_stackTracePattern).first.trim();
 
 Future<void> showSeerrConnectionDialog(BuildContext context) {
   return showDialogAdaptive(

--- a/lib/screens/settings/widgets/seerr_connection_dialog.dart
+++ b/lib/screens/settings/widgets/seerr_connection_dialog.dart
@@ -300,6 +300,7 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
     setState(() {
       processing = true;
       error = null;
+      warning = null;
     });
 
     try {

--- a/lib/screens/shared/file_picker.dart
+++ b/lib/screens/shared/file_picker.dart
@@ -1,5 +1,6 @@
 import 'package:desktop_drop/desktop_drop.dart';
 import 'package:iconsax_plus/iconsax_plus.dart';
+import 'package:fladder/providers/api_provider.dart';
 import 'package:fladder/screens/shared/outlined_text_field.dart';
 import 'package:fladder/util/adaptive_layout/adaptive_layout.dart';
 import 'package:flutter/foundation.dart';
@@ -191,7 +192,7 @@ bool _parseUrl(String url) {
     return false;
   }
 
-  if (!url.startsWith('https://') && !url.startsWith('http://')) {
+  if (!hasHttpScheme(url)) {
     return false;
   }
   return true;


### PR DESCRIPTION
## Pull Request Description

- ~~- When users enter a server URL without _http://_ or _https://_, the app now probes _https_ first and falls back to _http_ instead of failing silently.~~
- When users enter a server **URL without** _http://_ or _https://_, the app now probes _https_ and _http_ **parallel**.
- Falls back to _https_ when **both probes** failed. (Seerr: also shows a short info box that probing failed. Not needed for Jellyfin)
- Applies to **Jellyfin login**, **Seerr login** (at _Settings_ --> _Profile_), and the **_Advanced_ modal** at login screen.
- This feature was part of PR #812

## Testing Build
```
ghcr.io/v3djg6gl/fladder:test-auto-url-scheme
```

## Issue Being Fixed

N/A

## Screenshots / Recordings

N/A

## Notes
### AI Disclosure
*Developed with assistance from Claude Code (Opus 4.6). The AI helped me identify the related files, code parts and proposed possible code modifications and fixes.*
*I've manually reviewed, cleaned, refactored and hardened the code the best I could, but since my Dart capabilities are not that good, I see this PR more as a proposal/idea.*
***A Proper code review is required in any case...***

## Checklist

- [ ] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [ ] Check that any changes are related to the issue at hand.
