### PR TITLE
fix: Remove close delay on Linux

### DIFF
--- a/lib/bootstrap/platform/desktop_platform_wrapper.dart
+++ b/lib/bootstrap/platform/desktop_platform_wrapper.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'package:flutter/foundation.dart';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -46,6 +47,10 @@ class _DesktopAppWrapperState extends BaseAppWrapperState<DesktopAppWrapper> wit
       clientSettings,
       packageInfo,
     );
+
+    if (defaultTargetPlatform == TargetPlatform.linux) {
+      await windowManager.setPreventClose(true);
+    }
   }
 
   @override
@@ -55,10 +60,14 @@ class _DesktopAppWrapperState extends BaseAppWrapperState<DesktopAppWrapper> wit
   }
 
   @override
-  void onWindowClose() {
+  void onWindowClose() async {
     ref.read(videoPlayerProvider).stop();
     ref.read(clientSettingsProvider.notifier).closeDirectory();
     super.onWindowClose();
+
+    if (defaultTargetPlatform == TargetPlatform.linux) {
+      exit(0);
+    }
   }
 
   @override


### PR DESCRIPTION
## Pull Request Description

This pull request introduces platform-specific enhancements for Linux in the `desktop_platform_wrapper.dart` file. The changes ensure improved application shutdown behavior when running on Linux.

Platform-specific Linux improvements:

* Added logic in `_DesktopAppWrapperState.initPlatform()` to prevent the window from closing automatically on Linux by calling `windowManager.setPreventClose(true)`.
* Modified `_DesktopAppWrapperState.onWindowClose()` to explicitly exit the application using `exit(0)` when running on Linux, ensuring a clean shutdown.

## Issue Being Fixed

Previously on Linux, especially on Wayland with Nvidia GPU, it would take the app around 5-10 seconds to close as it hangs.

This PR provides a fix for that and makes the app close instantly by taking manual control of the cleanup ourselves.

This was the error when closing:

```sh
(Fladder:29862): Gdk-WARNING **: 20:24:37.493: eglMakeCurrent failed
Fladder: ../src/dispatch_common.c:885: epoxy_get_proc_address: Assertion `0 && "Couldn't find current GLX or EGL context.\n"' failed.
Lost connection to device.
```

## Checklist

- [ ] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [ ] Check that any changes are related to the issue at hand.
