### PR TITLE
fix: Performance impact in details screens

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,7 +15,6 @@ import 'package:fladder/providers/crash_log_provider.dart';
 import 'package:fladder/providers/settings/client_settings_provider.dart';
 import 'package:fladder/providers/shared_provider.dart';
 import 'package:fladder/providers/sync_provider.dart';
-import 'package:fladder/providers/window_title_provider.dart';
 import 'package:fladder/routes/auto_router.dart';
 import 'package:fladder/theme.dart';
 import 'package:fladder/util/adaptive_layout/adaptive_layout.dart';
@@ -102,7 +101,6 @@ class _FladderApp extends ConsumerWidget {
           light: lightTheme,
           dark: darkTheme,
           child: MaterialApp.router(
-            onGenerateTitle: (context) => ref.watch(windowTitleProvider),
             theme: lightTheme,
             scrollBehavior: scrollBehaviour.copyWith(
               dragDevices: {


### PR DESCRIPTION
## Pull Request Description

Removed the onGenerateTitle and specifically the ref.watch. It was rebuilding the details scaffold on every re-draw and/or update

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Resolves #issue-number

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Tested On

<!-- Please check all platforms you have tested this PR on -->

- [x] Android
- [ ] Android TV
- [ ] iOS
- [ ] Linux
- [ ] Windows
- [x] macOS
- [ ] Web

## Checklist

- [ ] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [ ] Check that any changes are related to the issue at hand.
