### PR TITLE
fix: Subtitle off and subtitle stream selection logic

### DIFF
--- a/lib/models/playback/playback_model.dart
+++ b/lib/models/playback/playback_model.dart
@@ -50,11 +50,19 @@ class Media {
 }
 
 extension PlaybackModelExtension on PlaybackModel? {
-  SubStreamModel? get defaultSubStream =>
-      this?.subStreams?.firstWhereOrNull((element) => element.index == this?.mediaStreams?.defaultSubStreamIndex);
+  SubStreamModel? get defaultSubStream {
+    final streams = this?.subStreams;
+    if (streams == null) return null;
+    return streams.firstWhereOrNull((element) => element.index == this?.mediaStreams?.defaultSubStreamIndex) ??
+        SubStreamModel.no();
+  }
 
-  AudioStreamModel? get defaultAudioStream =>
-      this?.audioStreams?.firstWhereOrNull((element) => element.index == this?.mediaStreams?.defaultAudioStreamIndex);
+  AudioStreamModel? get defaultAudioStream {
+    final streams = this?.audioStreams;
+    if (streams == null) return null;
+    return streams.firstWhereOrNull((element) => element.index == this?.mediaStreams?.defaultAudioStreamIndex) ??
+        AudioStreamModel.no();
+  }
 
   String? label(BuildContext context) => switch (this) {
         DirectPlaybackModel _ => PlaybackType.directStream.name(context),

--- a/lib/wrappers/players/lib_mdk.dart
+++ b/lib/wrappers/players/lib_mdk.dart
@@ -160,29 +160,26 @@ class LibMDK extends BasePlayer {
   @override
   Future<int> setSubtitleTrack(SubStreamModel? model, PlaybackModel playbackModel) async {
     final wantedSubtitle = model ?? playbackModel.defaultSubStream;
-    if (wantedSubtitle == SubStreamModel.no()) {
+    if (wantedSubtitle == null || wantedSubtitle == SubStreamModel.no()) {
       externalSubEnabled = false;
       _controller?.setSubtitleTracks([-1]);
       return -1;
     }
-    if (wantedSubtitle != null) {
-      if (wantedSubtitle.isExternal && wantedSubtitle.url != null) {
-        externalSubEnabled = true;
-        _controller?.setExternalSubtitle(wantedSubtitle.url!);
-        return wantedSubtitle.index;
-      } else {
-        if (externalSubEnabled) {
-          externalSubEnabled = false;
-          _controller?.setExternalSubtitle("");
-        }
-        final indexOf = playbackModel.subStreams?.indexOf(wantedSubtitle);
-        if (indexOf != null) {
-          _controller?.setSubtitleTracks([indexOf - 1]);
-        }
-        return wantedSubtitle.index;
+    if (wantedSubtitle.isExternal && wantedSubtitle.url != null) {
+      externalSubEnabled = true;
+      _controller?.setExternalSubtitle(wantedSubtitle.url!);
+      return wantedSubtitle.index;
+    } else {
+      if (externalSubEnabled) {
+        externalSubEnabled = false;
+        _controller?.setExternalSubtitle("");
       }
+      final indexOf = playbackModel.subStreams?.indexOf(wantedSubtitle);
+      if (indexOf != null) {
+        _controller?.setSubtitleTracks([indexOf - 1]);
+      }
+      return wantedSubtitle.index;
     }
-    return -1;
   }
 
   @override

--- a/lib/wrappers/players/lib_mpv.dart
+++ b/lib/wrappers/players/lib_mpv.dart
@@ -187,19 +187,18 @@ class LibMPV extends BasePlayer {
   Future<int> setSubtitleTrack(SubStreamModel? model, PlaybackModel playbackModel) async {
     if (_player == null) return -1;
     final wantedSubtitle = model ?? playbackModel.defaultSubStream;
-    if (wantedSubtitle == null) return -1;
-    _currentSubtitleCodec = wantedSubtitle.codec;
-    if (wantedSubtitle.index == SubStreamModel.no().index) {
+    if (wantedSubtitle == null || wantedSubtitle.index == SubStreamModel.no().index) {
       await _player?.setSubtitleTrack(mpv.SubtitleTrack.no());
-    } else {
-      final internalTrack = subTracks.getRange(2, subTracks.length).toList();
-      final index = playbackModel.subStreams?.sublist(1).indexWhere((element) => element.id == wantedSubtitle.id);
-      final subTrack = internalTrack.elementAtOrNull(index ?? -1);
-      if (wantedSubtitle.isExternal && wantedSubtitle.url != null && subTrack == null) {
-        await _player?.setSubtitleTrack(mpv.SubtitleTrack.uri(wantedSubtitle.url!));
-      } else if (subTrack != null) {
-        await _player?.setSubtitleTrack(subTrack);
-      }
+      return -1;
+    }
+    _currentSubtitleCodec = wantedSubtitle.codec;
+    final internalTrack = subTracks.getRange(2, subTracks.length).toList();
+    final index = playbackModel.subStreams?.sublist(1).indexWhere((element) => element.id == wantedSubtitle.id);
+    final subTrack = internalTrack.elementAtOrNull(index ?? -1);
+    if (wantedSubtitle.isExternal && wantedSubtitle.url != null && subTrack == null) {
+      await _player?.setSubtitleTrack(mpv.SubtitleTrack.uri(wantedSubtitle.url!));
+    } else if (subTrack != null) {
+      await _player?.setSubtitleTrack(subTrack);
     }
     return wantedSubtitle.index;
   }


### PR DESCRIPTION
## Pull Request Description

This pull request improves the handling of default subtitle and audio stream selection in the playback models and ensures more robust and consistent behavior when no valid stream is found. The main focus is on returning a default "no stream" object instead of null, and updating the player wrappers to correctly handle these cases.

**Improvements to stream selection logic:**

* Updated the `PlaybackModelExtension` in `playback_model.dart` so that `defaultSubStream` and `defaultAudioStream` return a default "no stream" object (e.g., `SubStreamModel.no()`, `AudioStreamModel.no()`) when no valid stream is found, instead of returning null. This makes downstream code safer and more predictable.

**Player wrapper updates for subtitle track selection:**

* In `LibMDK` (`lib_mdk.dart`), modified `setSubtitleTrack` to check for both null and the default "no" subtitle stream, disabling external subtitles and returning `-1` when appropriate.
* Cleaned up unreachable code in `LibMDK`'s `setSubtitleTrack` by removing a redundant return statement.
* In `LibMPV` (`lib_mpv.dart`), consolidated the check for invalid subtitle streams (null or "no" stream), ensuring that the player disables subtitles and returns `-1` in these cases, and moved the codec assignment after the check for clarity and correctness.
* Minor code cleanup in `LibMPV` to remove unnecessary braces after handling subtitle tracks.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Resolves https://github.com/DonutWare/Fladder/issues/877

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [ ] Check that any changes are related to the issue at hand.
