### PR TITLE
chore: simplify metadata pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -388,66 +388,6 @@ jobs:
             Fladder_x86_64.AppImage
             Fladder_x86_64.AppImage.zsync
 
-  prepare-metainfo:
-    runs-on: ubuntu-latest
-    needs: [fetch-info]
-    if: needs.fetch-info.outputs.build_type == 'release'
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4.1.1
-        with:
-          fetch-depth: 0
-
-      - name: Update metainfo.xml releases
-        uses: actions/github-script@v8
-        with:
-          script: |
-            const fs = require('fs');
-            const version = '${{ needs.fetch-info.outputs.version_name }}';
-            const date = new Date().toISOString().split('T')[0];
-
-            // Same API call that generate_release_notes: true uses internally
-            const { data } = await github.rest.repos.generateReleaseNotes({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              tag_name: `v${version}`,
-              target_commitish: 'HEAD',
-            });
-
-            const escape = s => s
-              .replace(/&/g, '&amp;')
-              .replace(/</g, '&lt;')
-              .replace(/>/g, '&gt;');
-
-            const items = data.body.split('\n')
-              .filter(l => l.trimStart().startsWith('* '))
-              .map(l => l.replace(/^\s*\*\s*/, '').trim())
-              .map(l => l.replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')) // strip markdown links
-              .map(l => l.replace(/\*\*([^*]+)\*\*/g, '$1'))        // strip bold
-              .filter(Boolean)
-              .slice(0, 30)
-              .map(l => `        <li>${escape(l)}</li>`)
-              .join('\n');
-
-            const description = items
-              ? `      <description>\n        <ul>\n${items}\n        </ul>\n      </description>`
-              : `      <description>\n        <p>See GitHub for detailed changelog</p>\n      </description>`;
-
-            const newReleases =
-              `  <releases>\n    <release version="${version}" date="${date}">\n${description}\n    </release>\n  </releases>`;
-
-            let content = fs.readFileSync('flatpak/nl.jknaapen.fladder.metainfo.xml', 'utf8');
-            content = content.replace(/  <releases>[\s\S]*?<\/releases>/, newReleases);
-            fs.writeFileSync('flatpak/nl.jknaapen.fladder.metainfo.xml', content);
-
-            core.info(`Updated metainfo.xml: version=${version}, date=${date}`);
-
-      - name: Upload updated metainfo
-        uses: actions/upload-artifact@v4
-        with:
-          name: fladder-metainfo
-          path: flatpak/nl.jknaapen.fladder.metainfo.xml
-
   build-linux-flatpak:
     runs-on: ubuntu-latest
     if: needs.fetch-info.outputs.build_type == 'release' || needs.fetch-info.outputs.build_type == 'nightly'
@@ -747,40 +687,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  commit-metainfo:
-    name: Commit metainfo to develop
-    needs:
-      - fetch-info
-      - prepare-metainfo
-      - create_release
-    runs-on: ubuntu-latest
-    if: needs.fetch-info.outputs.build_type == 'release'
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4.1.1
-        with:
-          ref: develop
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Download updated metainfo for commit
-        uses: actions/download-artifact@v4
-        with:
-          name: fladder-metainfo
-          path: fladder-metainfo
-
-      - name: Commit updated metainfo.xml to develop
-        run: |
-          cp fladder-metainfo/nl.jknaapen.fladder.metainfo.xml flatpak/nl.jknaapen.fladder.metainfo.xml
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add flatpak/nl.jknaapen.fladder.metainfo.xml
-          if git diff --staged --quiet; then
-            echo "No changes to metainfo.xml, skipping commit"
-          else
-            git commit -m "chore: update metainfo.xml to v${{ needs.fetch-info.outputs.version_name }}"
-            git push origin develop
-          fi
-
   release_play_console:
     name: Upload AAB to Google Play Console
     needs:
@@ -804,37 +710,6 @@ jobs:
           track: ${{ needs.fetch-info.outputs.build_type == 'nightly' && 'internal' || 'production' }}
           status: ${{ needs.fetch-info.outputs.build_type == 'nightly' && 'completed' || 'draft' }}
           releaseName: "${{ github.run_number }} (${{ needs.fetch-info.outputs.version_name }})"
-
-  update-fastlane-changelog:
-    name: Update Fastlane Changelog
-    needs:
-      - fetch-info
-      - create_release
-    runs-on: ubuntu-latest
-    if: needs.fetch-info.outputs.build_type == 'release'
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout develop
-        uses: actions/checkout@v4.1.1
-        with:
-          ref: develop
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Generate fastlane changelog
-        run: |
-          # Link directly to the GitHub release for the full changelog.
-          CLEAN="See the full changelog at: https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}"
-
-          mkdir -p fastlane/metadata/android/en-US/changelogs
-          printf '%s' "$CLEAN" > "fastlane/metadata/android/en-US/changelogs/${{ github.run_number }}.txt"
-
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add "fastlane/metadata/android/en-US/changelogs/${{ github.run_number }}.txt"
-          git diff --cached --quiet && echo "Nothing to commit" && exit 0
-          git commit -m "chore: add fastlane changelog for ${{ github.ref_name }} [skip ci]"
-          git push
 
   release_web:
     name: Release Web

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,94 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  prepare-release:
+    name: Update Metadata and Tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate Bot Token
+        id: generate-token
+        uses: actions/create-github-app-token@v3.1.1
+        with:
+          app-id: ${{ secrets.FLADDER_BOT_APP_ID }}
+          private-key: ${{ secrets.FLADDER_BOT_APP_PRIVATE_KEY }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v4.1.1
+        with:
+          ref: develop
+          fetch-depth: 0
+          token: ${{ steps.generate-token.outputs.token }}
+
+      - name: Extract Version
+        id: version
+        run: |
+          # Extract version from pubspec.yaml (e.g., 0.10.3+1)
+          FULL_VERSION=$(grep '^version: ' pubspec.yaml | sed 's/version: //')
+          # Remove build number (e.g., 0.10.3)
+          VERSION_NAME=$(echo "$FULL_VERSION" | cut -d'+' -f1)
+          # Exact Build Number (e.g., 1)
+          BUILD_NUMBER=$(echo "$FULL_VERSION" | cut -d'+' -f2)
+          
+          echo "version=${VERSION_NAME}" >> "$GITHUB_OUTPUT"
+          echo "build_number=${BUILD_NUMBER}" >> "$GITHUB_OUTPUT"
+          echo "Version: $VERSION_NAME (Build: $BUILD_NUMBER)"
+          
+          # Check if this version is already tagged
+          if git rev-parse "v${VERSION_NAME}" >/dev/null 2>&1; then
+            echo "is_new_version=false" >> "$GITHUB_OUTPUT"
+            echo "Status: Version is already tagged."
+          else
+            echo "is_new_version=true" >> "$GITHUB_OUTPUT"
+            echo "Status: New version detected."
+          fi
+
+      - name: Update metainfo.xml
+        if: steps.version.outputs.is_new_version == 'true'
+        env:
+          CHANGELOG_MSG: "See the full changelog at: https://github.com/${{ github.repository }}/releases/tag/v${{ steps.version.outputs.version }}"
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          DATE=$(date +%Y-%m-%d)
+          NEW_RELEASE="  <releases>\n    <release version=\"${VERSION}\" date=\"${DATE}\">\n      <description>\n        <p>${{ env.CHANGELOG_MSG }}</p>\n      </description>\n    </release>\n  </releases>"
+          perl -i -0777 -pe "s/  <releases>.*?<\/releases>/$NEW_RELEASE/s" flatpak/nl.jknaapen.fladder.metainfo.xml
+
+      - name: Update Fastlane Changelog
+        if: steps.version.outputs.is_new_version == 'true'
+        env:
+          CHANGELOG_MSG: "See the full changelog at: https://github.com/${{ github.repository }}/releases/tag/v${{ steps.version.outputs.version }}"
+        run: |
+          BUILD_NUMBER="${{ steps.version.outputs.build_number }}"
+          mkdir -p fastlane/metadata/android/en-US/changelogs
+          printf '%s' "${{ env.CHANGELOG_MSG }}" > "fastlane/metadata/android/en-US/changelogs/${BUILD_NUMBER}.txt"
+
+      - name: Commit, Merge and Tag
+        if: steps.version.outputs.is_new_version == 'true'
+        run: |
+          git config user.name "Fladder Bot"
+          git config user.email "fladder-bot[bot]@users.noreply.github.com"
+          
+          VERSION="v${{ steps.version.outputs.version }}"
+          
+          # 1. Commit metadata to develop
+          git add flatpak/nl.jknaapen.fladder.metainfo.xml
+          git add fastlane/metadata/android/en-US/changelogs/
+          
+          if git diff --staged --quiet; then
+            echo "No changes to metadata"
+          else
+            git commit -m "chore: prepare release $VERSION"
+            git push origin develop
+          fi
+          
+          # 2. Merge develop into master
+          git fetch origin master
+          git checkout master
+          git merge develop --no-ff -m "chore: merge develop into master for $VERSION"
+          git push origin master
+          
+          # 3. Create and push the tag on master
+          git tag "$VERSION"
+          git push origin "$VERSION"


### PR DESCRIPTION
## Pull Request Description

This PR aims to simplify the pipeline as after the last release failed I noticed a flaw with it.

The actual commits of the metadata would not be in the release itself which would be pointless when updatng Flatpak and F-Droid later, so this PR should solve that by updating the metadata before the actual build is run.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Fixes [GitHub Action](https://github.com/DonutWare/Fladder/actions/runs/24310174700) release issue

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Tested On

<!-- Please check all platforms you have tested this PR on -->

- [ ] Android
- [ ] Android TV
- [ ] iOS
- [ ] Linux
- [ ] Windows
- [ ] macOS
- [ ] Web

## Checklist

- [ ] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [ ] Check that any changes are related to the issue at hand.
