### PR TITLE
feat(library): add persistent recursive toggle setting with session m…

### DIFF
--- a/.github/workflows/Build-Fladder-Windows-(Manual).yml
+++ b/.github/workflows/Build-Fladder-Windows-(Manual).yml
@@ -1,0 +1,82 @@
+name: Build Fladder Windows (Manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: '要编译的分支'
+        required: false
+        default: 'custom-dev'
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  fetch-info:
+    runs-on: ubuntu-latest
+    outputs:
+      version_name: ${{ steps.fetch.outputs.version_name }}
+      flutter_version: ${{ steps.fetch.outputs.flutter_version }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4.1.1
+        with:
+          ref: ${{ github.event.inputs.branch || 'custom-dev' }}
+
+      - name: Fetch version info
+        id: fetch
+        run: |
+          VERSION_NAME=$(grep '^version:' pubspec.yaml | cut -d ':' -f2 | cut -d '+' -f1 | tr -d ' ')
+          echo "version_name=${VERSION_NAME}" >> "$GITHUB_OUTPUT"
+          
+          FLUTTER_VERSION=$(jq -r '.flutter' .fvmrc)
+          echo "flutter_version=${FLUTTER_VERSION}" >> "$GITHUB_OUTPUT"
+          
+          echo "Branch: ${{ github.event.inputs.branch || 'custom-dev' }}"
+          echo "Version: $VERSION_NAME"
+          echo "Flutter: $FLUTTER_VERSION"
+        shell: bash
+
+  build-windows:
+    runs-on: windows-2022
+    needs: [fetch-info]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4.1.1
+        with:
+          ref: ${{ github.event.inputs.branch || 'custom-dev' }}
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2.19.0
+        with:
+          channel: "stable"
+          flutter-version: ${{needs.fetch-info.outputs.flutter_version}}
+          cache: true
+          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
+          cache-path: "${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:"
+
+      - name: Get dependencies
+        run: flutter pub get
+
+      - name: Build Windows EXE
+        run: flutter build windows --build-number=${{ github.run_number }}
+
+      - name: Compile Inno Setup installer
+        uses: Minionguyjpro/Inno-Setup-Action@v1.2.2
+        with:
+          path: windows/windows_setup.iss
+          options: /O+ /DFLADDER_VERSION="${{ needs.fetch-info.outputs.version_name }}"
+
+      - name: Archive Windows portable artifact
+        uses: actions/upload-artifact@v4.0.0
+        with:
+          name: fladder-windows-portable
+          path: build\windows\x64\runner\Release\
+
+      - name: Archive Windows installer artifact
+        uses: actions/upload-artifact@v4.0.0
+        with:
+          name: fladder-windows-installer
+          path: windows\Output\fladder_setup.exe

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1570,6 +1570,8 @@
   "mediaTunnelingDesc": "Enable media tunneling for native player",
   "clientSettingsUseSystemIMETitle": "Use system keyboard",
   "clientSettingsUseSystemIMEDesc": "Use the built-in keyboard provided by your system",
+  "recursiveByDefaultTitle": "Recursive by default",
+  "recursiveByDefaultDesc": "When enabled, libraries will show all subfolder items by default. Users can manually toggle this setting while browsing.",
   "nextUpInCount": "Next-up in {seconds}",
   "@nextUpInCount": {
     "placeholders": {

--- a/lib/models/item_base_model.dart
+++ b/lib/models/item_base_model.dart
@@ -189,7 +189,7 @@ class ItemBaseModel with ItemBaseModelMappable {
       case FolderModel _:
       case BoxSetModel _:
       case PlaylistModel _:
-        context.router.push(LibrarySearchRoute(folderId: [id], recursive: true));
+        context.router.push(LibrarySearchRoute(folderId: [id], recursive: null));
         break;
       case PhotoAlbumModel _:
         context.router.push(LibrarySearchRoute(folderId: [id], recursive: false));

--- a/lib/models/settings/client_settings_model.dart
+++ b/lib/models/settings/client_settings_model.dart
@@ -94,6 +94,8 @@ abstract class ClientSettingsModel with _$ClientSettingsModel {
     String? lastViewedUpdate,
     int? libraryPageSize,
     @Default({}) Map<GlobalHotKeys, KeyCombination> shortcuts,
+    @Default(false) bool recursiveByDefault,
+    bool? sessionRecursiveOverride,
   }) = _ClientSettingsModel;
 
   static ClientSettingsModel defaultModel() {

--- a/lib/providers/library_search_provider.dart
+++ b/lib/providers/library_search_provider.dart
@@ -75,11 +75,15 @@ class LibrarySearchNotifier extends StateNotifier<LibrarySearchModel> {
 
     if (!wasInitialized) {
       wasInitialized = true;
+      final clientSettings = ref.read(clientSettingsProvider);
+      final effectiveRecursive = filters.recursive ??
+          clientSettings.sessionRecursiveOverride ??
+          clientSettings.recursiveByDefault;
       state = state.copyWith(
         filters: state.filters.copyWith(
           types: state.filters.types.replaceMap(filters.types, enabledOnly: true),
           genres: state.filters.genres.replaceMap(filters.genres, enabledOnly: true),
-          recursive: filters.recursive ?? true,
+          recursive: effectiveRecursive,
           favourites: filters.favourites ?? false,
         ),
       );
@@ -356,8 +360,11 @@ class LibrarySearchNotifier extends StateNotifier<LibrarySearchModel> {
 
   void toggleFavourite() =>
       state = state.copyWith(filters: state.filters.copyWith(favourites: state.filters.favourites == false));
-  void toggleRecursive() =>
-      state = state.copyWith(filters: state.filters.copyWith(recursive: state.filters.recursive == false));
+  void toggleRecursive() {
+    final newRecursive = state.filters.recursive == false;
+    state = state.copyWith(filters: state.filters.copyWith(recursive: newRecursive));
+    ref.read(clientSettingsProvider.notifier).setSessionRecursiveOverride(newRecursive);
+  }
   void toggleType(FladderItemType type) =>
       state = state.copyWith(filters: state.filters.copyWith(types: state.filters.types.toggleKey(type)));
   void toggleView(ViewModel view) => state = state.copyWith(views: state.views.toggleKey(view));

--- a/lib/providers/settings/client_settings_provider.dart
+++ b/lib/providers/settings/client_settings_provider.dart
@@ -113,4 +113,10 @@ class ClientSettingsNotifier extends StateNotifier<ClientSettingsModel> {
   void setBlurEffects(bool value) => state = state.copyWith(enableBlurEffects: value);
 
   void toggleSideBar() => state = state.copyWith(expandSideBar: !state.expandSideBar);
+
+  void setRecursiveByDefault(bool value) => state = state.copyWith(recursiveByDefault: value);
+
+  void setSessionRecursiveOverride(bool? value) => state = state.copyWith(sessionRecursiveOverride: value);
+
+  void clearSessionRecursiveOverride() => state = state.copyWith(sessionRecursiveOverride: null);
 }

--- a/lib/screens/settings/client_sections/client_settings_advanced.dart
+++ b/lib/screens/settings/client_sections/client_settings_advanced.dart
@@ -115,6 +115,17 @@ List<Widget> buildClientSettingsAdvanced(BuildContext context, WidgetRef ref) {
             onChanged: (value) => ref.read(clientSettingsProvider.notifier).useSystemIME(value),
           ),
         ),
+      SettingsListTile(
+        label: Text(context.localized.recursiveByDefaultTitle),
+        subLabel: Text(context.localized.recursiveByDefaultDesc),
+        onTap: () => ref
+            .read(clientSettingsProvider.notifier)
+            .setRecursiveByDefault(!ref.read(clientSettingsProvider.select((value) => value.recursiveByDefault))),
+        trailing: Switch(
+          value: ref.watch(clientSettingsProvider.select((value) => value.recursiveByDefault)),
+          onChanged: (value) => ref.read(clientSettingsProvider.notifier).setRecursiveByDefault(value),
+        ),
+      ),
     ],
   );
 }


### PR DESCRIPTION
…emory

- Add recursiveByDefault setting (default: false) in ClientSettingsModel
- Add sessionRecursiveOverride to track user's manual toggle during session
- Modify LibrarySearchNotifier to respect session state over default setting
- Change navigateTo() to pass recursive: null instead of hardcoded true
- Add UI toggle in Settings -> Client Settings -> Advanced
- Add localization strings for the new setting

Behavior:
- App startup: uses recursiveByDefault value
- Manual toggle: sessionRecursiveOverride is set, persists across all libraries
- Next app restart: session state cleared, falls back to recursiveByDefault

## Pull Request Description

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Resolves #issue-number

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Tested On

<!-- Please check all platforms you have tested this PR on -->

- [ ] Android
- [ ] Android TV
- [ ] iOS
- [ ] Linux
- [ ] Windows
- [ ] macOS
- [ ] Web

## Checklist

- [ ] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [ ] Check that any changes are related to the issue at hand.
