### PR TITLE
refactor: make Linux binary name lowercase

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -363,7 +363,7 @@ jobs:
             [[ -f "$lib" && -n "$(patchelf --print-rpath "$lib")" ]] && \
             patchelf --set-rpath '$ORIGIN' "$lib"
           done
-          patchelf --set-rpath '$ORIGIN/lib' "build/linux/x64/release/bundle/Fladder"
+          patchelf --set-rpath '$ORIGIN/lib' "build/linux/x64/release/bundle/fladder"
 
       - name: Archive Linux artifact
         uses: actions/upload-artifact@v4

--- a/AppImageBuilder.yml
+++ b/AppImageBuilder.yml
@@ -18,7 +18,7 @@ AppDir:
     name: Fladder
     icon: fladder_icon_desktop
     version: latest
-    exec: Fladder
+    exec: fladder
     exec_args: $@
   files:
     include:

--- a/flatpak/Fladder.desktop
+++ b/flatpak/Fladder.desktop
@@ -2,7 +2,7 @@
 Name=Fladder
 StartupWMClass=nl.jknaapen.fladder
 Comment=A Simple Jellyfin Frontend built on top of Flutter.
-Exec=Fladder
+Exec=fladder
 Icon=nl.jknaapen.fladder
 Terminal=false
 Type=Application

--- a/flatpak/nl.jknaapen.fladder.yaml
+++ b/flatpak/nl.jknaapen.fladder.yaml
@@ -3,7 +3,7 @@ runtime: org.gnome.Platform
 runtime-version: '48'
 sdk: org.gnome.Sdk
 
-command: Fladder
+command: fladder
 add-extensions:
   org.freedesktop.Platform.ffmpeg-full:
     directory: lib/ffmpeg
@@ -142,7 +142,7 @@ modules:
     build-commands:
       - mkdir -p /app/bin
       - cp -r build/linux/x64/release/bundle/* /app/bin/
-      - chmod +x /app/bin/Fladder
+      - chmod +x /app/bin/fladder
       - mkdir -p /app/share/applications
       - mkdir -p /app/share/icons/hicolor/scalable/apps
       - install -Dm644 flatpak/Fladder.desktop /app/share/applications/${FLATPAK_ID}.desktop

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -4,7 +4,7 @@ project(runner LANGUAGES CXX)
 
 # The name of the executable created for the application. Change this to change
 # the on-disk name of your application.
-set(BINARY_NAME "Fladder")
+set(BINARY_NAME "fladder")
 # The unique GTK application identifier for this application. See:
 # https://wiki.gnome.org/HowDoI/ChooseApplicationID
 set(APPLICATION_ID "nl.jknaapen.fladder")

--- a/linux/my_application.cc
+++ b/linux/my_application.cc
@@ -109,7 +109,7 @@ static void my_application_init(MyApplication *self) {}
 
 MyApplication *my_application_new()
 {
-	g_set_prgname("Fladder");
+	g_set_prgname("fladder");
 	return MY_APPLICATION(g_object_new(my_application_get_type(),
 									   "application-id", APPLICATION_ID,
 									   "flags", G_APPLICATION_NON_UNIQUE,


### PR DESCRIPTION
## Pull Request Description

### I think in the next update this should be added as a breaking change at the top of the release to ensure that all package maintainers know about this.

This pull request standardizes the application binary name from `Fladder` (capitalized) to `fladder` (lowercase) across the entire codebase and related build/deployment files, to follow standards used by every Linux distro.

**Application binary renaming:**

* Changed the executable name variable in `linux/CMakeLists.txt` from `Fladder` to `fladder` to set the on-disk binary name to lowercase.
* Updated the program name in `my_application.cc` by calling `g_set_prgname("fladder")` instead of `g_set_prgname("Fladder")`.

**Build and packaging adjustments:**

* Modified Flatpak build scripts and desktop entry files (`flatpak/nl.jknaapen.fladder.yaml`, `flatpak/Fladder.desktop`) to use `fladder` as the executable name, including the `command` field and file permissions.
* Updated the AppImage build configuration (`AppImageBuilder.yml`) to use `fladder` as the `exec` target.
* Changed the Linux artifact build and packaging workflow (`.github/workflows/build.yml`) to reference the lowercase binary name.

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Tested On

<!-- Please check all platforms you have tested this PR on -->

- [ ] Android
- [ ] Android TV
- [ ] iOS
- [x] Linux
- [ ] Windows
- [ ] macOS
- [ ] Web

## Checklist

- [ ] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [ ] Check that any changes are related to the issue at hand.
