### PR TITLE
fix: Episodes not showing on mobile

### DIFF
--- a/lib/screens/metadata/edit_screens/edit_image_content.dart
+++ b/lib/screens/metadata/edit_screens/edit_image_content.dart
@@ -226,7 +226,7 @@ class _EditImageContentState extends ConsumerState<EditImageContent> {
                     mainAxisSpacing: (8 * decimal) + 8,
                     crossAxisSpacing: (8 * decimal) + 8,
                     childAspectRatio: 1.0,
-                    crossAxisCount: posterSize.toInt(),
+                    crossAxisCount: posterSize.toInt().clamp(1, double.maxFinite).toInt(),
                   ),
                   children: allImageCards,
                 ),

--- a/lib/screens/shared/media/episode_details_list.dart
+++ b/lib/screens/shared/media/episode_details_list.dart
@@ -133,7 +133,7 @@ class EpisodeDetailsList extends ConsumerWidget {
             padding: padding,
             physics: const NeverScrollableScrollPhysics(),
             gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-                crossAxisCount: size.toInt(),
+                crossAxisCount: size.toInt().clamp(1, double.maxFinite).toInt(),
                 mainAxisSpacing: (8 * decimals) + 8,
                 crossAxisSpacing: (8 * decimals) + 8,
                 childAspectRatio: 1.67),

--- a/lib/screens/shared/media/poster_grid.dart
+++ b/lib/screens/shared/media/poster_grid.dart
@@ -29,7 +29,7 @@ class PosterGrid extends ConsumerWidget {
       padding: EdgeInsets.zero,
       physics: const NeverScrollableScrollPhysics(),
       gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-        crossAxisCount: size.toInt(),
+        crossAxisCount: size.toInt().clamp(1, double.maxFinite).toInt(),
         mainAxisSpacing: (8 * decimals) + 8,
         crossAxisSpacing: (8 * decimals) + 8,
         childAspectRatio: AdaptiveLayout.poster(context).ratio,


### PR DESCRIPTION
## Pull Request Description

This pull request updates how the `crossAxisCount` is calculated in several grid layouts to ensure it always has a valid value and avoids runtime errors. The main change is clamping the `crossAxisCount` to a minimum of 1, which prevents invalid grid configurations if the value is zero or negative.

**Grid layout safety improvements:**

* Updated `crossAxisCount` calculation in `PosterGrid`, `EpisodeDetailsList`, and `EditImageContentState` to use `.clamp(1, double.maxFinite).toInt()`, ensuring the count is always at least 1 and preventing crashes from invalid grid sizes.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Flutter error: 'package:flutter/src/rendering/sliver_grid.dart': Failed assertion: line 359 pos 15: 'crossAxisCount > 0': is not true.

Resolves https://github.com/DonutWare/Fladder/issues/858

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Tested On

<!-- Please check all platforms you have tested this PR on -->

- [x] Android
- [ ] Android TV
- [ ] iOS
- [ ] Linux
- [ ] Windows
- [ ] macOS
- [ ] Web

A test on iOS would also help.

## Checklist

- [ ] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [ ] Check that any changes are related to the issue at hand.
