### PR TITLE
fix: Android native player's chapter markers turn into huge circles when seeking

### DIFF
--- a/android/app/src/main/kotlin/nl/jknaapen/fladder/composables/controls/ProgressBar.kt
+++ b/android/app/src/main/kotlin/nl/jknaapen/fladder/composables/controls/ProgressBar.kt
@@ -566,6 +566,10 @@ internal fun RowScope.SimpleProgressBar(
                 val durMs = effectiveDuration.toDouble().coerceAtLeast(1.0)
                 val startPx = (width * (segStartMs / durMs)).toFloat()
 
+                val animatedChapterCircleHeight by animateDpAsState(
+                    if (thumbFocused) 1.dp else 6.dp,
+                    label = "Chapter height"
+                )
 
                 Box(
                     modifier = Modifier
@@ -575,12 +579,11 @@ internal fun RowScope.SimpleProgressBar(
                         .graphicsLayer {
                             translationX = startPx
                         }
-                        .padding(vertical = 0.5.dp)
-                        .fillMaxHeight()
-                        .aspectRatio(ratio = 1f)
+                        .width(6.dp)
+                        .height(animatedChapterCircleHeight)
                         .background(
                             color = if (isAfterCurrentPositon) Color.White.copy(
-                                alpha = 0.15f
+                                alpha = 0.25f
                             ) else MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.7f),
                             shape = CircleShape
                         )


### PR DESCRIPTION
## Pull Request Description

Screenshots explain better, the PR makes the chapter markers similar to the thumb when seeking, making it more uniform (also upped the opacity on upcoming chapter markers, they were hardly visible before).

## Screenshots / Recordings

### Before:
<img width="2712" height="1220" alt="image" src="https://github.com/user-attachments/assets/1b42a903-7a7f-4762-815b-0ad6237b9d70" />

### After:
<img width="2712" height="1220" alt="image" src="https://github.com/user-attachments/assets/99fd9dbe-9a7d-4da4-8983-11de659513b5" />