### PR TITLE
fix: improve play/pause behavior on desktop

### DIFF
--- a/lib/screens/video_player/video_player_controls.dart
+++ b/lib/screens/video_player/video_player_controls.dart
@@ -128,7 +128,7 @@ class _DesktopControlsState extends ConsumerState<DesktopControls> {
               children: [
                 Positioned.fill(
                   child: GestureDetector(
-                    onTap: initInputDevice == InputDevice.pointer ? () => player.playOrPause() : () => toggleOverlay(),
+                    onTap: initInputDevice == InputDevice.pointer ? null : () => toggleOverlay(),
                     onDoubleTapDown: initInputDevice == InputDevice.touch ? _handleDoubleTapDown : null,
                     onDoubleTap: initInputDevice == InputDevice.pointer
                         ? () => fullScreenHelper.toggleFullScreen(ref)
@@ -138,6 +138,9 @@ class _DesktopControlsState extends ConsumerState<DesktopControls> {
                     onVerticalDragStart: initInputDevice == InputDevice.touch ? _handleVerticalDragStart : null,
                     onVerticalDragUpdate: initInputDevice == InputDevice.touch ? _handleVerticalDragUpdate : null,
                     onVerticalDragEnd: initInputDevice == InputDevice.touch ? _handleVerticalDragEnd : null,
+                    //better play/pause handling on Desktop (works with dragging on click)
+                    onHorizontalDragDown:
+                        initInputDevice == InputDevice.pointer ? (details) => player.playOrPause() : null,
                   ),
                 ),
                 if (subtitleWidget != null) subtitleWidget,


### PR DESCRIPTION

## Pull Request Description

 Changed the GestureDetector on video_player_controls.dart:

-  onTap now handles only touch logic
- onHorizontalDragDown handles pointer play/pause logic (previously on onTap), it triggers on clicks with mouse moving also, improving reliability.

## Issue Being Fixed
Before, play/pause on click would not register if mouse was still moving when the click event triggered. But mouse movement is to be expected when quickly switching screens/windows, etc.

solves  #580

## Screenshots / Recordings


old: play/pause fails when mouse moving

https://github.com/user-attachments/assets/353612ed-a11e-43b3-9162-33961e85659b





new: play/pause works with mouse moving

https://github.com/user-attachments/assets/76688926-650d-4968-8777-20e048a097b4



## Tested On

<!-- Please check all platforms you have tested this PR on -->

- [ ] Android
- [ ] Android TV
- [ ] iOS
- [ ] Linux
- [X] Windows
- [X] macOS
- [ ] Web

## Checklist

- [X] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [X] Check that any changes are related to the issue at hand.
