### PR TITLE
fix: prevent navigation and focus issues by checking route state

### DIFF
--- a/lib/screens/video_player/tv_player_controls.dart
+++ b/lib/screens/video_player/tv_player_controls.dart
@@ -710,8 +710,12 @@ class _TvPlayerControlsState extends ConsumerState<TvPlayerControls> {
         }
         return true;
       case VideoHotKeys.exit:
-        closePlayer();
+        if (ModalRoute.of(context)?.isCurrent == true) {
+          closePlayer();
+          return true;
+        }
         return false;
+
       case VideoHotKeys.mute:
         if (volume != 0) {
           previousVolume = volume;

--- a/lib/screens/video_player/video_player_controls.dart
+++ b/lib/screens/video_player/video_player_controls.dart
@@ -929,8 +929,12 @@ class _DesktopControlsState extends ConsumerState<DesktopControls> {
         }
         return true;
       case VideoHotKeys.exit:
-        closePlayer();
+        if (ModalRoute.of(context)?.isCurrent == true) {
+          closePlayer();
+          return true;
+        }
         return false;
+
       case VideoHotKeys.mute:
         if (volume != 0) {
           previousVolume = volume;

--- a/lib/util/input_handler.dart
+++ b/lib/util/input_handler.dart
@@ -92,7 +92,8 @@ class _InputHandlerState<T> extends ConsumerState<InputHandler<T>> {
         skipTraversal: true,
         onFocusChange: (value) {
           final inputFieldFocus = isEditableTextFocused();
-          if (!focusNode.hasFocus && widget.autoFocus && !inputFieldFocus) {
+          final isCurrent = ModalRoute.of(context)?.isCurrent ?? true;
+          if (!focusNode.hasFocus && widget.autoFocus && !inputFieldFocus && isCurrent) {
             focusNode.requestFocus();
           }
         },


### PR DESCRIPTION
## Pull Request Description

This pull request improves the handling of focus and exit actions in the video player and input handler components by ensuring that certain actions only occur when the current route is active. This helps prevent unintended behavior when the widget is not the topmost route.

**Route-awareness improvements:**

* In both `_TvPlayerControlsState` (`tv_player_controls.dart`) and `_DesktopControlsState` (`video_player_controls.dart`), the exit hotkey now checks if the current route is active before closing the player, preventing accidental closure when not on the main route.
* In `_InputHandlerState` (`input_handler.dart`), autofocus is now only triggered if the current route is active, avoiding unwanted focus changes when the widget is not visible.


As an example, when going into one of the sub-menus while in the player, such as `Subtitles` or `Audio`, you can press `Escape` to go back to the player without actually exiting the player. If you are in the player itself it will then stop the player.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Resolves https://github.com/DonutWare/Fladder/issues/694

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Tested On

<!-- Please check all platforms you have tested this PR on -->

- [ ] Android
- [ ] Android TV
- [ ] iOS
- [x] Linux
- [ ] Windows
- [ ] macOS
- [x] Web

## Checklist

- [ ] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [ ] Check that any changes are related to the issue at hand.
