### PR TITLE
chore: automated GitHub issue labeling workflow

### DIFF
--- a/.github/advanced-issue-labeler.yml
+++ b/.github/advanced-issue-labeler.yml
@@ -1,0 +1,19 @@
+policy:
+  - section:
+      - id: [platform]
+        block-list: []
+        label:
+          - name: 'android'
+            keys: ['Android']
+          - name: 'android-tv'
+            keys: ['Android TV']
+          - name: 'ios'
+            keys: ['iOS']
+          - name: 'linux'
+            keys: ['Linux']
+          - name: 'windows'
+            keys: ['Windows']
+          - name: 'macos'
+            keys: ['macOS']
+          - name: 'web'
+            keys: ['Web']

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -1,0 +1,26 @@
+name: Issue Labeler
+on:
+  issues:
+    types: [opened, edited]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Parse issue body
+        uses: stefanbuck/github-issue-parser@v3.2.3
+        id: issue-parser
+        with:
+          template-path: .github/ISSUE_TEMPLATE/bug-report.yml
+
+      - name: Set labels based on platform field
+        uses: redhat-plumbers-in-action/advanced-issue-labeler@v3.2.4
+        with:
+          issue-form: ${{ steps.issue-parser.outputs.jsonString }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Pull Request Description

This pull request introduces automation for labeling GitHub issues based on the platform specified in issue forms. It adds a new workflow configuration and a policy file to map platform values to appropriate labels.

**Issue Labeling Automation:**

* Added `.github/workflows/issue-labeler.yml` to automatically label issues when they are opened or edited, using the platform field from the issue form and the `advanced-issue-labeler` GitHub Action.
* Introduced `.github/advanced-issue-labeler.yml` to define platform-specific label mappings (e.g., Android, iOS, Linux, etc.) for the labeler to use.

Adds workflow discussed here: https://github.com/DonutWare/Fladder/discussions/924

#### These labels need to be created:

- android
- android-tv
- ios
- linux
- windows
- macos
- web
