### PR TITLE
fix: Failed to play items with empty backdrop image list

### DIFF
--- a/lib/models/items/images_models.dart
+++ b/lib/models/items/images_models.dart
@@ -29,7 +29,7 @@ class ImagesData {
   }
 
   ImageData? get firstOrNull {
-    return primary ?? backDrop?[0];
+    return primary ?? backDrop?.firstOrNull;
   }
 
   ImageData? get randomBackDrop => (backDrop?..shuffle())?.firstOrNull ?? primary;


### PR DESCRIPTION
## Pull Request Description

ImagesData.firstOrNull accessed backDrop[0] directly, throwing a RangeError when the list existed but was empty. Use List.firstOrNull instead to safely return null, fixing video playback with this specific circumstance.

## Issue Being Fixed

I had an issue when playing a video in Linux and on iOS. The player would not load, it was stuck in "Loading" while the audio was playing in the background.

## Tested On

- [ ] Android
- [ ] Android TV
- [ ] iOS
- [x] Linux
- [ ] Windows
- [ ] macOS
- [ ] Web

## Checklist

- [x] Check that any changes are related to the issue at hand.