### PR TITLE
feat(player): add customizable aspect ratio override

### DIFF
--- a/lib/models/settings/client_settings_model.dart
+++ b/lib/models/settings/client_settings_model.dart
@@ -108,7 +108,7 @@ abstract class ClientSettingsModel with _$ClientSettingsModel {
   }
 
   Future<String?> getSavePath() async {
-    if (kIsWeb && syncPath == null) return null;
+    if (kIsWeb) return syncPath;
     if (Platform.isMacOS) {
       return await DirectoryBookmark().resolveDirectory(syncPathKey);
     }

--- a/lib/providers/settings/video_player_settings_provider.dart
+++ b/lib/providers/settings/video_player_settings_provider.dart
@@ -5,6 +5,8 @@ import 'package:collection/collection.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:screen_brightness/screen_brightness.dart';
 
+import 'package:fladder/models/item_base_model.dart';
+import 'package:fladder/models/items/episode_model.dart';
 import 'package:fladder/models/settings/key_combinations.dart';
 import 'package:fladder/models/settings/video_player_settings.dart';
 import 'package:fladder/providers/shared_provider.dart';
@@ -17,6 +19,7 @@ final videoPlayerSettingsProvider =
 
 final playbackRateProvider = StateProvider<double>((ref) => 1.0);
 final forcedAspectRatioProvider = StateProvider<double?>((ref) => null);
+final forcedAspectRatioOverridesProvider = StateProvider<Map<String, double>>((ref) => const {});
 
 class VideoPlayerSettingsProviderNotifier extends StateNotifier<VideoPlayerSettingsModel> {
   VideoPlayerSettingsProviderNotifier(this.ref) : super(VideoPlayerSettingsModel());
@@ -140,4 +143,42 @@ class VideoPlayerSettingsProviderNotifier extends StateNotifier<VideoPlayerSetti
   void setEnableAdvancedVideoOptions(bool value) => state = state.copyWith(enableAdvancedVideoOptions: value);
 
   void setForcedAspectRatio(double? value) => ref.read(forcedAspectRatioProvider.notifier).state = value;
+
+  String _overrideKeyForItem(ItemBaseModel? item) {
+    if (item == null) return '';
+    if (item is EpisodeModel && (item.parentId?.isNotEmpty == true)) {
+      return item.parentId!;
+    }
+    return item.id;
+  }
+
+  void loadPersistedAspectRatioOverrides() {
+    final overrides = ref.read(sharedUtilityProvider).videoAspectRatioOverrides;
+    ref.read(forcedAspectRatioOverridesProvider.notifier).state = overrides;
+  }
+
+  void applyForcedAspectRatioForItem(ItemBaseModel? item) {
+    final key = _overrideKeyForItem(item);
+    final overrides = ref.read(forcedAspectRatioOverridesProvider);
+    ref.read(forcedAspectRatioProvider.notifier).state = key.isEmpty ? null : overrides[key];
+  }
+
+  void setForcedAspectRatioForItem(ItemBaseModel? item, double? value) {
+    final key = _overrideKeyForItem(item);
+    if (key.isEmpty) {
+      setForcedAspectRatio(value);
+      return;
+    }
+
+    final updated = Map<String, double>.from(ref.read(forcedAspectRatioOverridesProvider));
+    if (value == null) {
+      updated.remove(key);
+    } else {
+      updated[key] = value;
+    }
+
+    ref.read(forcedAspectRatioOverridesProvider.notifier).state = updated;
+    ref.read(sharedUtilityProvider).videoAspectRatioOverrides = updated;
+    ref.read(forcedAspectRatioProvider.notifier).state = value;
+  }
 }

--- a/lib/providers/settings/video_player_settings_provider.dart
+++ b/lib/providers/settings/video_player_settings_provider.dart
@@ -16,6 +16,7 @@ final videoPlayerSettingsProvider =
 });
 
 final playbackRateProvider = StateProvider<double>((ref) => 1.0);
