### PR TITLE
Display episode air date in video playback and controls

### DIFF
--- a/lib/screens/video_player/components/video_playback_information.dart
+++ b/lib/screens/video_player/components/video_playback_information.dart
@@ -1,10 +1,12 @@
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:iconsax_plus/iconsax_plus.dart';
 
+import 'package:fladder/models/items/episode_model.dart';
 import 'package:fladder/models/playback/playback_model.dart';
 import 'package:fladder/providers/session_info_provider.dart';
 import 'package:fladder/providers/video_player_provider.dart';
@@ -28,6 +30,10 @@ class _VideoPlaybackInformation extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final playbackModel = ref.watch(playBackModel);
     final sessionInfo = ref.watch(sessionInfoProvider);
+    final playbackItem = playbackModel?.item;
+    final episodeAirDate = playbackItem is EpisodeModel && playbackItem.dateAired != null
+        ? DateFormat.yMMMEd(context.localized.localeName).format(playbackItem.dateAired!)
+        : null;
     final backend = ref.read(videoPlayerProvider.select((value) => value.backend));
     final playbackState = ref.watch(videoPlayerProvider.select((value) => value.lastState));
     return Dialog(
@@ -97,6 +103,11 @@ class _VideoPlaybackInformation extends ConsumerWidget {
                           mainAxisSize: MainAxisSize.min,
                           children: [const Text('type: '), Text(playbackModel.label(context) ?? "")],
                         ),
+                        if (episodeAirDate != null)
+                          Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [const Text('air date: '), Text(episodeAirDate)],
+                          ),
                         if (sessionInfo.transCodeInfo != null) ...[
                           Text("Transcoding", style: Theme.of(context).textTheme.titleMedium),
                           if (sessionInfo.transCodeInfo?.transcodeReasons?.isNotEmpty == true)

--- a/lib/screens/video_player/video_player_controls.dart
+++ b/lib/screens/video_player/video_player_controls.dart
@@ -8,9 +8,11 @@ import 'package:flutter/services.dart';
 import 'package:async/async.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:iconsax_plus/iconsax_plus.dart';
+import 'package:intl/intl.dart';
 import 'package:screen_brightness/screen_brightness.dart';
 
 import 'package:fladder/models/item_base_model.dart';
+import 'package:fladder/models/items/episode_model.dart';
 import 'package:fladder/models/items/media_segments_model.dart';
 import 'package:fladder/models/media_playback_model.dart';
 import 'package:fladder/models/playback/playback_model.dart';
@@ -452,8 +454,12 @@ class _DesktopControlsState extends ConsumerState<DesktopControls> {
       builder: (context, ref, child) {
         final playbackModel = ref.watch(playBackModel);
         final item = playbackModel?.item;
+        final episodeAirDate = item is EpisodeModel && item.dateAired != null
+            ? DateFormat.yMMMEd(context.localized.localeName).format(item.dateAired!)
+            : null;
         final List<String?> details = [
           if (AdaptiveLayout.of(context).isDesktop) item?.label(context.localized),
+          if (episodeAirDate != null) episodeAirDate,
           context.localized.endsAt(DateTime.now().add(Duration(
             milliseconds: (mediaPlayback.duration.inMilliseconds - mediaPlayback.position.inMilliseconds) ~/
                 ref.read(playbackRateProvider),

--- a/lib/widgets/navigation_scaffold/components/floating_player_bar.dart
+++ b/lib/widgets/navigation_scaffold/components/floating_player_bar.dart
@@ -3,9 +3,11 @@ import 'package:flutter/material.dart';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:iconsax_plus/iconsax_plus.dart';
+import 'package:intl/intl.dart';
 import 'package:overflow_view/overflow_view.dart';
 import 'package:window_manager/window_manager.dart';
 
+import 'package:fladder/models/items/episode_model.dart';
 import 'package:fladder/models/media_playback_model.dart';
 import 'package:fladder/providers/user_provider.dart';
 import 'package:fladder/providers/video_player_provider.dart';
@@ -66,6 +68,13 @@ class _CurrentlyPlayingBarState extends ConsumerState<FloatingPlayerBar> {
     final playbackInfo = ref.watch(mediaPlaybackProvider);
     final player = ref.watch(videoPlayerProvider);
     final item = ref.watch(playBackModel.select((value) => value?.item));
+    final episodeAirDate = item is EpisodeModel && item.dateAired != null
+        ? DateFormat.yMMMEd(context.localized.localeName).format(item.dateAired!)
+        : null;
+    final subtitleText = [
+      if (item?.detailedName(context.localized)?.isNotEmpty == true) item?.detailedName(context.localized),
+      if (episodeAirDate != null) episodeAirDate,
+    ].nonNulls.join(' - ');
     if (!changingSliderValue) {
       lastPosition = playbackInfo.position;
     }
@@ -199,10 +208,10 @@ class _CurrentlyPlayingBarState extends ConsumerState<FloatingPlayerBar> {
                                         maxLines: 1,
                                       ),
                                     ),
-                                    if (item?.detailedName(context.localized)?.isNotEmpty == true)
+                                    if (subtitleText.isNotEmpty)
                                       Flexible(
                                         child: Text(
-                                          item?.detailedName(context.localized) ?? "",
+                                          subtitleText,
                                           overflow: TextOverflow.ellipsis,
                                           style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                                                 color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.65),

--- a/lib/widgets/navigation_scaffold/components/floating_player_bar.dart
+++ b/lib/widgets/navigation_scaffold/components/floating_player_bar.dart
@@ -71,8 +71,9 @@ class _CurrentlyPlayingBarState extends ConsumerState<FloatingPlayerBar> {
     final episodeAirDate = item is EpisodeModel && item.dateAired != null
         ? DateFormat.yMMMEd(context.localized.localeName).format(item.dateAired!)
         : null;
+    final detailedName = item?.detailedName(context.localized);
     final subtitleText = [
-      if (item?.detailedName(context.localized)?.isNotEmpty == true) item?.detailedName(context.localized),
+      if (detailedName?.isNotEmpty == true) detailedName,
       if (episodeAirDate != null) episodeAirDate,
     ].nonNulls.join(' - ');
     if (!changingSliderValue) {


### PR DESCRIPTION
## Pull Request Description

This change adds episode airdate metadata to the player UI so it is visible during playback instead of only being inferred from episode labels.

#### What was changed
* Added airdate display to the playback details row in the video player controls.
* Added airdate display to the floating mini player subtitle line.
* Airdate is only shown for episode items and only when a valid airdate exists.
* Airdate formatting uses localized date formatting to match the user locale.

#### Result

When playing TV episodes, users now see the episode airdate directly in the active playback UI surfaces where episode context is shown.

## Issue Being Fixed

Episode playback UI was missing explicit airdate information in key player surfaces (full controls details row and floating player bar), making it harder to identify episode chronology at a glance. This update restores and standardizes airdate visibility in those locations.

## Screenshots / Recordings

<img width="569" height="176" alt="image" src="https://github.com/user-attachments/assets/7a55f48c-fcdc-467c-a8d7-369be6621875" />

<img width="533" height="86" alt="image" src="https://github.com/user-attachments/assets/98c74d4b-1a6e-4ef8-ae0c-57f8fd3315fb" />

## Tested On

<!-- Please check all platforms you have tested this PR on -->

- [ ] Android
- [ ] Android TV
- [ ] iOS
- [ ] Linux
- [x] Windows
- [ ] macOS
- [x] Web

## Checklist

- [ ] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [x] Check that any changes are related to the issue at hand.
