### PR TITLE
fix: remove eac3 from web direct play profile

### DIFF
--- a/lib/profiles/web_profile.dart
+++ b/lib/profiles/web_profile.dart
@@ -9,7 +9,7 @@ const DeviceProfile webProfile = DeviceProfile(
       container: 'mkv,webm',
       type: DlnaProfileType.video,
       videoCodec: 'h264,hevc,vp8,vp9,av1',
-      audioCodec: 'vorbis,opus,aac,eac3',
+      audioCodec: 'vorbis,opus,aac',
     ),
     DirectPlayProfile(
       container: 'mp4,m4v',


### PR DESCRIPTION
## Pull Request Description

The web profile lists `eac3` as a supported direct-play audio codec for mkv/webm containers. Most browsers (Chrome, Firefox) cannot decode EAC3 (Dolby Digital Plus / Atmos) — only Safari and Edge support it via platform media frameworks.

This causes silent audio when playing MKV files with EAC3/DDP Atmos audio tracks in the web build. Jellyfin sees `eac3` in the device profile, attempts direct play, and the browser silently fails to decode the audio stream.

Removing `eac3` from the web `DirectPlayProfile` causes Jellyfin to fall through to the `TranscodingProfile`, which transcodes audio to AAC — universally supported. Video with AAC/Opus/Vorbis audio is unaffected and continues to direct play.