+final forcedAspectRatioProvider = StateProvider<double?>((ref) => null);
 
 class VideoPlayerSettingsProviderNotifier extends StateNotifier<VideoPlayerSettingsModel> {
   VideoPlayerSettingsProviderNotifier(this.ref) : super(VideoPlayerSettingsModel());
@@ -137,4 +138,6 @@ class VideoPlayerSettingsProviderNotifier extends StateNotifier<VideoPlayerSetti
   void setEnableDoubleTapSeek(bool value) => state = state.copyWith(enableDoubleTapSeek: value);
 
   void setEnableAdvancedVideoOptions(bool value) => state = state.copyWith(enableAdvancedVideoOptions: value);
+
+  void setForcedAspectRatio(double? value) => ref.read(forcedAspectRatioProvider.notifier).state = value;
 }

--- a/lib/providers/shared_provider.dart
+++ b/lib/providers/shared_provider.dart
@@ -63,6 +63,7 @@ class SharedUtility extends SharedHelper {
       _ref.read(clientSettingsProvider.notifier).initialize(clientSettings);
       _ref.read(homeSettingsProvider.notifier).state = homeSettings;
       _ref.read(videoPlayerSettingsProvider.notifier).state = videoPlayerSettings;
+      _ref.read(videoPlayerSettingsProvider.notifier).loadPersistedAspectRatioOverrides();
       _ref.read(subtitleSettingsProvider.notifier).state = subtitleSettings;
       _ref.read(bookViewerSettingsProvider.notifier).state = bookViewSettings;
       _ref.read(photoViewSettingsProvider.notifier).state = photoViewSettings;
@@ -84,6 +85,7 @@ class SharedKeys {
   static const String _clientSettingsKey = 'clientSettings';
   static const String _homeSettingsKey = 'homeSettings';
   static const String _videoPlayerSettingsKey = 'videoPlayerSettings';
+  static const String _videoAspectRatioOverridesKey = 'videoAspectRatioOverrides';
   static const String _subtitleSettingsKey = 'subtitleSettings';
   static const String _bookViewSettingsKey = 'bookViewSettings';
   static const String _photoViewSettingsKey = 'photoViewSettings';
@@ -265,6 +267,22 @@ class SharedHelper {
 
   set videoPlayerSettings(VideoPlayerSettingsModel settings) {
     sharedPreferences.setString(SharedKeys._videoPlayerSettingsKey, jsonEncode(settings.toJson()));
+  }
+
+  Map<String, double> get videoAspectRatioOverrides {
+    try {
+      final raw = sharedPreferences.getString(SharedKeys._videoAspectRatioOverridesKey);
+      if (raw == null || raw.isEmpty) return {};
+      final decoded = jsonDecode(raw) as Map<String, dynamic>;
+      return decoded.map((key, value) => MapEntry(key, (value as num).toDouble()));
+    } catch (e) {
+      log(e.toString());
+      return {};
+    }
+  }
+
+  set videoAspectRatioOverrides(Map<String, double> values) {
+    sharedPreferences.setString(SharedKeys._videoAspectRatioOverridesKey, jsonEncode(values));
   }
 
   PhotoViewSettingsModel get photoViewSettings {

--- a/lib/screens/video_player/components/video_player_options_sheet.dart
+++ b/lib/screens/video_player/components/video_player_options_sheet.dart
@@ -163,6 +163,11 @@ class _VideoOptionsMobileState extends ConsumerState<VideoOptions> {
               ],
             ),
           ),
+          SpacedListTile(
+            title: const Text("Aspect ratio override"),
+            content: Text(_aspectRatioLabel(videoSettings, ref)),
+            onTap: () => showAspectRatioOverride(context, ref),
+          ),
           if (!AdaptiveLayout.of(context).isDesktop)
             ListTile(
               onTap: () => ref.read(videoPlayerSettingsProvider.notifier).setFillScreen(!videoSettings.fillScreen),
@@ -379,6 +384,12 @@ class _VideoOptionsMobileState extends ConsumerState<VideoOptions> {
       ],
     );
   }
+
+  String _aspectRatioLabel(VideoPlayerSettingsModel settings, WidgetRef ref) {
+    final forcedAspectRatio = ref.watch(forcedAspectRatioProvider);
+    if (forcedAspectRatio == null) return context.localized.off;
+    return "${forcedAspectRatio.toStringAsFixed(2)}:1";
+  }
 }
 
 Future<void> showSubSelection(BuildContext context) {
@@ -588,4 +599,87 @@ Future<void> showOrientationOptions(BuildContext context, WidgetRef ref) async {
       });
     },
   );
