### PR TITLE
fix: Seerr login button disabled when SEERR_BASE_URL (and/or SEERR_HEADER)* is set

### DIFF
--- a/lib/screens/settings/widgets/seerr_connection_dialog.dart
+++ b/lib/screens/settings/widgets/seerr_connection_dialog.dart
@@ -61,7 +61,6 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
 
   bool get _hasPresetSeerrBaseUrl => FladderConfig.seerrBaseUrl?.isNotEmpty == true;
   bool get _hasPresetSeerrHeader => FladderConfig.seerrHeader?.isNotEmpty == true;
-  bool get _disableAuthActions => _hasPresetSeerrBaseUrl || _hasPresetSeerrHeader;
 
   @override
   void initState() {
@@ -178,7 +177,6 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
   }
 
   Future<void> _useApiKey() async {
-    if (_disableAuthActions) return;
     if (!_applyServerUrl()) return;
     setState(() {
       processing = true;
@@ -206,7 +204,6 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
   }
 
   Future<void> _loginLocal() async {
-    if (_disableAuthActions) return;
     if (!_applyServerUrl()) return;
     setState(() {
       processing = true;
@@ -241,7 +238,6 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
   }
 
   Future<void> _loginJellyfin() async {
-    if (_disableAuthActions) return;
     if (!_applyServerUrl()) return;
     setState(() {
       processing = true;
@@ -505,7 +501,7 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
               mainAxisAlignment: MainAxisAlignment.end,
               children: [
                 FilledButton(
-                  onPressed: (processing || _disableAuthActions) ? null : _useApiKey,
+                  onPressed: processing ? null : _useApiKey,
                   child: processing
                       ? const SizedBox(width: 20, height: 20, child: CircularProgressIndicator())
                       : Text(context.localized.save),
@@ -544,7 +540,7 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
               mainAxisAlignment: MainAxisAlignment.end,
               children: [
                 FilledButton(
-                  onPressed: (processing || _disableAuthActions) ? null : _loginLocal,
+                  onPressed: processing ? null : _loginLocal,
                   child: processing
                       ? const SizedBox(width: 20, height: 20, child: CircularProgressIndicator())
                       : Text(context.localized.login),
@@ -582,7 +578,7 @@ class _SeerrConnectionDialogState extends ConsumerState<SeerrConnectionDialog> {
               mainAxisAlignment: MainAxisAlignment.end,
               children: [
                 FilledButton(
-                  onPressed: (processing || _disableAuthActions) ? null : _loginJellyfin,
+                  onPressed: processing ? null : _loginJellyfin,
                   child: processing
                       ? const SizedBox(width: 20, height: 20, child: CircularProgressIndicator())
                       : Text(context.localized.login),


### PR DESCRIPTION
## Pull Request Description
- This PR fixes a bug where ENV `SEERR_BASE_URL` (and/or `SEERR_HEADER`)* is set. If one or both* ENVs are set, it will disable Seerr _Log In_ button.
- Removes the `_disableAuthActions` guard that was blocking `_useApiKey`, `_loginLocal`, and `_loginJellyfin` when preset ENV vars were set.
- The Preset ENV vars should pre-fill the server URL but still allow the user to Log in with their Seerr Credentials/API Key

## Testing Build
```
ghcr.io/v3djg6gl/fladder:test-fix-seerr-preset-login 
```

## Issue Being Fixed
- https://github.com/DonutWare/Fladder/issues/832

## Screenshots / Recordings

N/A

## Notes
### *
*Setting `SEERR_HEADER` never disabled the `Log In` button in my testings. I suppose it's bc the parsing issues I menationed here: https://github.com/DonutWare/Fladder/pull/817#pullrequestreview-3922268968*
### AI Disclosure
*Developed with assistance from Claude Code (Opus 4.6). The AI helped me identify the related files, code parts and proposed possible code modifications and fixes.*
*I've manually reviewed, cleaned, refactored and hardened the code the best I could, but since my Dart capabilities are not that good, I see this PR more as a proposal/idea.*
***A Proper code review is required in any case...***

## Checklist

- [ ] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [ ] Check that any changes are related to the issue at hand.