### PR TITLE
fix: improve subpath handling in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ COPY build/web /usr/share/nginx/html
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 
 RUN mkdir -p /usr/share/nginx/html/assets/config && \
-    chmod +x /docker-entrypoint.sh
+    chown -R nginx:nginx /usr/share/nginx/html && \
+    chmod +x /docker-entrypoint.sh && \
+    chown -R nginx:nginx /etc/nginx/conf.d
 
 CMD ["/docker-entrypoint.sh"]

--- a/Dockerfile-rootless
+++ b/Dockerfile-rootless
@@ -13,7 +13,8 @@ COPY docker-entrypoint.sh /docker-entrypoint.sh
 RUN mkdir -p /usr/share/nginx/html/assets/config && \
     chown -R nginx:nginx /usr/share/nginx/html && \
     chmod +x /docker-entrypoint.sh && \
-    chown nginx:nginx /docker-entrypoint.sh
+    chown nginx:nginx /docker-entrypoint.sh && \
+    chown -R nginx:nginx /etc/nginx/conf.d
 
 USER nginx
 CMD ["/docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -9,8 +9,65 @@ cat > /usr/share/nginx/html/assets/config/config.json <<EOF
 }
 EOF
 
-if [ -n "$FLADDER_WEBPATH" ]; then
-  sed -i "s|<base href=\"[^\"]*\">|<base href=\"$FLADDER_WEBPATH\">|g" /usr/share/nginx/html/index.html
+# Normalize FLADDER_WEBPATH (e.g. /fladder/)
+WEBPATH=$(echo "${FLADDER_WEBPATH:-/}" | sed 's|^/*|/|; s|/*$|/|')
+
+# Update base href in index.html (always at root of build/web)
+if [ -f "/usr/share/nginx/html/index.html" ]; then
+  sed -i "s|<base href=\"[^\"]*\">|<base href=\"$WEBPATH\">|g" /usr/share/nginx/html/index.html
+fi
+
+# Determine port (standard Nginx uses 80, rootless typically 8080)
+if [ "$(id -u)" = "0" ]; then
+    PORT=80
+else
+    PORT=8080
+fi
+
+if [ "$WEBPATH" = "/" ]; then
+    echo "Configuring Fladder at root path"
+    cat > /etc/nginx/conf.d/default.conf <<EOF
+server {
+    listen $PORT;
+    listen [::]:$PORT;
+    server_name localhost;
+
+    location / {
+        root /usr/share/nginx/html;
+        index index.html;
+        try_files \$uri \$uri/ /index.html;
+    }
+}
+EOF
+else
+    echo "Configuring Fladder on subpath: $WEBPATH"
+    WEBPATH_NO_SLASH=$(echo "$WEBPATH" | sed 's|/*$||')
+    
+    cat > /etc/nginx/conf.d/default.conf <<EOF
+server {
+    listen $PORT;
+    listen [::]:$PORT;
+    server_name localhost;
+
+    # Handle the subpath
+    location $WEBPATH {
+        alias /usr/share/nginx/html/;
+        index index.html;
+        try_files \$uri \$uri/ $WEBPATH/index.html;
+    }
+
+    # Redirect without trailing slash
+    location = $WEBPATH_NO_SLASH {
+        return 301 $WEBPATH;
+    }
+
+    # Fallback for root or other paths
+    location / {
+        return 404;
+    }
+}
+EOF
 fi
 
 exec nginx -g "daemon off;"
+


### PR DESCRIPTION
## Pull Request Description

This pull request improves the Docker setup and entrypoint logic for the Fladder web application, focusing on better handling of custom web paths and permissions. The main changes involve normalizing and applying the `FLADDER_WEBPATH` variable more robustly, dynamically generating the Nginx configuration based on the deployment context, and ensuring correct file ownership for Nginx.

**Entrypoint and Nginx configuration improvements:**

* The `docker-entrypoint.sh` script now normalizes the `FLADDER_WEBPATH` variable, ensuring it always starts and ends with a single slash, and updates the `<base href>` in `index.html` accordingly.
* The script dynamically generates the Nginx configuration in `/etc/nginx/conf.d/default.conf` depending on whether Fladder is served at the root or a subpath, and selects the correct port based on the user (root or rootless).

**File and directory permissions:**

* Both `Dockerfile` and `Dockerfile-rootless` now ensure that `/usr/share/nginx/html` and `/etc/nginx/conf.d` are owned by the `nginx` user, preventing permission issues at runtime.
* Ownership of the `docker-entrypoint.sh` script is explicitly set to `nginx:nginx` in the rootless Dockerfile for consistency.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Resolves https://github.com/DonutWare/Fladder/discussions/917#discussioncomment-16532230

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Tested On

<!-- Please check all platforms you have tested this PR on -->

- [ ] Android
- [ ] Android TV
- [ ] iOS
- [ ] Linux
- [ ] Windows
- [ ] macOS
- [x] Web

## Checklist

- [ ] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [ ] Check that any changes are related to the issue at hand.
