### PR TITLE
fix: macOS shortcut handling

### DIFF
--- a/lib/models/settings/key_combinations.dart
+++ b/lib/models/settings/key_combinations.dart
@@ -102,10 +102,8 @@ abstract class KeyCombination with _$KeyCombination {
     if (pressedModifier == configuredModifier) return true;
     if (pressedModifier == null || configuredModifier == null) return false;
 
-    return (shiftKeys.contains(pressedModifier) && shiftKeys.contains(configuredModifier)) ||
-        (altKeys.contains(pressedModifier) && altKeys.contains(configuredModifier)) ||
-        (ctrlKeys.contains(pressedModifier) && ctrlKeys.contains(configuredModifier)) ||
-        (superKeys.contains(pressedModifier) && superKeys.contains(configuredModifier));
+    // Keep left/right distinction for Shift/Alt/Ctrl, but normalize macOS Command/Super variants.
+    return superKeys.contains(pressedModifier) && superKeys.contains(configuredModifier);
   }
 }
 

--- a/lib/models/settings/key_combinations.dart
+++ b/lib/models/settings/key_combinations.dart
@@ -31,7 +31,8 @@ abstract class KeyCombination with _$KeyCombination {
   }
 
   bool containsSameSet(KeyCombination other) {
-    return (key == other.key && modifier == other.modifier) || (altKey == other.key && altModifier == other.modifier);
+    return ((key?.keyId == other.key?.keyId) && modifierMatches(modifier, other.modifier)) ||
+        ((altKey?.keyId == other.key?.keyId) && modifierMatches(altModifier, other.modifier));
   }
 
   @override
@@ -83,11 +84,29 @@ abstract class KeyCombination with _$KeyCombination {
     LogicalKeyboardKey.controlRight,
   };
 
+  static final superKeys = {
+    LogicalKeyboardKey.meta,
+    LogicalKeyboardKey.metaLeft,
+    LogicalKeyboardKey.metaRight,
+    LogicalKeyboardKey.superKey,
+  };
+
   static final modifierKeys = {
     ...shiftKeys,
     ...altKeys,
     ...ctrlKeys,
+    ...superKeys,
   };
+
+  static bool modifierMatches(LogicalKeyboardKey? pressedModifier, LogicalKeyboardKey? configuredModifier) {
+    if (pressedModifier == configuredModifier) return true;
+    if (pressedModifier == null || configuredModifier == null) return false;
+
+    return (shiftKeys.contains(pressedModifier) && shiftKeys.contains(configuredModifier)) ||
+        (altKeys.contains(pressedModifier) && altKeys.contains(configuredModifier)) ||
+        (ctrlKeys.contains(pressedModifier) && ctrlKeys.contains(configuredModifier)) ||
+        (superKeys.contains(pressedModifier) && superKeys.contains(configuredModifier));
+  }
 }
 
 class LogicalKeyboardSerializer extends JsonConverter<LogicalKeyboardKey, String> {

--- a/lib/util/input_handler.dart
+++ b/lib/util/input_handler.dart
@@ -148,11 +148,11 @@ class _InputHandlerState<T> extends ConsumerState<InputHandler<T>> {
         final keyCombination = entry.value;
 
         bool isMainKeyPressed = logicalKey == keyCombination.key;
-        bool isModifierKeyPressed = pressedModifier == keyCombination.modifier;
+        bool isModifierKeyPressed = KeyCombination.modifierMatches(pressedModifier, keyCombination.modifier);
 
         bool isAltKeyPressed = logicalKey == keyCombination.altKey;
 
-        bool isAltModifierKeyPressed = pressedModifier == keyCombination.altModifier;
+        bool isAltModifierKeyPressed = KeyCombination.modifierMatches(pressedModifier, keyCombination.altModifier);
 
         if ((isMainKeyPressed && isModifierKeyPressed) || isAltKeyPressed && isAltModifierKeyPressed) {
           if (widget.keyMapResult?.call(hotKey) ?? false) {


### PR DESCRIPTION
## Pull Request Description

This pull request improves the flexibility and accuracy of keyboard shortcut handling by enhancing how modifier keys are compared and recognized. The main changes introduce a new method for matching modifier keys, expand support for "super" keys, and update the logic for detecting key combinations throughout the codebase.

Key combination logic improvements:

* Added the `modifierMatches` static method to `KeyCombination` to allow comparison of modifier keys by their functional group (shift, alt, ctrl, super), not just by exact key identity. This enables consistent recognition of different physical keys that serve the same modifier function (e.g., left/right shift, meta, super).
* Updated the `containsSameSet` method in `KeyCombination` to use `modifierMatches` for more robust comparison of key combinations.
* Expanded the set of recognized modifier keys by introducing `superKeys` (including meta and super keys) and incorporating them into the `modifierKeys` set.

Input handling updates:

* Modified `_InputHandlerState` in `input_handler.dart` to use `KeyCombination.modifierMatches` when checking if a pressed modifier key matches a configured modifier, ensuring consistent behavior with the new comparison logic.

Previous PR (https://github.com/DonutWare/Fladder/pull/901) did not fix the issue as when I tried the nightly build on my Macbook the fix did not work.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Resolves https://github.com/DonutWare/Fladder/issues/882

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [ ] Check that any changes are related to the issue at hand.
