### PR TITLE
fix: video playback state synchronization

### DIFF
--- a/lib/providers/video_player_provider.dart
+++ b/lib/providers/video_player_provider.dart
@@ -84,7 +84,7 @@ class VideoPlayerNotifier extends StateNotifier<MediaControlsWrapper> {
     mediaState.update(
       (state) => state.copyWith(playing: event),
     );
-    ref.read(playBackModel)?.updatePlaybackPosition(currentState.position, currentState.playing, ref);
+    ref.read(playBackModel)?.updatePlaybackPosition(currentState.position, event, ref);
   }
 
   Future<void> updatePosition(Duration event) async {

--- a/lib/screens/video_player/video_player.dart
+++ b/lib/screens/video_player/video_player.dart
@@ -59,10 +59,21 @@ class _VideoPlayerState extends ConsumerState<VideoPlayer> with WidgetsBindingOb
     super.dispose();
   }
 
+  void _setupListeners() {
+    ref.listenManual(
+      mediaPlaybackProvider.select((value) => value.playing),
+      (previous, next) {
+        playing = next;
+      },
+      fireImmediately: true,
+    );
+  }
+
   @override
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
+    _setupListeners();
     Future.microtask(() {
       ref.read(mediaPlaybackProvider.notifier).update((state) => state.copyWith(state: VideoPlayerState.fullScreen));
       final orientations = ref.read(videoPlayerSettingsProvider.select((value) => value.allowedOrientations));


### PR DESCRIPTION
## Pull Request Description

This pull request improves the handling of playback state synchronization between the UI and the playback model in the video player feature. The main updates ensure that the playback state is accurately reflected and that the UI stays in sync with the underlying state.

**Playback state synchronization improvements:**

* Added a `_setupListeners` method in `_VideoPlayerState` to listen for changes to the `playing` state from `mediaPlaybackProvider` and update the local `playing` variable accordingly, ensuring the UI remains in sync with the playback state.
* Updated the call to `updatePlaybackPosition` in `VideoPlayerNotifier` to use the new `playing` value from the event, rather than the previous state, for more accurate state updates.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Resolves https://github.com/DonutWare/Fladder/issues/787

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Tested On

<!-- Please check all platforms you have tested this PR on -->

- [ ] Android
- [ ] Android TV
- [ ] iOS
- [ ] Linux
- [ ] Windows
- [ ] macOS
- [ ] Web

## Checklist

- [ ] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [ ] Check that any changes are related to the issue at hand.