+}
+
+Future<void> showAspectRatioOverride(BuildContext context, WidgetRef ref) async {
+  final current = ref.read(forcedAspectRatioProvider);
+  final controller = TextEditingController(
+    text: current == null ? '' : current.toStringAsFixed(2),
+  );
+  String? error;
+
+  await showDialog(
+    context: context,
+    builder: (context) {
+      return StatefulBuilder(
+        builder: (context, setState) => AlertDialog(
+          title: const Text("Aspect ratio override"),
+          content: SizedBox(
+            width: 360,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                TextField(
+                  controller: controller,
+                  autofocus: true,
+                  decoration: InputDecoration(
+                    hintText: "2:1, 21:9 or 2.35",
+                    errorText: error,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  "Leave empty to disable.",
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
+              ],
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () {
+                ref.read(videoPlayerSettingsProvider.notifier).setForcedAspectRatio(null);
+                Navigator.of(context).pop();
+              },
+              child: Text(context.localized.off),
+            ),
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: Text(context.localized.cancel),
+            ),
+            FilledButton(
+              onPressed: () {
+                final parsed = _parseAspectRatioInput(controller.text);
+                if (parsed == null) {
+                  setState(() => error = "Invalid ratio format");
+                  return;
+                }
+                ref.read(videoPlayerSettingsProvider.notifier).setForcedAspectRatio(parsed);
+                Navigator.of(context).pop();
+              },
+              child: Text(context.localized.save),
+            ),
+          ],
+        ),
+      );
+    },
+  );
+}
+
+double? _parseAspectRatioInput(String input) {
+  final text = input.trim().replaceAll(' ', '');
+  if (text.isEmpty) return null;
+
+  final colonOrSlash = RegExp(r'^([0-9]*\.?[0-9]+)[:/]([0-9]*\.?[0-9]+)$').firstMatch(text);
+  if (colonOrSlash != null) {
+    final width = double.tryParse(colonOrSlash.group(1)!);
+    final height = double.tryParse(colonOrSlash.group(2)!);
+    if (width == null || height == null || width <= 0 || height <= 0) return null;
+    return width / height;
+  }
+
+  final ratio = double.tryParse(text);
+  if (ratio == null || ratio <= 0) return null;
+  return ratio;
 }

