### PR TITLE
fix: specials showing in wrong category in sync

### DIFF
--- a/lib/providers/sync_provider.dart
+++ b/lib/providers/sync_provider.dart
@@ -762,7 +762,7 @@ extension SyncNotifierHelpers on SyncNotifier {
         seriesId: seriesItem.id,
       );
 
-      final episodes = episodesResponse.body?.items ?? [];
+      final episodes = episodesResponse.body?.items?.where((ep) => ep.seasonId == newSeason.id).toList() ?? [];
 
       final episodeResults = await Future.wait(
         episodes.map((ep) async {


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This pull request updates the logic for fetching episodes in the `SyncNotifierHelpers` extension to ensure that specials remain separate from season 1

Data filtering improvement:

* Updated the assignment of `episodes` to filter for episodes where `ep.seasonId` matches `newSeason.id`, ensuring only relevant episodes are included in subsequent operations.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Resolves https://github.com/DonutWare/Fladder/issues/947

I found this issue occurring on most of my devices.

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Tested On

<!-- Please check all platforms you have tested this PR on -->

- [x] Android
- [ ] Android TV
- [ ] iOS
- [x] Linux
- [ ] Windows
- [ ] macOS
- [ ] Web

## Checklist

- [ ] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [ ] Check that any changes are related to the issue at hand.
