### PR TITLE
fix: optimize WindowTitleNotifier lifecycle in detail scaffold

### DIFF
--- a/lib/screens/shared/detail_scaffold.dart
+++ b/lib/screens/shared/detail_scaffold.dart
@@ -73,6 +73,8 @@ class _DetailScaffoldState extends ConsumerState<DetailScaffold> {
   ImageProvider? _lastRequestedImage;
   ImageData? _lastColorImage;
 
+  WindowTitleNotifier? _windowTitleNotifier;
+
   void _pushTitle() {
     final isCurrent = ModalRoute.of(context)?.isCurrent ?? false;
     if (!isCurrent) return;
@@ -91,12 +93,13 @@ class _DetailScaffoldState extends ConsumerState<DetailScaffold> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
+    _windowTitleNotifier = ref.read(windowTitleProvider.notifier);
     _pushTitle();
   }
 
   @override
   void dispose() {
-    ref.read(windowTitleProvider.notifier).removeTitle(this);
+    _windowTitleNotifier?.removeTitle(this);
     super.dispose();
   }
 


### PR DESCRIPTION
## Pull Request Description

This pull request refactors how the `DetailScaffold` widget manages its interaction with the window title provider. The changes focus on improving resource management and code clarity by storing the notifier instance and ensuring proper cleanup.

**State management improvements:**

* Added a private `_windowTitleNotifier` field to cache the notifier instance obtained from `windowTitleProvider`, reducing repeated lookups.
* Updated `didChangeDependencies` to initialize `_windowTitleNotifier` using `ref.read(windowTitleProvider.notifier)`.
* Modified `dispose` to call `removeTitle(this)` on the cached `_windowTitleNotifier` instead of reading the provider again, ensuring proper cleanup and avoiding redundant reads.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

```dart
2026-04-13 07:53:14.444 11061-11061 flutter                 nl.jknaapen.fladder.dev              I  SEVERE: 2026-04-13 09:53:14.444685: Flutter error: Bad state: Cannot use "ref" after the widget was disposed.

2026-04-13 07:53:14.446 11061-11061 flutter                 nl.jknaapen.fladder.dev              I  #0      ConsumerStatefulElement._assertNotDisposed (package:flutter_riverpod/src/consumer.dart:550:7)
#1      ConsumerStatefulElement.read (package:flutter_riverpod/src/consumer.dart:619:5)
#2      _DetailScaffoldState.dispose (package:fladder/screens/shared/detail_scaffold.dart:99:9)
#3      StatefulElement.unmount (package:flutter/src/widgets/framework.dart:5932:11)
#4      ConsumerStatefulElement.unmount (package:flutter_riverpod/src/consumer.dart:575:11)
#5      _InactiveElements._unmount (package:flutter/src/widgets/framework.dart:2076:13)
#6      _InactiveElements._unmount.<anonymous closure> (package:flutter/src/widgets/framework.dart:2074:7)
#7      ComponentElement.visitChildren (package:flutter/src/widgets/framework.dart:5773:14)
#8      _InactiveElements._unmount (package:flutter/src/widgets/framework.dart:2072:13)
#9      _InactiveElements._unmount.<anonymous closure> (package:flutter/src/widgets/framework.dart:2074:7)
#10     SingleChildRenderObjectElement.visitChildren (package:flutter/src/widg
 ```

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Tested On

<!-- Please check all platforms you have tested this PR on -->

- [x] Android
- [ ] Android TV
- [ ] iOS
- [x] Linux
- [ ] Windows
- [ ] macOS
- [ ] Web

## Checklist

- [ ] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [ ] Check that any changes are related to the issue at hand.
