### PR TITLE
docs: Update metadata license to GPL-3.0-only

### DIFF
--- a/flatpak/nl.jknaapen.fladder.metainfo.xml
+++ b/flatpak/nl.jknaapen.fladder.metainfo.xml
@@ -2,7 +2,7 @@
 <component type="desktop-application">
   <id>nl.jknaapen.fladder</id>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>MPL-2.0</project_license>
+  <project_license>GPL-3.0-only</project_license>
   <name>Fladder</name>
   <summary>A cross-platform Jellyfin client</summary>
   
@@ -61,7 +61,7 @@
   </content_rating>
   
   <releases>
-    <release version="0.9.0" date="2026-01-05">
+    <release version="0.10.2" date="2026-01-05">
       <description>
         <p>Latest release - see GitHub for detailed changelog</p>
       </description>


### PR DESCRIPTION
## Pull Request Description

This pull request updates the Flatpak metadata for the Fladder application. The most important changes are a license update and a new release version.


* Changed the `project_license` in `nl.jknaapen.fladder.metainfo.xml` from `MPL-2.0` to `GPL-3.0-only`. (Sorry did it incorrect last time)

* Updated the release version from `0.9.0` to `0.10.2` in `nl.jknaapen.fladder.metainfo.xml`.

## Checklist

- [ ] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [ ] Check that any changes are related to the issue at hand.
