### PR TITLE
fix: audio glitches on Android

### DIFF
--- a/lib/wrappers/players/lib_mpv.dart
+++ b/lib/wrappers/players/lib_mpv.dart
@@ -70,10 +70,13 @@ class LibMPV extends BasePlayer {
     }
 
     if (_player?.platform is mpv.NativePlayer) {
-      await (_player?.platform as dynamic).setProperty(
-        'force-seekable',
-        'yes',
-      );
+      final nativePlayer = _player!.platform as dynamic;
+      await nativePlayer.setProperty('force-seekable', 'yes');
+
+      if (defaultTargetPlatform == TargetPlatform.android) {
+        // Use audiotrack as it is generally more stable on modern Android
+        await nativePlayer.setProperty('ao', 'audiotrack');
+      }
     }
   }
 


### PR DESCRIPTION
## Pull Request Description

This pull request enhances the audio output stability on Android devices by configuring the underlying MPV player to use the `audiotrack` audio output when running on Android. This should help address audio playback glitches that have been reported.

Platform-specific configuration:

* In `lib/wrappers/players/lib_mpv.dart`, when initializing the MPV player on Android (`TargetPlatform.android`), the code now sets the `ao` (audio output) property to `audiotrack` for improved stability.


I would like your opinion for this "fix" if this is something you would want or not? But according to the user it does work.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Resolves https://github.com/DonutWare/Fladder/issues/762#issuecomment-4273241812

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Tested On

<!-- Please check all platforms you have tested this PR on -->

- [x] Android
- [ ] Android TV
- [ ] iOS
- [ ] Linux
- [ ] Windows
- [ ] macOS
- [ ] Web

## Checklist

- [ ] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [ ] Check that any changes are related to the issue at hand.
