### PR TITLE
fix: Android native player trickplay incorrect offsetting

### DIFF
--- a/android/app/src/main/kotlin/nl/jknaapen/fladder/composables/controls/TrickplayOverlay.kt
+++ b/android/app/src/main/kotlin/nl/jknaapen/fladder/composables/controls/TrickplayOverlay.kt
@@ -161,7 +161,7 @@ private fun Thumbnail(
 
     Box(
         modifier = modifier
-            .aspectRatio(16f / 9f)
+            .aspectRatio(trickPlayModel.width.toFloat() / trickPlayModel.height)
             .clip(
                 shape = RoundedCornerShape(12.dp)
             )

--- a/android/app/src/main/kotlin/nl/jknaapen/fladder/composables/controls/TrickplayOverlay.kt
+++ b/android/app/src/main/kotlin/nl/jknaapen/fladder/composables/controls/TrickplayOverlay.kt
@@ -29,6 +29,7 @@ import coil3.compose.rememberAsyncImagePainter
 import coil3.imageLoader
 import coil3.request.ImageRequest
 import coil3.toBitmap
+import kotlin.math.roundToInt
 import kotlin.time.Duration
 
 private data class ThumbnailData(val tileUrl: String, val offset: Pair<Double, Double>)
@@ -156,6 +157,7 @@ private fun Thumbnail(
             .build()
     )
     val imageState by painter.state.collectAsState()
+    val trickPlayTotalWidth = (trickPlayModel.width * trickPlayModel.tileWidth).toFloat()
 
     Box(
         modifier = modifier
@@ -167,15 +169,18 @@ private fun Thumbnail(
         when (val state = imageState) {
             is AsyncImagePainter.State.Success -> {
                 val imageBitmap = state.result.image.toBitmap().asImageBitmap()
+
+                val trickPlayScalingFactor = state.result.image.width.toFloat() / trickPlayTotalWidth
+
+                val offsetX = (offset.first * trickPlayScalingFactor).roundToInt()
+                val offsetY = (offset.second * trickPlayScalingFactor).roundToInt()
+                val scaledWidth = (trickPlayModel.width * trickPlayScalingFactor).roundToInt()
+                val scaledHeight = (trickPlayModel.height * trickPlayScalingFactor).roundToInt()
                 Canvas(modifier = Modifier.matchParentSize()) {
-                    val (offsetX, offsetY) = offset
                     drawImage(
                         image = imageBitmap,
-                        srcOffset = IntOffset(offsetX.toInt(), offsetY.toInt()),
-                        srcSize = IntSize(
-                            trickPlayModel.width.toInt(),
-                            trickPlayModel.height.toInt()
-                        ),
+                        srcOffset = IntOffset(offsetX, offsetY),
+                        srcSize = IntSize(scaledWidth, scaledHeight),
                         dstSize = IntSize(size.width.toInt(), size.height.toInt())
                     )
                 }


### PR DESCRIPTION
## Pull Request Description

Due to a maximum texture size set by Coil (4096 pixels in either dimension on my phone), my trickplay tiles were being downscaled to 4096, without the `trickPlayModel` knowing about it, causing some incorrect display on the timeline. This PR rescales the display offset and size to match this downscaled bitmap.

Also fixed trickplay images being stretched (ugly) when the images are not 16:9, which is true in many movies especially.

## Checklist

- [x] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [x] Check that any changes are related to the issue at hand.
