### PR TITLE
feat: Web path support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ EXPOSE 80
 ENV BASE_URL=""
 ENV SEERR_BASE_URL=""
 ENV SEERR_HEADER="null"
+ENV FLADDER_WEBPATH="/"
 
 COPY build/web /usr/share/nginx/html
 COPY docker-entrypoint.sh /docker-entrypoint.sh

--- a/Dockerfile-rootless
+++ b/Dockerfile-rootless
@@ -5,6 +5,7 @@ EXPOSE 8080
 ENV BASE_URL=""
 ENV SEERR_BASE_URL=""
 ENV SEERR_HEADER="null"
+ENV FLADDER_WEBPATH="/"
 
 USER root
 COPY build/web /usr/share/nginx/html

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,3 +8,4 @@ services:
       - BASE_URL=https://server-url #OPTIONAL: Locks the Fladder front-end to a certain jellyfin server
       - SEERR_BASE_URL=https://seerr-url #OPTIONAL: Presets Seerr base URL
       - SEERR_HEADER={"key":"value"} #OPTIONAL: JSON object string of Seerr headers
+      - FLADDER_WEBPATH=/ #OPTIONAL: Configures a subpath to run Fladder at

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -9,4 +9,8 @@ cat > /usr/share/nginx/html/assets/config/config.json <<EOF
 }
 EOF
 
+if [ -n "$FLADDER_WEBPATH" ]; then
+  sed -i "s|<base href=\"[^\"]*\">|<base href=\"$FLADDER_WEBPATH\">|g" /usr/share/nginx/html/index.html
+fi
+
 exec nginx -g "daemon off;"


### PR DESCRIPTION
## Pull Request Description

This pull request adds support for configuring a custom web path (subpath) for the Fladder frontend via a new `FLADDER_WEBPATH` environment variable. This allows users to serve the application from a subdirectory instead of the root, improving deployment flexibility. The changes update Dockerfiles, the entrypoint script, and docker-compose configuration to support this new option.

Configuration and deployment improvements:

* Introduced the `FLADDER_WEBPATH` environment variable in both `Dockerfile` and `Dockerfile-rootless` to allow specifying a custom web path for the Fladder frontend.
* Updated `docker-compose.yml` to document and support the new `FLADDER_WEBPATH` environment variable, making it easier for users to configure deployments.

Entrypoint/script enhancements:

* Modified `docker-entrypoint.sh` to update the `<base href>` tag in `index.html` based on the `FLADDER_WEBPATH` value, ensuring the frontend works correctly when served from a subpath.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Resolves https://github.com/DonutWare/Fladder/discussions/917

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Tested On

<!-- Please check all platforms you have tested this PR on -->

- [ ] Android
- [ ] Android TV
- [ ] iOS
- [ ] Linux
- [ ] Windows
- [ ] macOS
- [x] Web

## Checklist

- [ ] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [ ] Check that any changes are related to the issue at hand.
