### PR TITLE
fix: Slideshow banner thumb incorrect position

### DIFF
--- a/lib/screens/shared/media/media_banner.dart
+++ b/lib/screens/shared/media/media_banner.dart
@@ -273,7 +273,7 @@ class _MediaBannerState extends ConsumerState<MediaBanner> {
                 activeTrackColor: Theme.of(context).colorScheme.surfaceDim,
                 inactiveTrackColor: Theme.of(context).colorScheme.surfaceDim,
                 max: widget.items.length.toDouble() - 1,
-                onChanged: (value) => setState(() => currentPage = value.toInt()),
+                onChanged: (value) => setState(() => currentPage = value.round()),
               ),
             )
           else


### PR DESCRIPTION
## Pull Request Description

Slideshow banner's slider logic to switch between items by dragging is more natural this way, whichever item is closest instead of the one on the left of the cursor (record for tiniest PR?).