### PR TITLE
fix: screen flicker when stopping floating player on small devices

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,6 +15,7 @@ import 'package:fladder/providers/crash_log_provider.dart';
 import 'package:fladder/providers/settings/client_settings_provider.dart';
 import 'package:fladder/providers/shared_provider.dart';
 import 'package:fladder/providers/sync_provider.dart';
+import 'package:fladder/providers/window_title_provider.dart';
 import 'package:fladder/routes/auto_router.dart';
 import 'package:fladder/theme.dart';
 import 'package:fladder/util/adaptive_layout/adaptive_layout.dart';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -102,7 +102,7 @@ class _FladderApp extends ConsumerWidget {
           light: lightTheme,
           dark: darkTheme,
           child: MaterialApp.router(
-            onGenerateTitle: (context) => ref.watch(windowTitleProvider),
+            title: 'Fladder',
             theme: lightTheme,
             scrollBehavior: scrollBehaviour.copyWith(
               dragDevices: {
@@ -126,12 +126,18 @@ class _FladderApp extends ConsumerWidget {
 
               return matchByLanguage;
             },
-            builder: (context, child) => MediaQueryScaler(
-              child: LocalizationContextWrapper(
-                child: child ?? Container(),
-                currentLocale: language,
+            builder: (context, child) => Consumer(
+              builder: (context, ref, _) => Title(
+                title: ref.watch(windowTitleProvider),
+                color: Colors.black,
+                child: MediaQueryScaler(
+                  child: LocalizationContextWrapper(
+                    child: child ?? Container(),
+                    currentLocale: language,
+                  ),
+                  enable: ref.read(argumentsStateProvider).leanBackMode,
+                ),
               ),
-              enable: ref.read(argumentsStateProvider).leanBackMode,
             ),
             debugShowCheckedModeBanner: false,
             darkTheme: darkTheme.copyWith(


### PR DESCRIPTION
## Pull Request Description

This pull request updates how the application window title is set in the `lib/main.dart` file. Instead of using the `onGenerateTitle` property of `MaterialApp.router`, the window title is now managed by wrapping the app's content in a `Title` widget that dynamically responds to the `windowTitleProvider`. This change allows for more flexible and reactive window title updates.

**Window Title Management:**

* Replaced the use of `onGenerateTitle` in `MaterialApp.router` with a static `title` property, and moved dynamic title handling to a `Title` widget that listens to `windowTitleProvider` via a `Consumer`.
* Wrapped the main app content with the `Title` widget to ensure the window title updates reactively based on provider changes.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

I noticed an issue on Android where when pressing stop on the floating player the screen flickered. After checking the logs I found this:

```dart
2026-04-15 08:35:11.475 19271-19271 flutter                 nl.jknaapen.fladder.dev              I  SEVERE: 2026-04-15 10:35:11.475711: Flutter error: Looking up a deactivated widget's ancestor is unsafe.
At this point the state of the widget's element tree is no longer stable.
To safely refer to a widget's ancestor in its dispose() method, save a reference to the ancestor by calling dependOnInheritedWidgetOfExactType() in the widget's didChangeDependencies() method.
2026-04-15 08:35:11.476 19271-19271 flutter                 nl.jknaapen.fladder.dev              I  #0      Element._debugCheckStateIsActiveForAncestorLookup.<anonymous closure> (package:flutter/src/widgets/framework.dart:4954:9)
#1      Element._debugCheckStateIsActiveForAncestorLookup (package:flutter/src/widgets/framework.dart:4968:6)
#2      Element.dependOnInheritedWidgetOfExactType (package:flutter/src/widgets/framework.dart:4988:12)
#3      PopupMenuTheme.of (package:flutter/src/material/popup_menu_theme.dart:278:10)
#4      PopupMenuButtonState._positionBuilder (package:flutter/src/material/popup_menu.dart:1612:62)
#5      _PopupMenuRoute.buildPage.<anonymous closure> (package:flutter/src/material/popup_menu.dart:1054:32)
#6      _LayoutBuilderElement._rebuildWithConstraints.updateChildCallback (package:flutter/src/widgets/layout_builder.dart:233:74)
#7      BuildOwner.buildScope (package:flutter/src/widgets/framework.dart:3046:19)
#8      _LayoutBuilderElement._rebuildWithConstraints (package:flutter/src/widgets/layout_builder.dart:271:12)
#9      RenderAbstractLayoutBuilderMixin.layoutCallback (p
```

This indicated to me that it was probably caused by https://github.com/DonutWare/Fladder/pull/845, which has led to this change which resolves the issue.

Funnily enough this only happens on Android (at least from the platforms which I can test) and not on the desktops, I have no idea why.

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Tested On

<!-- Please check all platforms you have tested this PR on -->

- [x] Android
- [ ] Android TV
- [ ] iOS
- [x] Linux
- [ ] Windows
- [x] macOS
- [x] Web

Also tested with Russian translation as well and works fine.

## Checklist

- [ ] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [ ] Check that any changes are related to the issue at hand.