--- a/lib/screens/video_player/components/video_player_options_sheet.dart
+++ b/lib/screens/video_player/components/video_player_options_sheet.dart
@@ -166,7 +166,7 @@ class _VideoOptionsMobileState extends ConsumerState<VideoOptions> {
           SpacedListTile(
             title: const Text("Aspect ratio override"),
             content: Text(_aspectRatioLabel(videoSettings, ref)),
-            onTap: () => showAspectRatioOverride(context, ref),
+            onTap: () => showAspectRatioOverride(context, ref, currentItem),
           ),
           if (!AdaptiveLayout.of(context).isDesktop)
             ListTile(
@@ -601,7 +601,7 @@ Future<void> showOrientationOptions(BuildContext context, WidgetRef ref) async {
   );
 }
 
-Future<void> showAspectRatioOverride(BuildContext context, WidgetRef ref) async {
+Future<void> showAspectRatioOverride(BuildContext context, WidgetRef ref, ItemBaseModel? currentItem) async {
   final current = ref.read(forcedAspectRatioProvider);
   final controller = TextEditingController(
     text: current == null ? '' : current.toStringAsFixed(2),
@@ -639,7 +639,7 @@ Future<void> showAspectRatioOverride(BuildContext context, WidgetRef ref) async 
           actions: [
             TextButton(
               onPressed: () {
-                ref.read(videoPlayerSettingsProvider.notifier).setForcedAspectRatio(null);
+                ref.read(videoPlayerSettingsProvider.notifier).setForcedAspectRatioForItem(currentItem, null);
                 Navigator.of(context).pop();
               },
               child: Text(context.localized.off),
@@ -655,7 +655,7 @@ Future<void> showAspectRatioOverride(BuildContext context, WidgetRef ref) async 
                   setState(() => error = "Invalid ratio format");
                   return;
                 }
-                ref.read(videoPlayerSettingsProvider.notifier).setForcedAspectRatio(parsed);
+                ref.read(videoPlayerSettingsProvider.notifier).setForcedAspectRatioForItem(currentItem, parsed);
                 Navigator.of(context).pop();
               },
               child: Text(context.localized.save),

--- a/lib/screens/video_player/video_player.dart
+++ b/lib/screens/video_player/video_player.dart
@@ -76,6 +76,7 @@ class _VideoPlayerState extends ConsumerState<VideoPlayer> with WidgetsBindingOb
   Widget build(BuildContext context) {
     final fillScreen = ref.watch(videoPlayerSettingsProvider.select((value) => value.fillScreen));
     final videoFit = ref.watch(videoPlayerSettingsProvider.select((value) => value.videoFit));
+    final forcedAspectRatio = ref.watch(forcedAspectRatioProvider);
     final padding = MediaQuery.of(context).padding;
 
     final playerController = ref.watch(videoPlayerProvider.select((value) => value));
@@ -108,6 +109,7 @@ class _VideoPlayerState extends ConsumerState<VideoPlayer> with WidgetsBindingOb
       child: playerController.videoWidget(
         const Key("VideoPlayer"),
         fillScreen ? (MediaQuery.of(context).orientation == Orientation.portrait ? videoFit : BoxFit.cover) : videoFit,
+        forcedAspectRatio: forcedAspectRatio,
       ),
     );
 

--- a/lib/screens/video_player/video_player.dart
+++ b/lib/screens/video_player/video_player.dart
@@ -68,6 +68,7 @@ class _VideoPlayerState extends ConsumerState<VideoPlayer> with WidgetsBindingOb
       final orientations = ref.read(videoPlayerSettingsProvider.select((value) => value.allowedOrientations));
       SystemChrome.setPreferredOrientations(
           orientations?.isNotEmpty == true ? orientations!.toList() : DeviceOrientation.values);
+      ref.read(videoPlayerSettingsProvider.notifier).applyForcedAspectRatioForItem(ref.read(playBackModel)?.item);
       return ref.read(videoPlayerSettingsProvider.notifier).setSavedBrightness();
     });
   }
@@ -86,6 +87,9 @@ class _VideoPlayerState extends ConsumerState<VideoPlayer> with WidgetsBindingOb
       playBackModel,
       (previous, next) {
         if (next == null) return;
+        if (previous?.item.id != next.item.id) {
+          ref.read(videoPlayerSettingsProvider.notifier).applyForcedAspectRatioForItem(next.item);
+        }
         if (previous.runtimeType != next.runtimeType) {
           setState(() {
             currentPlaybackModel = next;

--- a/lib/stubs/web/lib_mdk_web.dart
+++ b/lib/stubs/web/lib_mdk_web.dart
@@ -71,7 +71,7 @@ class LibMDK extends BasePlayer {
     Key key,
     BoxFit fit, {
       double? forcedAspectRatio,
-    }
+    },
   ) =>
       null;
 

--- a/lib/stubs/web/lib_mdk_web.dart
+++ b/lib/stubs/web/lib_mdk_web.dart
@@ -70,9 +70,8 @@ class LibMDK extends BasePlayer {
   Widget? videoWidget(
     Key key,
     BoxFit fit, {
-      double? forcedAspectRatio,
-    }
-  ) =>
+    double? forcedAspectRatio,
+  }) =>
       null;
 
   @override

--- a/lib/stubs/web/lib_mdk_web.dart
+++ b/lib/stubs/web/lib_mdk_web.dart
@@ -70,6 +70,9 @@ class LibMDK extends BasePlayer {
   Widget? videoWidget(
     Key key,
     BoxFit fit,
+    {
+      double? forcedAspectRatio,
+    }
   ) =>
       null;
 

--- a/lib/stubs/web/lib_mdk_web.dart
+++ b/lib/stubs/web/lib_mdk_web.dart
@@ -69,8 +69,7 @@ class LibMDK extends BasePlayer {
   @override
   Widget? videoWidget(
     Key key,
-    BoxFit fit,
-    {
+    BoxFit fit, {
       double? forcedAspectRatio,
     }
   ) =>

--- a/lib/stubs/web/lib_mdk_web.dart
+++ b/lib/stubs/web/lib_mdk_web.dart
@@ -71,7 +71,7 @@ class LibMDK extends BasePlayer {
     Key key,
     BoxFit fit, {
       double? forcedAspectRatio,
-    },
+    }
   ) =>
       null;
 

--- a/lib/wrappers/media_control_wrapper.dart
+++ b/lib/wrappers/media_control_wrapper.dart
@@ -49,7 +49,8 @@ class MediaControlsWrapper extends BaseAudioHandler implements VideoPlayerContro
 
   Widget? subtitleWidget(bool showOverlay, {GlobalKey? controlsKey}) =>
       _player?.subtitles(showOverlay, controlsKey: controlsKey);
-  Widget? videoWidget(Key key, BoxFit fit) => _player?.videoWidget(key, fit);
+  Widget? videoWidget(Key key, BoxFit fit, {double? forcedAspectRatio}) =>
+      _player?.videoWidget(key, fit, forcedAspectRatio: forcedAspectRatio);
 
   final Ref ref;
 

--- a/lib/wrappers/media_control_wrapper.dart
+++ b/lib/wrappers/media_control_wrapper.dart
@@ -132,7 +132,7 @@ class MediaControlsWrapper extends BaseAudioHandler implements VideoPlayerContro
   Future<void> openPlayer(BuildContext context) async => _player?.open(context);
 
   void _subscribePlayer() {
-    if (Platform.isWindows && !kIsWeb) {
+    if (!kIsWeb && Platform.isWindows) {
       smtc = SMTCWindows(
         config: const SMTCConfig(
           fastForwardEnabled: true,

--- a/lib/wrappers/players/base_player.dart
+++ b/lib/wrappers/players/base_player.dart
@@ -20,7 +20,7 @@ abstract class BasePlayer {
     Key key,
     BoxFit fit, {
       double? forcedAspectRatio,
-    }
+    },
   );
   Widget? subtitles(
     bool showOverlay, {

--- a/lib/wrappers/players/base_player.dart
+++ b/lib/wrappers/players/base_player.dart
@@ -20,7 +20,7 @@ abstract class BasePlayer {
     Key key,
     BoxFit fit, {
       double? forcedAspectRatio,
-    },
+    }
   );
   Widget? subtitles(
     bool showOverlay, {

--- a/lib/wrappers/players/base_player.dart
+++ b/lib/wrappers/players/base_player.dart
@@ -19,9 +19,8 @@ abstract class BasePlayer {
   Widget? videoWidget(
     Key key,
     BoxFit fit, {
-      double? forcedAspectRatio,
-    }
-  );
+    double? forcedAspectRatio,
+  });
   Widget? subtitles(
     bool showOverlay, {
     GlobalKey? controlsKey,

--- a/lib/wrappers/players/base_player.dart
+++ b/lib/wrappers/players/base_player.dart
@@ -18,8 +18,7 @@ abstract class BasePlayer {
   Future<void> init(VideoPlayerSettingsModel settings);
   Widget? videoWidget(
     Key key,
-    BoxFit fit,
-    {
+    BoxFit fit, {
       double? forcedAspectRatio,
     }
   );

--- a/lib/wrappers/players/base_player.dart
+++ b/lib/wrappers/players/base_player.dart
@@ -19,6 +19,9 @@ abstract class BasePlayer {
   Widget? videoWidget(
     Key key,
     BoxFit fit,
+    {
+      double? forcedAspectRatio,
+    }
   );
   Widget? subtitles(
     bool showOverlay, {

--- a/lib/wrappers/players/lib_mdk.dart
+++ b/lib/wrappers/players/lib_mdk.dart
@@ -208,8 +208,7 @@ class LibMDK extends BasePlayer {
   @override
   Widget? videoWidget(
     Key key,
-    BoxFit fit,
-    {
+    BoxFit fit, {
       double? forcedAspectRatio,
     }
   ) =>

--- a/lib/wrappers/players/lib_mdk.dart
+++ b/lib/wrappers/players/lib_mdk.dart
@@ -210,7 +210,7 @@ class LibMDK extends BasePlayer {
     Key key,
     BoxFit fit, {
       double? forcedAspectRatio,
-    }
+    },
   ) =>
       _controller == null
           ? null

--- a/lib/wrappers/players/lib_mdk.dart
+++ b/lib/wrappers/players/lib_mdk.dart
@@ -209,6 +209,9 @@ class LibMDK extends BasePlayer {
   Widget? videoWidget(
     Key key,
     BoxFit fit,
+    {
+      double? forcedAspectRatio,
+    }
   ) =>
       _controller == null
           ? null
@@ -219,24 +222,48 @@ class LibMDK extends BasePlayer {
                 builder: (context, constraints) => Stack(
                   fit: StackFit.expand,
                   children: [
-                    FittedBox(
-                      fit: fit,
-                      alignment: Alignment.center,
-                      child: ValueListenableBuilder<VideoPlayerValue>(
-                        valueListenable: _controller ?? ValueNotifier(const VideoPlayerValue.uninitialized()),
-                        builder: (context, value, child) {
-                          final aspectRatio = value.isInitialized ? value.aspectRatio : 1.77;
-                          final controller = _controller;
-                          if (controller == null) return const SizedBox.shrink();
-                          return SizedBox(
-                            width: constraints.maxWidth,
-                            child: AspectRatio(
-                              aspectRatio: aspectRatio,
-                              child: VideoPlayer(controller),
-                            ),
+                    ValueListenableBuilder<VideoPlayerValue>(
+                      valueListenable: _controller ?? ValueNotifier(const VideoPlayerValue.uninitialized()),
+                      builder: (context, value, child) {
+                        final sourceAspectRatio = value.isInitialized ? value.aspectRatio : 1.77;
+                        final controller = _controller;
+                        if (controller == null) return const SizedBox.shrink();
+
+                        final sourceVideo = SizedBox(
+                          width: constraints.maxWidth,
+                          child: AspectRatio(
+                            aspectRatio: sourceAspectRatio,
+                            child: VideoPlayer(controller),
+                          ),
+                        );
+
+                        if (forcedAspectRatio == null) {
+                          return FittedBox(
+                            fit: fit,
+                            alignment: Alignment.center,
+                            child: sourceVideo,
                           );
-                        },
-                      ),
+                        }
+
+                        return Center(
+                          child: ConstrainedBox(
+                            constraints: BoxConstraints(
+                              maxWidth: constraints.maxWidth,
+                              maxHeight: constraints.maxHeight,
+                            ),
+                            child: AspectRatio(
+                              aspectRatio: forcedAspectRatio,
+                              child: ClipRect(
+                                child: FittedBox(
+                                  fit: BoxFit.cover,
+                                  alignment: Alignment.center,
+                                  child: sourceVideo,
+                                ),
+                              ),
+                            ),
+                          ),
+                        );
+                      },
                     ),
                   ],
                 ),

--- a/lib/wrappers/players/lib_mdk.dart
+++ b/lib/wrappers/players/lib_mdk.dart
@@ -209,9 +209,8 @@ class LibMDK extends BasePlayer {
   Widget? videoWidget(
     Key key,
     BoxFit fit, {
-      double? forcedAspectRatio,
-    }
-  ) =>
+    double? forcedAspectRatio,
+  }) =>
       _controller == null
           ? null
           : Container(

--- a/lib/wrappers/players/lib_mdk.dart
+++ b/lib/wrappers/players/lib_mdk.dart
@@ -210,7 +210,7 @@ class LibMDK extends BasePlayer {
     Key key,
     BoxFit fit, {
       double? forcedAspectRatio,
-    },
+    }
   ) =>
       _controller == null
           ? null

--- a/lib/wrappers/players/lib_mpv.dart
+++ b/lib/wrappers/players/lib_mpv.dart
@@ -217,7 +217,7 @@ class LibMPV extends BasePlayer {
     Key key,
     BoxFit fit, {
       double? forcedAspectRatio,
-    }
+    },
   ) =>
       _controller == null
           ? null

--- a/lib/wrappers/players/lib_mpv.dart
+++ b/lib/wrappers/players/lib_mpv.dart
@@ -217,7 +217,7 @@ class LibMPV extends BasePlayer {
     Key key,
     BoxFit fit, {
       double? forcedAspectRatio,
-    },
+    }
   ) =>
       _controller == null
           ? null

--- a/lib/wrappers/players/lib_mpv.dart
+++ b/lib/wrappers/players/lib_mpv.dart
@@ -216,17 +216,41 @@ class LibMPV extends BasePlayer {
   Widget? videoWidget(
     Key key,
     BoxFit fit,
+    {
+      double? forcedAspectRatio,
+    }
   ) =>
       _controller == null
           ? null
-          : Video(
-              key: key,
-              controller: _controller!,
-              wakelock: false,
-              fill: Colors.transparent,
-              fit: fit,
-              subtitleViewConfiguration: const SubtitleViewConfiguration(visible: false),
-              controls: NoVideoControls,
+          : LayoutBuilder(
+              builder: (context, constraints) {
+                final video = Video(
+                  key: key,
+                  controller: _controller!,
+                  wakelock: false,
+                  fill: Colors.transparent,
+                  fit: forcedAspectRatio != null ? BoxFit.cover : fit,
+                  subtitleViewConfiguration: const SubtitleViewConfiguration(visible: false),
+                  controls: NoVideoControls,
+                );
+
+                if (forcedAspectRatio == null) {
+                  return video;
+                }
+
+                return Center(
+                  child: ConstrainedBox(
+                    constraints: BoxConstraints(
+                      maxWidth: constraints.maxWidth,
+                      maxHeight: constraints.maxHeight,
+                    ),
+                    child: AspectRatio(
+                      aspectRatio: forcedAspectRatio,
+                      child: ClipRect(child: video),
+                    ),
+                  ),
+                );
+              },
             );
 
   @override

--- a/lib/wrappers/players/lib_mpv.dart
+++ b/lib/wrappers/players/lib_mpv.dart
@@ -215,8 +215,7 @@ class LibMPV extends BasePlayer {
   @override
   Widget? videoWidget(
     Key key,
-    BoxFit fit,
-    {
+    BoxFit fit, {
       double? forcedAspectRatio,
     }
   ) =>

--- a/lib/wrappers/players/lib_mpv.dart
+++ b/lib/wrappers/players/lib_mpv.dart
@@ -216,9 +216,8 @@ class LibMPV extends BasePlayer {
   Widget? videoWidget(
     Key key,
     BoxFit fit, {
-      double? forcedAspectRatio,
-    }
-  ) =>
+    double? forcedAspectRatio,
+  }) =>
       _controller == null
           ? null
           : LayoutBuilder(

--- a/lib/wrappers/players/native_player.dart
+++ b/lib/wrappers/players/native_player.dart
@@ -98,7 +98,7 @@ class NativePlayer extends BasePlayer implements VideoPlayerListenerCallback {
   Widget? subtitles(bool showOverlay, {GlobalKey<State<StatefulWidget>>? controlsKey}) => null;
 
   @override
-  Widget? videoWidget(Key key, BoxFit fit) => null;
+  Widget? videoWidget(Key key, BoxFit fit, {double? forcedAspectRatio}) => null;
 
   @override
   void onPlaybackStateChanged(PlaybackState state) {


### PR DESCRIPTION
## Pull Request Description

Added customizable aspect ration override, the override was inplemented on the player but it could be easily moved to the option panel if needed, usefull for content where the video was encoded differntly, for example the new one piece tv show where the video is 16:9 but the content is 2:1 so now there are'nt any way to watch it at the macimum size with no content cut

## Screenshots / Recordings

<img width="3436" height="1439" alt="immagine" src="https://github.com/user-attachments/assets/a349a86d-96a3-4fdd-afc7-2fa8549df235" />
<img width="3439" height="1439" alt="immagine" src="https://github.com/user-attachments/assets/f2b25c26-6ddb-4aa3-85a9-138680fae684" />

