### PR TITLE
fix(web): container ENV vars unreliably applied due to startup race

### DIFF
--- a/lib/bootstrap/app_bootstrap.dart
+++ b/lib/bootstrap/app_bootstrap.dart
@@ -1,6 +1,8 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 
 import 'package:desktop_multi_window/desktop_multi_window.dart';
 import 'package:package_info_plus/package_info_plus.dart';
@@ -11,6 +13,7 @@ import 'package:fladder/models/settings/arguments_model.dart';
 import 'package:fladder/providers/crash_log_provider.dart';
 import 'package:fladder/src/video_player_helper.g.dart';
 import 'package:fladder/util/application_info.dart';
+import 'package:fladder/util/fladder_config.dart';
 import 'package:fladder/util/string_extensions.dart';
 import 'package:fladder/util/svg_utils.dart';
 
@@ -41,6 +44,11 @@ class AppBootstrapResult {
 
 Future<AppBootstrapResult> bootstrapApplication(List<String> args) async {
   final crashProvider = CrashLogNotifier();
+
+  if (kIsWeb) {
+    final configString = await rootBundle.loadString('config/config.json');
+    FladderConfig.fromJson(jsonDecode(configString) as Map<String, dynamic>);
+  }
 
   await SvgUtils.preCacheSVGs();
 

--- a/lib/bootstrap/platform/web_app_wrapper.dart
+++ b/lib/bootstrap/platform/web_app_wrapper.dart
@@ -1,12 +1,7 @@
-import 'dart:convert';
-
-import 'package:flutter/services.dart';
-
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:universal_html/html.dart' as html;
 
 import 'package:fladder/bootstrap/platform/base_app_wrapper.dart';
-import 'package:fladder/util/fladder_config.dart';
 
 class WebAppWrapper extends BaseAppWrapper {
   const WebAppWrapper({super.key, required super.builder});
@@ -22,12 +17,5 @@ class _WebAppWrapperState extends BaseAppWrapperState<WebAppWrapper> {
   @override
   Future<void> platformInit() async {
     html.document.onContextMenu.listen((event) => event.preventDefault());
-    final result = await _loadConfig();
-    FladderConfig.fromJson(result);
-  }
-
-  Future<Map<String, dynamic>> _loadConfig() async {
-    final configString = await rootBundle.loadString('config/config.json');
-    return jsonDecode(configString);
   }
 }


### PR DESCRIPTION
## Pull Request Description

Container ENV vars (`BASE_URL`, `SEERR_BASE_URL`, etc.) stopped being applied reliably on my Container/WebUI deployment. After some researching, I found PR #805 which seems to introduce a regression:

The behaviour I see is inconsistent: sometimes the login screen reflects the ENV vars (Jellyfin URL/Seerr URL ENV vars set -> both URL field hidden from UI, etc.), sometimes it doesn't - the Jellyfin URL field reappears Seerr URL field is configurable, and so on. A page refresh makes it fail much more often, but it can also go wrong on the very first load.

---

## Possible Regression

Before #805, `config.json` was loaded in `main()` before the app started. So by the time any screen rendered, the config was guaranteed ready.

After #805, the load was moved into a post-frame callback on the web wrapper. That callback is async, but Flutter's post-frame queue doesn't wait for async work to finish. So `LoginScreen`'s own post-frame callback runs in the same tick and reads the still-empty config singleton.

It's a timing race: whoever finishes first wins. The ~500ms `SplashScreen` delay usually hides it on cold loads (the network fetch has time to resolve), but on a refresh everything is served from the cache in milliseconds and the race is lost almost every time. On first loads it can still go wrong whenever the config fetch happens to be slow enough.

---

## Fix

Restore the pre-#805 behaviour: Load `config.json` inside `bootstrapApplication`, awaited before `runApp`. By the time any widget's `initState` runs, `FladderConfig` is guaranteed populated.

---

## Issue Being Fixed

Regression from #805.

---

## How To Reproduce (before this fix)

1. Run the Docker image with e.g. `BASE_URL=https://jellyfin.DOMAIN.TLD`
2. Open the web UI → Jellyfin URL field may or may not be hidden depending on timing
3. Refresh the page (F5) → usually the Jellyfin URL field comes back (race almost always lost once the service worker is primed)

After applyint this PR, the UI state is consistent across cold loads and refreshes.

---

## Screenshots

N/A
---

## Notes

### AI Disclosure
*Diagnosed and fixed with assistance help from Claude Code (Opus 4.7). The LLM helped me trace the init sequence.*
*I've reviewed and tested the fix end-to-end.*

## Tested On
- [ ] Android
- [ ] Android TV
- [ ] iOS
- [ ] Linux
- [ ] Windows
- [ ] macOS
- [X] Web

## Checklist
- [ ] If a new package was added, did you ensure it works for all supported platforms?
- [X] Check that any changes are related to the issue at hand.