### PR TITLE
feat(pip): add Picture-in-Picture support for Android and iOS

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -38,6 +38,7 @@
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
+            android:supportsPictureInPicture="true"
             android:windowSoftInputMode="adjustResize">
             <!-- Specifies an Android theme to apply to this Activity as soon as
                  the Android process has started. This theme is visible to the user

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -50,6 +50,7 @@
 
 		<key>UIBackgroundModes</key>
 		<array>
+			<string>audio</string>
 			<string>fetch</string>
 		</array>
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1186,6 +1186,22 @@
   "@videoScalingFillScreenNotif": {},
   "videoScalingFillScreenTitle": "Fill screen",
   "@videoScalingFillScreenTitle": {},
+  "pictureInPictureTitle": "Picture-in-Picture",
+  "@pictureInPictureTitle": {
+    "description": "Tooltip on the in-player PiP button"
+  },
+  "pictureInPictureAutoTitle": "Auto Picture-in-Picture",
+  "@pictureInPictureAutoTitle": {
+    "description": "Title of the auto-enter Picture-in-Picture setting toggle"
+  },
+  "pictureInPictureSubtitle": "Automatically enter Picture-in-Picture when you leave the player. The PiP button in the controls always works regardless of this setting.",
+  "@pictureInPictureSubtitle": {
+    "description": "Subtitle of the auto-enter Picture-in-Picture setting toggle"
+  },
+  "pictureInPictureNotSupported": "Picture-in-Picture is not available on this device",
+  "@pictureInPictureNotSupported": {
+    "description": "Snackbar shown when the user taps the PiP button and the OS reports it unsupported"
+  },
   "videoScalingFitHeight": "Fit Height",
   "@videoScalingFitHeight": {},
   "videoScalingFitWidth": "Fit Width",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -23,6 +23,7 @@ import 'package:fladder/util/deep_link_helper.dart';
 import 'package:fladder/util/localization_helper.dart';
 import 'package:fladder/util/themes_data.dart';
 import 'package:fladder/widgets/media_query_scaler.dart';
+import 'package:fladder/widgets/pip_lifecycle_controller.dart';
 
 void main(List<String> args) async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -126,7 +127,7 @@ class _FladderApp extends ConsumerWidget {
             },
             builder: (context, child) => MediaQueryScaler(
               child: LocalizationContextWrapper(
-                child: child ?? Container(),
+                child: PipLifecycleController(child: child ?? Container()),
                 currentLocale: language,
               ),
               enable: ref.read(argumentsStateProvider).leanBackMode,

--- a/lib/models/settings/video_player_settings.dart
+++ b/lib/models/settings/video_player_settings.dart
@@ -104,6 +104,7 @@ abstract class VideoPlayerSettingsModel with _$VideoPlayerSettingsModel {
     @Default(false) bool enableAdvancedVideoOptions,
     @Default(true) bool enableEdgeGestures,
     @Default(false) bool reverseEdgeGestures,
+    @Default(true) bool enablePictureInPicture,
     @Default(true) bool enableReplayGain,
     @Default(ReplayGainVolumeLevel.quiet) ReplayGainVolumeLevel replayGainVolumeLevel,
     @Default(true) bool enablePlayPauseFade,

--- a/lib/models/settings/video_player_settings.freezed.dart
+++ b/lib/models/settings/video_player_settings.freezed.dart
@@ -37,6 +37,7 @@ mixin _$VideoPlayerSettingsModel implements DiagnosticableTreeMixin {
   bool get enableAdvancedVideoOptions;
   bool get enableEdgeGestures;
   bool get reverseEdgeGestures;
+  bool get enablePictureInPicture;
   bool get enableReplayGain;
   ReplayGainVolumeLevel get replayGainVolumeLevel;
   bool get enablePlayPauseFade;
@@ -48,7 +49,8 @@ mixin _$VideoPlayerSettingsModel implements DiagnosticableTreeMixin {
   @JsonKey(includeFromJson: false, includeToJson: false)
   @pragma('vm:prefer-inline')
   $VideoPlayerSettingsModelCopyWith<VideoPlayerSettingsModel> get copyWith =>
-      _$VideoPlayerSettingsModelCopyWithImpl<VideoPlayerSettingsModel>(this as VideoPlayerSettingsModel, _$identity);
+      _$VideoPlayerSettingsModelCopyWithImpl<VideoPlayerSettingsModel>(
+          this as VideoPlayerSettingsModel, _$identity);
 
   /// Serializes this VideoPlayerSettingsModel to a JSON map.
   Map<String, dynamic> toJson();
@@ -77,9 +79,12 @@ mixin _$VideoPlayerSettingsModel implements DiagnosticableTreeMixin {
       ..add(DiagnosticsProperty('enableSpeedBoost', enableSpeedBoost))
       ..add(DiagnosticsProperty('speedBoostRate', speedBoostRate))
       ..add(DiagnosticsProperty('enableDoubleTapSeek', enableDoubleTapSeek))
-      ..add(DiagnosticsProperty('enableAdvancedVideoOptions', enableAdvancedVideoOptions))
+      ..add(DiagnosticsProperty(
+          'enableAdvancedVideoOptions', enableAdvancedVideoOptions))
       ..add(DiagnosticsProperty('enableEdgeGestures', enableEdgeGestures))
       ..add(DiagnosticsProperty('reverseEdgeGestures', reverseEdgeGestures))
+      ..add(
+          DiagnosticsProperty('enablePictureInPicture', enablePictureInPicture))
       ..add(DiagnosticsProperty('enableReplayGain', enableReplayGain))
       ..add(DiagnosticsProperty('replayGainVolumeLevel', replayGainVolumeLevel))
       ..add(DiagnosticsProperty('enablePlayPauseFade', enablePlayPauseFade))
@@ -89,14 +94,14 @@ mixin _$VideoPlayerSettingsModel implements DiagnosticableTreeMixin {
 
   @override
   String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
-    return 'VideoPlayerSettingsModel(screenBrightness: $screenBrightness, videoFit: $videoFit, fillScreen: $fillScreen, hardwareAccel: $hardwareAccel, useLibass: $useLibass, enableTunneling: $enableTunneling, bufferSize: $bufferSize, playerOptions: $playerOptions, internalVolume: $internalVolume, allowedOrientations: $allowedOrientations, nextVideoType: $nextVideoType, maxHomeBitrate: $maxHomeBitrate, maxInternetBitrate: $maxInternetBitrate, audioDevice: $audioDevice, segmentSkipSettings: $segmentSkipSettings, hotKeys: $hotKeys, screensaver: $screensaver, enableSpeedBoost: $enableSpeedBoost, speedBoostRate: $speedBoostRate, enableDoubleTapSeek: $enableDoubleTapSeek, enableAdvancedVideoOptions: $enableAdvancedVideoOptions, enableEdgeGestures: $enableEdgeGestures, reverseEdgeGestures: $reverseEdgeGestures, enableReplayGain: $enableReplayGain, replayGainVolumeLevel: $replayGainVolumeLevel, enablePlayPauseFade: $enablePlayPauseFade, enableCrossfade: $enableCrossfade, crossfadeDurationMs: $crossfadeDurationMs)';
+    return 'VideoPlayerSettingsModel(screenBrightness: $screenBrightness, videoFit: $videoFit, fillScreen: $fillScreen, hardwareAccel: $hardwareAccel, useLibass: $useLibass, enableTunneling: $enableTunneling, bufferSize: $bufferSize, playerOptions: $playerOptions, internalVolume: $internalVolume, allowedOrientations: $allowedOrientations, nextVideoType: $nextVideoType, maxHomeBitrate: $maxHomeBitrate, maxInternetBitrate: $maxInternetBitrate, audioDevice: $audioDevice, segmentSkipSettings: $segmentSkipSettings, hotKeys: $hotKeys, screensaver: $screensaver, enableSpeedBoost: $enableSpeedBoost, speedBoostRate: $speedBoostRate, enableDoubleTapSeek: $enableDoubleTapSeek, enableAdvancedVideoOptions: $enableAdvancedVideoOptions, enableEdgeGestures: $enableEdgeGestures, reverseEdgeGestures: $reverseEdgeGestures, enablePictureInPicture: $enablePictureInPicture, enableReplayGain: $enableReplayGain, replayGainVolumeLevel: $replayGainVolumeLevel, enablePlayPauseFade: $enablePlayPauseFade, enableCrossfade: $enableCrossfade, crossfadeDurationMs: $crossfadeDurationMs)';
   }
 }
 
 /// @nodoc
 abstract mixin class $VideoPlayerSettingsModelCopyWith<$Res> {
-  factory $VideoPlayerSettingsModelCopyWith(
-          VideoPlayerSettingsModel value, $Res Function(VideoPlayerSettingsModel) _then) =
+  factory $VideoPlayerSettingsModelCopyWith(VideoPlayerSettingsModel value,
+          $Res Function(VideoPlayerSettingsModel) _then) =
       _$VideoPlayerSettingsModelCopyWithImpl;
   @useResult
   $Res call(
@@ -123,6 +128,7 @@ abstract mixin class $VideoPlayerSettingsModelCopyWith<$Res> {
       bool enableAdvancedVideoOptions,
       bool enableEdgeGestures,
       bool reverseEdgeGestures,
+      bool enablePictureInPicture,
       bool enableReplayGain,
       ReplayGainVolumeLevel replayGainVolumeLevel,
       bool enablePlayPauseFade,
@@ -131,7 +137,8 @@ abstract mixin class $VideoPlayerSettingsModelCopyWith<$Res> {
 }
 
 /// @nodoc
-class _$VideoPlayerSettingsModelCopyWithImpl<$Res> implements $VideoPlayerSettingsModelCopyWith<$Res> {
+class _$VideoPlayerSettingsModelCopyWithImpl<$Res>
+    implements $VideoPlayerSettingsModelCopyWith<$Res> {
   _$VideoPlayerSettingsModelCopyWithImpl(this._self, this._then);
 
   final VideoPlayerSettingsModel _self;
@@ -165,6 +172,7 @@ class _$VideoPlayerSettingsModelCopyWithImpl<$Res> implements $VideoPlayerSettin
     Object? enableAdvancedVideoOptions = null,
     Object? enableEdgeGestures = null,
     Object? reverseEdgeGestures = null,
+    Object? enablePictureInPicture = null,
     Object? enableReplayGain = null,
     Object? replayGainVolumeLevel = null,
     Object? enablePlayPauseFade = null,
@@ -263,6 +271,10 @@ class _$VideoPlayerSettingsModelCopyWithImpl<$Res> implements $VideoPlayerSettin
       reverseEdgeGestures: null == reverseEdgeGestures
           ? _self.reverseEdgeGestures
           : reverseEdgeGestures // ignore: cast_nullable_to_non_nullable
+              as bool,
+      enablePictureInPicture: null == enablePictureInPicture
+          ? _self.enablePictureInPicture
+          : enablePictureInPicture // ignore: cast_nullable_to_non_nullable
               as bool,
       enableReplayGain: null == enableReplayGain
           ? _self.enableReplayGain
@@ -405,6 +417,7 @@ extension VideoPlayerSettingsModelPatterns on VideoPlayerSettingsModel {
             bool enableAdvancedVideoOptions,
             bool enableEdgeGestures,
             bool reverseEdgeGestures,
+            bool enablePictureInPicture,
             bool enableReplayGain,
             ReplayGainVolumeLevel replayGainVolumeLevel,
             bool enablePlayPauseFade,
@@ -440,6 +453,7 @@ extension VideoPlayerSettingsModelPatterns on VideoPlayerSettingsModel {
             _that.enableAdvancedVideoOptions,
             _that.enableEdgeGestures,
             _that.reverseEdgeGestures,
+            _that.enablePictureInPicture,
             _that.enableReplayGain,
             _that.replayGainVolumeLevel,
             _that.enablePlayPauseFade,
@@ -489,6 +503,7 @@ extension VideoPlayerSettingsModelPatterns on VideoPlayerSettingsModel {
             bool enableAdvancedVideoOptions,
             bool enableEdgeGestures,
             bool reverseEdgeGestures,
+            bool enablePictureInPicture,
             bool enableReplayGain,
             ReplayGainVolumeLevel replayGainVolumeLevel,
             bool enablePlayPauseFade,
@@ -523,6 +538,7 @@ extension VideoPlayerSettingsModelPatterns on VideoPlayerSettingsModel {
             _that.enableAdvancedVideoOptions,
             _that.enableEdgeGestures,
             _that.reverseEdgeGestures,
+            _that.enablePictureInPicture,
             _that.enableReplayGain,
             _that.replayGainVolumeLevel,
             _that.enablePlayPauseFade,
@@ -571,6 +587,7 @@ extension VideoPlayerSettingsModelPatterns on VideoPlayerSettingsModel {
             bool enableAdvancedVideoOptions,
             bool enableEdgeGestures,
             bool reverseEdgeGestures,
+            bool enablePictureInPicture,
             bool enableReplayGain,
             ReplayGainVolumeLevel replayGainVolumeLevel,
             bool enablePlayPauseFade,
@@ -605,6 +622,7 @@ extension VideoPlayerSettingsModelPatterns on VideoPlayerSettingsModel {
             _that.enableAdvancedVideoOptions,
             _that.enableEdgeGestures,
             _that.reverseEdgeGestures,
+            _that.enablePictureInPicture,
             _that.enableReplayGain,
             _that.replayGainVolumeLevel,
             _that.enablePlayPauseFade,
@@ -618,7 +636,8 @@ extension VideoPlayerSettingsModelPatterns on VideoPlayerSettingsModel {
 
 /// @nodoc
 @JsonSerializable()
-class _VideoPlayerSettingsModel extends VideoPlayerSettingsModel with DiagnosticableTreeMixin {
+class _VideoPlayerSettingsModel extends VideoPlayerSettingsModel
+    with DiagnosticableTreeMixin {
   _VideoPlayerSettingsModel(
       {this.screenBrightness,
       this.videoFit = BoxFit.contain,
@@ -634,7 +653,8 @@ class _VideoPlayerSettingsModel extends VideoPlayerSettingsModel with Diagnostic
       this.maxHomeBitrate = Bitrate.original,
       this.maxInternetBitrate = Bitrate.original,
       this.audioDevice,
-      final Map<MediaSegmentType, SegmentSkip> segmentSkipSettings = defaultSegmentSkipValues,
+      final Map<MediaSegmentType, SegmentSkip> segmentSkipSettings =
+          defaultSegmentSkipValues,
       final Map<VideoHotKeys, KeyCombination> hotKeys = const {},
       this.screensaver = Screensaver.logo,
       this.enableSpeedBoost = false,
@@ -643,6 +663,7 @@ class _VideoPlayerSettingsModel extends VideoPlayerSettingsModel with Diagnostic
       this.enableAdvancedVideoOptions = false,
       this.enableEdgeGestures = true,
       this.reverseEdgeGestures = false,
+      this.enablePictureInPicture = true,
       this.enableReplayGain = true,
       this.replayGainVolumeLevel = ReplayGainVolumeLevel.quiet,
       this.enablePlayPauseFade = true,
@@ -652,7 +673,8 @@ class _VideoPlayerSettingsModel extends VideoPlayerSettingsModel with Diagnostic
         _segmentSkipSettings = segmentSkipSettings,
         _hotKeys = hotKeys,
         super._();
-  factory _VideoPlayerSettingsModel.fromJson(Map<String, dynamic> json) => _$VideoPlayerSettingsModelFromJson(json);
+  factory _VideoPlayerSettingsModel.fromJson(Map<String, dynamic> json) =>
+      _$VideoPlayerSettingsModelFromJson(json);
 
   @override
   final double? screenBrightness;
@@ -684,7 +706,8 @@ class _VideoPlayerSettingsModel extends VideoPlayerSettingsModel with Diagnostic
   Set<DeviceOrientation>? get allowedOrientations {
     final value = _allowedOrientations;
     if (value == null) return null;
-    if (_allowedOrientations is EqualUnmodifiableSetView) return _allowedOrientations;
+    if (_allowedOrientations is EqualUnmodifiableSetView)
+      return _allowedOrientations;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableSetView(value);
   }
@@ -704,7 +727,8 @@ class _VideoPlayerSettingsModel extends VideoPlayerSettingsModel with Diagnostic
   @override
   @JsonKey()
   Map<MediaSegmentType, SegmentSkip> get segmentSkipSettings {
-    if (_segmentSkipSettings is EqualUnmodifiableMapView) return _segmentSkipSettings;
+    if (_segmentSkipSettings is EqualUnmodifiableMapView)
+      return _segmentSkipSettings;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableMapView(_segmentSkipSettings);
   }
@@ -741,6 +765,9 @@ class _VideoPlayerSettingsModel extends VideoPlayerSettingsModel with Diagnostic
   final bool reverseEdgeGestures;
   @override
   @JsonKey()
+  final bool enablePictureInPicture;
+  @override
+  @JsonKey()
   final bool enableReplayGain;
   @override
   @JsonKey()
@@ -761,7 +788,8 @@ class _VideoPlayerSettingsModel extends VideoPlayerSettingsModel with Diagnostic
   @JsonKey(includeFromJson: false, includeToJson: false)
   @pragma('vm:prefer-inline')
   _$VideoPlayerSettingsModelCopyWith<_VideoPlayerSettingsModel> get copyWith =>
-      __$VideoPlayerSettingsModelCopyWithImpl<_VideoPlayerSettingsModel>(this, _$identity);
+      __$VideoPlayerSettingsModelCopyWithImpl<_VideoPlayerSettingsModel>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
@@ -794,9 +822,12 @@ class _VideoPlayerSettingsModel extends VideoPlayerSettingsModel with Diagnostic
       ..add(DiagnosticsProperty('enableSpeedBoost', enableSpeedBoost))
       ..add(DiagnosticsProperty('speedBoostRate', speedBoostRate))
       ..add(DiagnosticsProperty('enableDoubleTapSeek', enableDoubleTapSeek))
-      ..add(DiagnosticsProperty('enableAdvancedVideoOptions', enableAdvancedVideoOptions))
+      ..add(DiagnosticsProperty(
+          'enableAdvancedVideoOptions', enableAdvancedVideoOptions))
       ..add(DiagnosticsProperty('enableEdgeGestures', enableEdgeGestures))
       ..add(DiagnosticsProperty('reverseEdgeGestures', reverseEdgeGestures))
+      ..add(
+          DiagnosticsProperty('enablePictureInPicture', enablePictureInPicture))
       ..add(DiagnosticsProperty('enableReplayGain', enableReplayGain))
       ..add(DiagnosticsProperty('replayGainVolumeLevel', replayGainVolumeLevel))
       ..add(DiagnosticsProperty('enablePlayPauseFade', enablePlayPauseFade))
@@ -806,14 +837,15 @@ class _VideoPlayerSettingsModel extends VideoPlayerSettingsModel with Diagnostic
 
   @override
   String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
-    return 'VideoPlayerSettingsModel(screenBrightness: $screenBrightness, videoFit: $videoFit, fillScreen: $fillScreen, hardwareAccel: $hardwareAccel, useLibass: $useLibass, enableTunneling: $enableTunneling, bufferSize: $bufferSize, playerOptions: $playerOptions, internalVolume: $internalVolume, allowedOrientations: $allowedOrientations, nextVideoType: $nextVideoType, maxHomeBitrate: $maxHomeBitrate, maxInternetBitrate: $maxInternetBitrate, audioDevice: $audioDevice, segmentSkipSettings: $segmentSkipSettings, hotKeys: $hotKeys, screensaver: $screensaver, enableSpeedBoost: $enableSpeedBoost, speedBoostRate: $speedBoostRate, enableDoubleTapSeek: $enableDoubleTapSeek, enableAdvancedVideoOptions: $enableAdvancedVideoOptions, enableEdgeGestures: $enableEdgeGestures, reverseEdgeGestures: $reverseEdgeGestures, enableReplayGain: $enableReplayGain, replayGainVolumeLevel: $replayGainVolumeLevel, enablePlayPauseFade: $enablePlayPauseFade, enableCrossfade: $enableCrossfade, crossfadeDurationMs: $crossfadeDurationMs)';
+    return 'VideoPlayerSettingsModel(screenBrightness: $screenBrightness, videoFit: $videoFit, fillScreen: $fillScreen, hardwareAccel: $hardwareAccel, useLibass: $useLibass, enableTunneling: $enableTunneling, bufferSize: $bufferSize, playerOptions: $playerOptions, internalVolume: $internalVolume, allowedOrientations: $allowedOrientations, nextVideoType: $nextVideoType, maxHomeBitrate: $maxHomeBitrate, maxInternetBitrate: $maxInternetBitrate, audioDevice: $audioDevice, segmentSkipSettings: $segmentSkipSettings, hotKeys: $hotKeys, screensaver: $screensaver, enableSpeedBoost: $enableSpeedBoost, speedBoostRate: $speedBoostRate, enableDoubleTapSeek: $enableDoubleTapSeek, enableAdvancedVideoOptions: $enableAdvancedVideoOptions, enableEdgeGestures: $enableEdgeGestures, reverseEdgeGestures: $reverseEdgeGestures, enablePictureInPicture: $enablePictureInPicture, enableReplayGain: $enableReplayGain, replayGainVolumeLevel: $replayGainVolumeLevel, enablePlayPauseFade: $enablePlayPauseFade, enableCrossfade: $enableCrossfade, crossfadeDurationMs: $crossfadeDurationMs)';
   }
 }
 
 /// @nodoc
-abstract mixin class _$VideoPlayerSettingsModelCopyWith<$Res> implements $VideoPlayerSettingsModelCopyWith<$Res> {
-  factory _$VideoPlayerSettingsModelCopyWith(
-          _VideoPlayerSettingsModel value, $Res Function(_VideoPlayerSettingsModel) _then) =
+abstract mixin class _$VideoPlayerSettingsModelCopyWith<$Res>
+    implements $VideoPlayerSettingsModelCopyWith<$Res> {
+  factory _$VideoPlayerSettingsModelCopyWith(_VideoPlayerSettingsModel value,
+          $Res Function(_VideoPlayerSettingsModel) _then) =
       __$VideoPlayerSettingsModelCopyWithImpl;
   @override
   @useResult
@@ -841,6 +873,7 @@ abstract mixin class _$VideoPlayerSettingsModelCopyWith<$Res> implements $VideoP
       bool enableAdvancedVideoOptions,
       bool enableEdgeGestures,
       bool reverseEdgeGestures,
+      bool enablePictureInPicture,
       bool enableReplayGain,
       ReplayGainVolumeLevel replayGainVolumeLevel,
       bool enablePlayPauseFade,
@@ -849,7 +882,8 @@ abstract mixin class _$VideoPlayerSettingsModelCopyWith<$Res> implements $VideoP
 }
 
 /// @nodoc
-class __$VideoPlayerSettingsModelCopyWithImpl<$Res> implements _$VideoPlayerSettingsModelCopyWith<$Res> {
+class __$VideoPlayerSettingsModelCopyWithImpl<$Res>
+    implements _$VideoPlayerSettingsModelCopyWith<$Res> {
   __$VideoPlayerSettingsModelCopyWithImpl(this._self, this._then);
 
   final _VideoPlayerSettingsModel _self;
@@ -883,6 +917,7 @@ class __$VideoPlayerSettingsModelCopyWithImpl<$Res> implements _$VideoPlayerSett
     Object? enableAdvancedVideoOptions = null,
     Object? enableEdgeGestures = null,
     Object? reverseEdgeGestures = null,
+    Object? enablePictureInPicture = null,
     Object? enableReplayGain = null,
     Object? replayGainVolumeLevel = null,
     Object? enablePlayPauseFade = null,
@@ -981,6 +1016,10 @@ class __$VideoPlayerSettingsModelCopyWithImpl<$Res> implements _$VideoPlayerSett
       reverseEdgeGestures: null == reverseEdgeGestures
           ? _self.reverseEdgeGestures
           : reverseEdgeGestures // ignore: cast_nullable_to_non_nullable
+              as bool,
+      enablePictureInPicture: null == enablePictureInPicture
+          ? _self.enablePictureInPicture
+          : enablePictureInPicture // ignore: cast_nullable_to_non_nullable
               as bool,
       enableReplayGain: null == enableReplayGain
           ? _self.enableReplayGain

--- a/lib/models/settings/video_player_settings.g.dart
+++ b/lib/models/settings/video_player_settings.g.dart
@@ -6,48 +6,68 @@ part of 'video_player_settings.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_VideoPlayerSettingsModel _$VideoPlayerSettingsModelFromJson(Map<String, dynamic> json) => _VideoPlayerSettingsModel(
+_VideoPlayerSettingsModel _$VideoPlayerSettingsModelFromJson(
+        Map<String, dynamic> json) =>
+    _VideoPlayerSettingsModel(
       screenBrightness: (json['screenBrightness'] as num?)?.toDouble(),
-      videoFit: $enumDecodeNullable(_$BoxFitEnumMap, json['videoFit']) ?? BoxFit.contain,
+      videoFit: $enumDecodeNullable(_$BoxFitEnumMap, json['videoFit']) ??
+          BoxFit.contain,
       fillScreen: json['fillScreen'] as bool? ?? false,
       hardwareAccel: json['hardwareAccel'] as bool? ?? true,
       useLibass: json['useLibass'] as bool? ?? true,
       enableTunneling: json['enableTunneling'] as bool? ?? false,
       bufferSize: (json['bufferSize'] as num?)?.toInt() ?? 32,
-      playerOptions: $enumDecodeNullable(_$PlayerOptionsEnumMap, json['playerOptions']),
+      playerOptions:
+          $enumDecodeNullable(_$PlayerOptionsEnumMap, json['playerOptions']),
       internalVolume: (json['internalVolume'] as num?)?.toDouble() ?? 100,
       allowedOrientations: (json['allowedOrientations'] as List<dynamic>?)
           ?.map((e) => $enumDecode(_$DeviceOrientationEnumMap, e))
           .toSet(),
-      nextVideoType: $enumDecodeNullable(_$AutoNextTypeEnumMap, json['nextVideoType']) ?? AutoNextType.smart,
-      maxHomeBitrate: $enumDecodeNullable(_$BitrateEnumMap, json['maxHomeBitrate']) ?? Bitrate.original,
-      maxInternetBitrate: $enumDecodeNullable(_$BitrateEnumMap, json['maxInternetBitrate']) ?? Bitrate.original,
+      nextVideoType:
+          $enumDecodeNullable(_$AutoNextTypeEnumMap, json['nextVideoType']) ??
+              AutoNextType.smart,
+      maxHomeBitrate:
+          $enumDecodeNullable(_$BitrateEnumMap, json['maxHomeBitrate']) ??
+              Bitrate.original,
+      maxInternetBitrate:
+          $enumDecodeNullable(_$BitrateEnumMap, json['maxInternetBitrate']) ??
+              Bitrate.original,
       audioDevice: json['audioDevice'] as String?,
-      segmentSkipSettings: (json['segmentSkipSettings'] as Map<String, dynamic>?)?.map(
-            (k, e) => MapEntry($enumDecode(_$MediaSegmentTypeEnumMap, k), $enumDecode(_$SegmentSkipEnumMap, e)),
-          ) ??
-          defaultSegmentSkipValues,
+      segmentSkipSettings:
+          (json['segmentSkipSettings'] as Map<String, dynamic>?)?.map(
+                (k, e) => MapEntry($enumDecode(_$MediaSegmentTypeEnumMap, k),
+                    $enumDecode(_$SegmentSkipEnumMap, e)),
+              ) ??
+              defaultSegmentSkipValues,
       hotKeys: (json['hotKeys'] as Map<String, dynamic>?)?.map(
-            (k, e) =>
-                MapEntry($enumDecode(_$VideoHotKeysEnumMap, k), KeyCombination.fromJson(e as Map<String, dynamic>)),
+            (k, e) => MapEntry($enumDecode(_$VideoHotKeysEnumMap, k),
+                KeyCombination.fromJson(e as Map<String, dynamic>)),
           ) ??
           const {},
-      screensaver: $enumDecodeNullable(_$ScreensaverEnumMap, json['screensaver']) ?? Screensaver.logo,
+      screensaver:
+          $enumDecodeNullable(_$ScreensaverEnumMap, json['screensaver']) ??
+              Screensaver.logo,
       enableSpeedBoost: json['enableSpeedBoost'] as bool? ?? false,
       speedBoostRate: (json['speedBoostRate'] as num?)?.toDouble() ?? 2.0,
       enableDoubleTapSeek: json['enableDoubleTapSeek'] as bool? ?? true,
-      enableAdvancedVideoOptions: json['enableAdvancedVideoOptions'] as bool? ?? false,
+      enableAdvancedVideoOptions:
+          json['enableAdvancedVideoOptions'] as bool? ?? false,
       enableEdgeGestures: json['enableEdgeGestures'] as bool? ?? true,
       reverseEdgeGestures: json['reverseEdgeGestures'] as bool? ?? false,
+      enablePictureInPicture: json['enablePictureInPicture'] as bool? ?? true,
       enableReplayGain: json['enableReplayGain'] as bool? ?? true,
-      replayGainVolumeLevel: $enumDecodeNullable(_$ReplayGainVolumeLevelEnumMap, json['replayGainVolumeLevel']) ??
+      replayGainVolumeLevel: $enumDecodeNullable(
+              _$ReplayGainVolumeLevelEnumMap, json['replayGainVolumeLevel']) ??
           ReplayGainVolumeLevel.quiet,
       enablePlayPauseFade: json['enablePlayPauseFade'] as bool? ?? true,
       enableCrossfade: json['enableCrossfade'] as bool? ?? true,
-      crossfadeDurationMs: (json['crossfadeDurationMs'] as num?)?.toInt() ?? 400,
+      crossfadeDurationMs:
+          (json['crossfadeDurationMs'] as num?)?.toInt() ?? 400,
     );
 
-Map<String, dynamic> _$VideoPlayerSettingsModelToJson(_VideoPlayerSettingsModel instance) => <String, dynamic>{
+Map<String, dynamic> _$VideoPlayerSettingsModelToJson(
+        _VideoPlayerSettingsModel instance) =>
+    <String, dynamic>{
       'screenBrightness': instance.screenBrightness,
       'videoFit': _$BoxFitEnumMap[instance.videoFit]!,
       'fillScreen': instance.fillScreen,
@@ -57,14 +77,17 @@ Map<String, dynamic> _$VideoPlayerSettingsModelToJson(_VideoPlayerSettingsModel 
       'bufferSize': instance.bufferSize,
       'playerOptions': _$PlayerOptionsEnumMap[instance.playerOptions],
       'internalVolume': instance.internalVolume,
-      'allowedOrientations': instance.allowedOrientations?.map((e) => _$DeviceOrientationEnumMap[e]!).toList(),
+      'allowedOrientations': instance.allowedOrientations
+          ?.map((e) => _$DeviceOrientationEnumMap[e]!)
+          .toList(),
       'nextVideoType': _$AutoNextTypeEnumMap[instance.nextVideoType]!,
       'maxHomeBitrate': _$BitrateEnumMap[instance.maxHomeBitrate]!,
       'maxInternetBitrate': _$BitrateEnumMap[instance.maxInternetBitrate]!,
       'audioDevice': instance.audioDevice,
-      'segmentSkipSettings':
-          instance.segmentSkipSettings.map((k, e) => MapEntry(_$MediaSegmentTypeEnumMap[k]!, _$SegmentSkipEnumMap[e]!)),
-      'hotKeys': instance.hotKeys.map((k, e) => MapEntry(_$VideoHotKeysEnumMap[k]!, e)),
+      'segmentSkipSettings': instance.segmentSkipSettings.map((k, e) =>
+          MapEntry(_$MediaSegmentTypeEnumMap[k]!, _$SegmentSkipEnumMap[e]!)),
+      'hotKeys': instance.hotKeys
+          .map((k, e) => MapEntry(_$VideoHotKeysEnumMap[k]!, e)),
       'screensaver': _$ScreensaverEnumMap[instance.screensaver]!,
       'enableSpeedBoost': instance.enableSpeedBoost,
       'speedBoostRate': instance.speedBoostRate,
@@ -72,8 +95,10 @@ Map<String, dynamic> _$VideoPlayerSettingsModelToJson(_VideoPlayerSettingsModel 
       'enableAdvancedVideoOptions': instance.enableAdvancedVideoOptions,
       'enableEdgeGestures': instance.enableEdgeGestures,
       'reverseEdgeGestures': instance.reverseEdgeGestures,
+      'enablePictureInPicture': instance.enablePictureInPicture,
       'enableReplayGain': instance.enableReplayGain,
-      'replayGainVolumeLevel': _$ReplayGainVolumeLevelEnumMap[instance.replayGainVolumeLevel]!,
+      'replayGainVolumeLevel':
+          _$ReplayGainVolumeLevelEnumMap[instance.replayGainVolumeLevel]!,
       'enablePlayPauseFade': instance.enablePlayPauseFade,
       'enableCrossfade': instance.enableCrossfade,
       'crossfadeDurationMs': instance.crossfadeDurationMs,

--- a/lib/providers/pip_provider.dart
+++ b/lib/providers/pip_provider.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:fladder/wrappers/pip_manager.dart';
+
+final pipManagerProvider = Provider<PipManager>((ref) {
+  final manager = PipManager();
+  ref.onDispose(manager.dispose);
+  return manager;
+});
+
+final pipStateProvider = StreamProvider<bool>((ref) {
+  final manager = ref.watch(pipManagerProvider);
+  return manager.isInPip;
+});

--- a/lib/providers/settings/video_player_settings_provider.dart
+++ b/lib/providers/settings/video_player_settings_provider.dart
@@ -181,6 +181,8 @@ class VideoPlayerSettingsProviderNotifier extends StateNotifier<VideoPlayerSetti
 
   void setReverseEdgeGestures(bool value) => state = state.copyWith(reverseEdgeGestures: value);
 
+  void setEnablePictureInPicture(bool value) => state = state.copyWith(enablePictureInPicture: value);
+
   void setEnableReplayGain(bool value) => state = state.copyWith(enableReplayGain: value);
 
   void setEnablePlayPauseFade(bool value) => state = state.copyWith(enablePlayPauseFade: value);

--- a/lib/screens/settings/player_settings_page.dart
+++ b/lib/screens/settings/player_settings_page.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
@@ -30,6 +28,7 @@ import 'package:fladder/util/box_fit_extension.dart';
 import 'package:fladder/util/localization_helper.dart';
 import 'package:fladder/widgets/shared/fladder_slider.dart';
 import 'package:fladder/widgets/shared/item_actions.dart';
+import 'package:fladder/wrappers/pip_manager.dart';
 
 @RoutePage()
 class PlayerSettingsPage extends ConsumerStatefulWidget {
@@ -81,7 +80,7 @@ class _PlayerSettingsPageState extends ConsumerState<PlayerSettingsPage> {
                   ),
                 ],
               ),
-            if (!kIsWeb && (Platform.isAndroid || Platform.isIOS))
+            if (pipPlatformSupported)
               SettingsListTile(
                 label: Text(context.localized.pictureInPictureAutoTitle),
                 subLabel: Text(context.localized.pictureInPictureSubtitle),

--- a/lib/screens/settings/player_settings_page.dart
+++ b/lib/screens/settings/player_settings_page.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
@@ -78,6 +80,16 @@ class _PlayerSettingsPageState extends ConsumerState<PlayerSettingsPage> {
                         : Container(),
                   ),
                 ],
+              ),
+            if (!kIsWeb && (Platform.isAndroid || Platform.isIOS))
+              SettingsListTile(
+                label: Text(context.localized.pictureInPictureAutoTitle),
+                subLabel: Text(context.localized.pictureInPictureSubtitle),
+                onTap: () => provider.setEnablePictureInPicture(!videoSettings.enablePictureInPicture),
+                trailing: Switch(
+                  value: videoSettings.enablePictureInPicture,
+                  onChanged: (value) => provider.setEnablePictureInPicture(value),
+                ),
               ),
             SettingsListTileEnum(
               label: Text(context.localized.videoScaling),

--- a/lib/screens/video_player/video_player.dart
+++ b/lib/screens/video_player/video_player.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -19,7 +18,6 @@ import 'package:fladder/screens/video_player/video_player_controls.dart';
 import 'package:fladder/util/adaptive_layout/adaptive_layout.dart';
 import 'package:fladder/util/themes_data.dart';
 import 'package:fladder/widgets/shared/back_intent_dpad.dart';
-import 'package:fladder/wrappers/pip_manager.dart';
 
 class VideoPlayer extends ConsumerStatefulWidget {
   const VideoPlayer({super.key});
@@ -35,8 +33,6 @@ class _VideoPlayerState extends ConsumerState<VideoPlayer> with WidgetsBindingOb
   bool playing = false;
 
   late PlaybackModel? currentPlaybackModel = ref.read(playBackModel);
-
-  PipManager? _pipManager;
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
@@ -63,7 +59,6 @@ class _VideoPlayerState extends ConsumerState<VideoPlayer> with WidgetsBindingOb
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
     SystemChrome.setPreferredOrientations(DeviceOrientation.values);
-    _pipManager?.disable();
     super.dispose();
   }
 
@@ -78,16 +73,6 @@ class _VideoPlayerState extends ConsumerState<VideoPlayer> with WidgetsBindingOb
           orientations?.isNotEmpty == true ? orientations!.toList() : DeviceOrientation.values);
       return ref.read(videoPlayerSettingsProvider.notifier).setSavedBrightness();
     });
-    Future.microtask(_maybeConfigurePip);
-  }
-
-  void _maybeConfigurePip() {
-    if (kIsWeb) return;
-    if (!(Platform.isAndroid || Platform.isIOS)) return;
-    _pipManager = ref.read(pipManagerProvider);
-    final autoEnter = ref.read(videoPlayerSettingsProvider).enablePictureInPicture;
-    // 16:9 default — PlayerState does not expose real video dimensions.
-    _pipManager?.enable(aspectWidth: 16.0, aspectHeight: 9.0, autoEnter: autoEnter);
   }
 
   @override
@@ -118,14 +103,6 @@ class _VideoPlayerState extends ConsumerState<VideoPlayer> with WidgetsBindingOb
         if (previous != next) {
           SystemChrome.setPreferredOrientations(next?.isNotEmpty == true ? next!.toList() : DeviceOrientation.values);
         }
-      },
-    );
-
-    ref.listen(
-      videoPlayerSettingsProvider.select((value) => value.enablePictureInPicture),
-      (previous, next) {
-        if (previous == next) return;
-        _pipManager?.enable(aspectWidth: 16.0, aspectHeight: 9.0, autoEnter: next);
       },
     );
 

--- a/lib/screens/video_player/video_player.dart
+++ b/lib/screens/video_player/video_player.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -9,6 +10,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:fladder/models/media_playback_model.dart';
 import 'package:fladder/models/playback/playback_model.dart';
 import 'package:fladder/models/playback/tv_playback_model.dart';
+import 'package:fladder/providers/pip_provider.dart';
 import 'package:fladder/providers/settings/video_player_settings_provider.dart';
 import 'package:fladder/providers/video_player_provider.dart';
 import 'package:fladder/screens/video_player/components/video_player_guide_wrapper.dart';
@@ -17,6 +19,7 @@ import 'package:fladder/screens/video_player/video_player_controls.dart';
 import 'package:fladder/util/adaptive_layout/adaptive_layout.dart';
 import 'package:fladder/util/themes_data.dart';
 import 'package:fladder/widgets/shared/back_intent_dpad.dart';
+import 'package:fladder/wrappers/pip_manager.dart';
 
 class VideoPlayer extends ConsumerStatefulWidget {
   const VideoPlayer({super.key});
@@ -33,10 +36,14 @@ class _VideoPlayerState extends ConsumerState<VideoPlayer> with WidgetsBindingOb
 
   late PlaybackModel? currentPlaybackModel = ref.read(playBackModel);
 
+  PipManager? _pipManager;
+
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     //Don't pause on desktop focus loss
     if (!(AdaptiveLayout.of(context).isDesktop || kIsWeb)) {
+      // Don't pause when entering PiP — playback must continue.
+      final inPip = ref.read(pipStateProvider).asData?.value ?? false;
       switch (state) {
         case AppLifecycleState.resumed:
           if (playing) ref.read(videoPlayerProvider).play();
@@ -44,7 +51,7 @@ class _VideoPlayerState extends ConsumerState<VideoPlayer> with WidgetsBindingOb
         case AppLifecycleState.hidden:
         case AppLifecycleState.paused:
         case AppLifecycleState.detached:
-          if (playing) ref.read(videoPlayerProvider).pause();
+          if (playing && !inPip) ref.read(videoPlayerProvider).pause();
           break;
         default:
           break;
@@ -56,6 +63,7 @@ class _VideoPlayerState extends ConsumerState<VideoPlayer> with WidgetsBindingOb
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
     SystemChrome.setPreferredOrientations(DeviceOrientation.values);
+    _pipManager?.disable();
     super.dispose();
   }
 
@@ -70,6 +78,16 @@ class _VideoPlayerState extends ConsumerState<VideoPlayer> with WidgetsBindingOb
           orientations?.isNotEmpty == true ? orientations!.toList() : DeviceOrientation.values);
       return ref.read(videoPlayerSettingsProvider.notifier).setSavedBrightness();
     });
+    Future.microtask(_maybeConfigurePip);
+  }
+
+  void _maybeConfigurePip() {
+    if (kIsWeb) return;
+    if (!(Platform.isAndroid || Platform.isIOS)) return;
+    _pipManager = ref.read(pipManagerProvider);
+    final autoEnter = ref.read(videoPlayerSettingsProvider).enablePictureInPicture;
+    // 16:9 default — PlayerState does not expose real video dimensions.
+    _pipManager?.enable(aspectWidth: 16.0, aspectHeight: 9.0, autoEnter: autoEnter);
   }
 
   @override
@@ -100,6 +118,14 @@ class _VideoPlayerState extends ConsumerState<VideoPlayer> with WidgetsBindingOb
         if (previous != next) {
           SystemChrome.setPreferredOrientations(next?.isNotEmpty == true ? next!.toList() : DeviceOrientation.values);
         }
+      },
+    );
+
+    ref.listen(
+      videoPlayerSettingsProvider.select((value) => value.enablePictureInPicture),
+      (previous, next) {
+        if (previous == next) return;
+        _pipManager?.enable(aspectWidth: 16.0, aspectHeight: 9.0, autoEnter: next);
       },
     );
 

--- a/lib/screens/video_player/video_player_controls.dart
+++ b/lib/screens/video_player/video_player_controls.dart
@@ -382,7 +382,7 @@ class _DesktopControlsState extends ConsumerState<DesktopControls> {
                                 );
                               }
                             },
-                            icon: const Icon(Icons.picture_in_picture_alt_outlined),
+                            icon: const Icon(IconsaxPlusLinear.screenmirroring),
                           ),
                         if (AdaptiveLayout.layoutOf(context) == ViewSize.tablet) ...[
                           IconButton(

--- a/lib/screens/video_player/video_player_controls.dart
+++ b/lib/screens/video_player/video_player_controls.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
@@ -16,6 +17,7 @@ import 'package:fladder/models/items/media_streams_model.dart';
 import 'package:fladder/models/media_playback_model.dart';
 import 'package:fladder/models/playback/playback_model.dart';
 import 'package:fladder/models/settings/video_player_settings.dart';
+import 'package:fladder/providers/pip_provider.dart';
 import 'package:fladder/providers/settings/client_settings_provider.dart';
 import 'package:fladder/providers/settings/video_player_settings_provider.dart';
 import 'package:fladder/providers/user_provider.dart';
@@ -96,8 +98,18 @@ class _DesktopControlsState extends ConsumerState<DesktopControls> {
 
   @override
   Widget build(BuildContext context) {
-    final mediaSegments = ref.watch(playBackModel.select((value) => value?.mediaSegments));
+    final isInPip = ref.watch(pipStateProvider).asData?.value ?? false;
     final player = ref.watch(videoPlayerProvider);
+    if (isInPip) {
+      // Keep only the subtitle widget so it's captured in the PiP frame.
+      final pipSubtitleWidget = player.subtitleWidget(false, controlsKey: _bottomControlsKey);
+      return Stack(
+        children: [
+          if (pipSubtitleWidget != null) Positioned.fill(child: pipSubtitleWidget),
+        ],
+      );
+    }
+    final mediaSegments = ref.watch(playBackModel.select((value) => value?.mediaSegments));
     final subtitleWidget = player.subtitleWidget(showOverlay, controlsKey: _bottomControlsKey);
     final isDesktop = AdaptiveLayout.of(context).isDesktop || kIsWeb;
     final speedBoostEnabled = ref.watch(videoPlayerSettingsProvider.select((value) => value.enableSpeedBoost));
@@ -357,6 +369,21 @@ class _DesktopControlsState extends ConsumerState<DesktopControls> {
                         IconButton(
                             onPressed: () => showVideoPlayerOptions(context, () => minimizePlayer(context)),
                             icon: const Icon(IconsaxPlusLinear.more)),
+                        if (!kIsWeb &&
+                            (Platform.isAndroid || Platform.isIOS) &&
+                            MediaQuery.orientationOf(context) == Orientation.landscape)
+                          IconButton(
+                            tooltip: context.localized.pictureInPictureTitle,
+                            onPressed: () async {
+                              final ok = await ref.read(pipManagerProvider).enter();
+                              if (!ok && context.mounted) {
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  SnackBar(content: Text(context.localized.pictureInPictureNotSupported)),
+                                );
+                              }
+                            },
+                            icon: const Icon(Icons.picture_in_picture_alt_outlined),
+                          ),
                         if (AdaptiveLayout.layoutOf(context) == ViewSize.tablet) ...[
                           IconButton(
                             onPressed: () => showSubSelection(context),

--- a/lib/screens/video_player/video_player_controls.dart
+++ b/lib/screens/video_player/video_player_controls.dart
@@ -369,8 +369,7 @@ class _DesktopControlsState extends ConsumerState<DesktopControls> {
                         IconButton(
                             onPressed: () => showVideoPlayerOptions(context, () => minimizePlayer(context)),
                             icon: const Icon(IconsaxPlusLinear.more)),
-                        if (pipPlatformSupported &&
-                            MediaQuery.orientationOf(context) == Orientation.landscape)
+                        if (pipPlatformSupported && MediaQuery.orientationOf(context) == Orientation.landscape)
                           IconButton(
                             tooltip: context.localized.pictureInPictureTitle,
                             onPressed: () async {

--- a/lib/screens/video_player/video_player_controls.dart
+++ b/lib/screens/video_player/video_player_controls.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
@@ -42,6 +41,7 @@ import 'package:fladder/util/list_padding.dart';
 import 'package:fladder/util/localization_helper.dart';
 import 'package:fladder/util/string_extensions.dart';
 import 'package:fladder/widgets/full_screen_helpers/full_screen_wrapper.dart';
+import 'package:fladder/wrappers/pip_manager.dart';
 
 class DesktopControls extends ConsumerStatefulWidget {
   const DesktopControls({super.key});
@@ -369,8 +369,7 @@ class _DesktopControlsState extends ConsumerState<DesktopControls> {
                         IconButton(
                             onPressed: () => showVideoPlayerOptions(context, () => minimizePlayer(context)),
                             icon: const Icon(IconsaxPlusLinear.more)),
-                        if (!kIsWeb &&
-                            (Platform.isAndroid || Platform.isIOS) &&
+                        if (pipPlatformSupported &&
                             MediaQuery.orientationOf(context) == Orientation.landscape)
                           IconButton(
                             tooltip: context.localized.pictureInPictureTitle,

--- a/lib/widgets/pip_lifecycle_controller.dart
+++ b/lib/widgets/pip_lifecycle_controller.dart
@@ -1,0 +1,90 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:fladder/models/media_playback_model.dart';
+import 'package:fladder/providers/pip_provider.dart';
+import 'package:fladder/providers/settings/video_player_settings_provider.dart';
+import 'package:fladder/providers/video_player_provider.dart';
+
+class PipLifecycleController extends ConsumerStatefulWidget {
+  const PipLifecycleController({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  ConsumerState<PipLifecycleController> createState() => _PipLifecycleControllerState();
+}
+
+class _PipLifecycleControllerState extends ConsumerState<PipLifecycleController> {
+  bool get _platformSupported => !kIsWeb && (Platform.isAndroid || Platform.isIOS);
+
+  @override
+  void initState() {
+    super.initState();
+    if (_platformSupported) {
+      WidgetsBinding.instance.addPostFrameCallback((_) => _applyCurrent());
+    }
+  }
+
+  void _applyCurrent() {
+    if (!mounted) return;
+    final state = ref.read(mediaPlaybackProvider).state;
+    final autoEnter = ref.read(videoPlayerSettingsProvider).enablePictureInPicture;
+    _apply(state, autoEnter);
+  }
+
+  void _apply(VideoPlayerState state, bool autoEnter) {
+    final manager = ref.read(pipManagerProvider);
+    if (state == VideoPlayerState.fullScreen || state == VideoPlayerState.minimized) {
+      manager.enable(aspectWidth: 16.0, aspectHeight: 9.0, autoEnter: autoEnter);
+    } else {
+      manager.disable();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_platformSupported) {
+      return widget.child;
+    }
+    ref.listen<VideoPlayerState>(
+      mediaPlaybackProvider.select((v) => v.state),
+      (previous, next) {
+        if (previous == next) return;
+        final autoEnter = ref.read(videoPlayerSettingsProvider).enablePictureInPicture;
+        _apply(next, autoEnter);
+      },
+    );
+    ref.listen<bool>(
+      videoPlayerSettingsProvider.select((v) => v.enablePictureInPicture),
+      (previous, next) {
+        if (previous == next) return;
+        final state = ref.read(mediaPlaybackProvider).state;
+        _apply(state, next);
+      },
+    );
+
+    final inPip = ref.watch(pipStateProvider).asData?.value ?? false;
+    final state = ref.watch(mediaPlaybackProvider.select((v) => v.state));
+    if (inPip && state == VideoPlayerState.minimized) {
+      final player = ref.watch(videoPlayerProvider);
+      final video = player.videoWidget(const ValueKey('pip_minimized_video'), BoxFit.contain);
+      final subtitle = player.subtitleWidget(false);
+      return ColoredBox(
+        color: Colors.black,
+        child: Stack(
+          fit: StackFit.expand,
+          children: [
+            if (video != null) video,
+            if (subtitle != null) subtitle,
+          ],
+        ),
+      );
+    }
+    return widget.child;
+  }
+}

--- a/lib/widgets/pip_lifecycle_controller.dart
+++ b/lib/widgets/pip_lifecycle_controller.dart
@@ -1,6 +1,3 @@
-import 'dart:io';
-
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -9,6 +6,7 @@ import 'package:fladder/models/media_playback_model.dart';
 import 'package:fladder/providers/pip_provider.dart';
 import 'package:fladder/providers/settings/video_player_settings_provider.dart';
 import 'package:fladder/providers/video_player_provider.dart';
+import 'package:fladder/wrappers/pip_manager.dart';
 
 class PipLifecycleController extends ConsumerStatefulWidget {
   const PipLifecycleController({super.key, required this.child});
@@ -20,12 +18,10 @@ class PipLifecycleController extends ConsumerStatefulWidget {
 }
 
 class _PipLifecycleControllerState extends ConsumerState<PipLifecycleController> {
-  bool get _platformSupported => !kIsWeb && (Platform.isAndroid || Platform.isIOS);
-
   @override
   void initState() {
     super.initState();
-    if (_platformSupported) {
+    if (pipPlatformSupported) {
       WidgetsBinding.instance.addPostFrameCallback((_) => _applyCurrent());
     }
   }
@@ -48,7 +44,7 @@ class _PipLifecycleControllerState extends ConsumerState<PipLifecycleController>
 
   @override
   Widget build(BuildContext context) {
-    if (!_platformSupported) {
+    if (!pipPlatformSupported) {
       return widget.child;
     }
     ref.listen<VideoPlayerState>(

--- a/lib/wrappers/pip_manager.dart
+++ b/lib/wrappers/pip_manager.dart
@@ -4,7 +4,7 @@ import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:pip/pip.dart';
 
-bool _platformSupportsPip() {
+bool get pipPlatformSupported {
   if (kIsWeb) return false;
   return Platform.isAndroid || Platform.isIOS;
 }
@@ -34,7 +34,7 @@ class _RealPipClient implements PipClient {
 
   @override
   Future<bool> isSupported() async {
-    if (!_platformSupportsPip()) return false;
+    if (!pipPlatformSupported) return false;
     return _pip.isSupported();
   }
 

--- a/lib/wrappers/pip_manager.dart
+++ b/lib/wrappers/pip_manager.dart
@@ -1,0 +1,148 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:pip/pip.dart';
+
+bool _platformSupportsPip() {
+  if (kIsWeb) return false;
+  return Platform.isAndroid || Platform.isIOS;
+}
+
+abstract class PipClient {
+  Future<bool> isSupported();
+  Future<bool> isAutoEnterSupported();
+  Future<void> setup({
+    required double aspectWidth,
+    required double aspectHeight,
+    required bool autoEnterEnabled,
+  });
+
+  // stop() only exits an active session; this re-runs setup with auto-enter off.
+  Future<void> disableAutoEnter();
+  Future<bool> start();
+  Future<void> stop();
+  void registerStateChangedObserver(void Function(bool isInPip) observer);
+  Future<void> dispose();
+}
+
+class _RealPipClient implements PipClient {
+  _RealPipClient() : _pip = Pip();
+
+  final Pip _pip;
+  bool _observerRegistered = false;
+
+  @override
+  Future<bool> isSupported() async {
+    if (!_platformSupportsPip()) return false;
+    return _pip.isSupported();
+  }
+
+  @override
+  Future<bool> isAutoEnterSupported() => _pip.isAutoEnterSupported();
+
+  @override
+  Future<void> setup({
+    required double aspectWidth,
+    required double aspectHeight,
+    required bool autoEnterEnabled,
+  }) async {
+    await _pip.setup(PipOptions(
+      autoEnterEnabled: autoEnterEnabled,
+      aspectRatioX: aspectWidth.toInt(),
+      aspectRatioY: aspectHeight.toInt(),
+    ));
+  }
+
+  @override
+  Future<void> disableAutoEnter() async {
+    await _pip.setup(const PipOptions(autoEnterEnabled: false));
+  }
+
+  @override
+  Future<bool> start() => _pip.start();
+
+  @override
+  Future<void> stop() => _pip.stop();
+
+  @override
+  void registerStateChangedObserver(void Function(bool isInPip) observer) {
+    final wrapped = PipStateChangedObserver(
+      onPipStateChanged: (state, error) {
+        observer(state == PipState.pipStateStarted);
+      },
+    );
+    _pip.registerStateChangedObserver(wrapped);
+    _observerRegistered = true;
+  }
+
+  @override
+  Future<void> dispose() async {
+    if (_observerRegistered) {
+      await _pip.unregisterStateChangedObserver();
+      _observerRegistered = false;
+    }
+    await _pip.dispose();
+  }
+}
+
+// Only file that imports `package:pip` — everything else depends on PipManager.
+class PipManager {
+  PipManager({PipClient? client}) : _client = client ?? _RealPipClient() {
+    _client.registerStateChangedObserver(_onStateChanged);
+  }
+
+  final PipClient _client;
+  final StreamController<bool> _stateController = StreamController<bool>.broadcast();
+
+  bool _supportCached = false;
+  bool _supportChecked = false;
+
+  Stream<bool> get isInPip => _stateController.stream;
+
+  // Always sets up aspect so manual enter() works; autoEnter gates the
+  // OS auto-enter-on-background behavior independently.
+  Future<bool> enable({
+    required double aspectWidth,
+    required double aspectHeight,
+    required bool autoEnter,
+  }) async {
+    if (!await _ensureSupported()) return false;
+    final autoEnterAllowed = autoEnter && await _client.isAutoEnterSupported();
+    await _client.setup(
+      aspectWidth: aspectWidth,
+      aspectHeight: aspectHeight,
+      autoEnterEnabled: autoEnterAllowed,
+    );
+    return true;
+  }
+
+  Future<void> disable() async {
+    if (!await _ensureSupported()) return;
+    await _client.disableAutoEnter();
+    await _client.stop();
+  }
+
+  Future<bool> enter() async {
+    if (!await _ensureSupported()) return false;
+    return _client.start();
+  }
+
+  Future<void> dispose() async {
+    await _client.dispose();
+    await _stateController.close();
+  }
+
+  Future<bool> _ensureSupported() async {
+    if (_supportChecked) return _supportCached;
+    _supportCached = await _client.isSupported();
+    _supportChecked = true;
+    return _supportCached;
+  }
+
+  void _onStateChanged(bool isInPip) {
+    if (!_stateController.isClosed) {
+      _stateController.add(isInPip);
+    }
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1557,6 +1557,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "26.1.0"
+  pip:
+    dependency: "direct main"
+    description:
+      name: pip
+      sha256: f3c0890458a1e7ea3597fd2432841fb82565d66e4aa5b4931326a2ec052b3505
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.3"
   platform:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -72,6 +72,7 @@ dependencies:
   audio_service: ^0.18.18
   audio_service_mpris: ^0.2.0
   fvp: ^0.35.0
+  pip: ^0.0.3
   video_player: ^2.10.0
 
   image: ^4.5.4 # For saving screenshots.

--- a/test/pip_manager_test.dart
+++ b/test/pip_manager_test.dart
@@ -1,0 +1,170 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fladder/wrappers/pip_manager.dart';
+
+class _FakePipClient implements PipClient {
+  bool supported = true;
+  bool autoEnterSupported = true;
+  bool startResult = true;
+
+  final List<PipOptionsSnapshot> setupCalls = [];
+  int startCount = 0;
+  int stopCount = 0;
+  int disableAutoEnterCount = 0;
+  int disposeCount = 0;
+  void Function(bool isInPip)? _observer;
+
+  void emitState(bool isInPip) => _observer?.call(isInPip);
+
+  @override
+  Future<bool> isSupported() async => supported;
+
+  @override
+  Future<bool> isAutoEnterSupported() async => autoEnterSupported;
+
+  @override
+  Future<void> setup({
+    required double aspectWidth,
+    required double aspectHeight,
+    required bool autoEnterEnabled,
+  }) async {
+    setupCalls.add(PipOptionsSnapshot(aspectWidth, aspectHeight, autoEnterEnabled));
+  }
+
+  @override
+  Future<bool> start() async {
+    startCount++;
+    return startResult;
+  }
+
+  @override
+  Future<void> stop() async {
+    stopCount++;
+  }
+
+  @override
+  Future<void> disableAutoEnter() async {
+    disableAutoEnterCount++;
+  }
+
+  @override
+  void registerStateChangedObserver(void Function(bool isInPip) observer) {
+    _observer = observer;
+  }
+
+  @override
+  Future<void> dispose() async {
+    disposeCount++;
+  }
+}
+
+class PipOptionsSnapshot {
+  PipOptionsSnapshot(this.width, this.height, this.autoEnter);
+  final double width;
+  final double height;
+  final bool autoEnter;
+}
+
+void main() {
+  group('PipManager', () {
+    test('enable calls setup with aspect ratio and propagates autoEnter=true', () async {
+      final fake = _FakePipClient();
+      final manager = PipManager(client: fake);
+
+      await manager.enable(aspectWidth: 1920, aspectHeight: 1080, autoEnter: true);
+
+      expect(fake.setupCalls, hasLength(1));
+      expect(fake.setupCalls.single.width, 1920);
+      expect(fake.setupCalls.single.height, 1080);
+      expect(fake.setupCalls.single.autoEnter, isTrue);
+    });
+
+    test('enable with autoEnter=false still sets up aspect but disables auto-enter', () async {
+      final fake = _FakePipClient();
+      final manager = PipManager(client: fake);
+
+      await manager.enable(aspectWidth: 16, aspectHeight: 9, autoEnter: false);
+
+      expect(fake.setupCalls, hasLength(1));
+      expect(fake.setupCalls.single.autoEnter, isFalse);
+    });
+
+    test('enable forces autoEnter=false when client reports auto-enter unsupported', () async {
+      final fake = _FakePipClient()..autoEnterSupported = false;
+      final manager = PipManager(client: fake);
+
+      await manager.enable(aspectWidth: 16, aspectHeight: 9, autoEnter: true);
+
+      expect(fake.setupCalls.single.autoEnter, isFalse);
+    });
+
+    test('enable returns false when isSupported is false and skips setup', () async {
+      final fake = _FakePipClient()..supported = false;
+      final manager = PipManager(client: fake);
+
+      final result = await manager.enable(aspectWidth: 16, aspectHeight: 9, autoEnter: true);
+
+      expect(result, isFalse);
+      expect(fake.setupCalls, isEmpty);
+    });
+
+    test('enter calls start and returns its result', () async {
+      final fake = _FakePipClient();
+      final manager = PipManager(client: fake);
+
+      final ok = await manager.enter();
+
+      expect(ok, isTrue);
+      expect(fake.startCount, 1);
+    });
+
+    test('enter returns false when isSupported is false', () async {
+      final fake = _FakePipClient()..supported = false;
+      final manager = PipManager(client: fake);
+
+      final ok = await manager.enter();
+
+      expect(ok, isFalse);
+      expect(fake.startCount, 0);
+    });
+
+    test('disable turns off auto-enter and stops any active PiP', () async {
+      final fake = _FakePipClient();
+      final manager = PipManager(client: fake);
+
+      await manager.disable();
+
+      expect(fake.disableAutoEnterCount, 1);
+      expect(fake.stopCount, 1);
+    });
+
+    test('isInPip stream emits values from the observer', () async {
+      final fake = _FakePipClient();
+      final manager = PipManager(client: fake);
+      final emitted = <bool>[];
+      final sub = manager.isInPip.listen(emitted.add);
+
+      fake.emitState(true);
+      fake.emitState(false);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(emitted, [true, false]);
+      await sub.cancel();
+      await manager.dispose();
+    });
+
+    test('dispose closes the stream and calls client.dispose', () async {
+      final fake = _FakePipClient();
+      final manager = PipManager(client: fake);
+
+      await manager.dispose();
+
+      expect(fake.disposeCount, 1);
+      final emitted = <bool>[];
+      final sub = manager.isInPip.listen(emitted.add);
+      await Future<void>.delayed(Duration.zero);
+      expect(emitted, isEmpty);
+      await sub.cancel();
+    });
+  });
+}


### PR DESCRIPTION
Adds Picture-in-Picture (PiP) support for the Flutter-rendered video players (`libMPV` / `libMDK`) on Android, with the iOS plumbing in place but untested. The standalone native ExoPlayer `VideoPlayerActivity` is intentionally out of scope.

### Behavior

- A **PiP icon** is now part of the player controls (bottom row, landscape only — see "Decisions" below). Tapping it enters PiP at any time.
- A new **"Auto Picture-in-Picture"** toggle under *Settings → Player* controls whether the OS should also auto-enter PiP when the app is backgrounded from the player. Defaults to **on**.
- While in PiP, the controls overlay is hidden so only the video surface (plus the subtitle widget, if any) is captured for the PiP window.
- On player dispose, auto-enter is turned **off** so the user is never auto-PiP'd from unrelated screens.

### Architecture

- **`lib/wrappers/pip_manager.dart`** — new `PipManager` wrapper hides `package:pip` behind a narrow `PipClient` interface so it can be unit-tested without the native plugin. Exposes `enable` / `enter` / `disable` / `dispose` and a `Stream<bool>` for the current PiP state. 9 unit tests.
- **`lib/providers/pip_provider.dart`** — `pipManagerProvider` + `pipStateProvider`.
- **`VideoPlayer`** integration listens to the auto-enter preference and re-applies it live if the user toggles the setting mid-playback.

### Platform plumbing

- `pubspec.yaml`: add `pip: ^0.0.3` (only file in `lib/` that imports `package:pip` is the wrapper).
- `android/app/src/main/AndroidManifest.xml`: add `android:supportsPictureInPicture="true"` to `MainActivity`. `configChanges` already covers `screenSize|smallestScreenSize|screenLayout`.
- `ios/Runner/Info.plist`: add `audio` to `UIBackgroundModes` (required for iOS PiP per `package:pip` docs).

### Decisions taken during implementation

1. **Setting semantics split.** Originally the single toggle gated both manual button visibility *and* auto-enter. Per UX feedback this was split: the toggle now controls *only* the OS auto-enter-on-background behavior; the manual PiP button is always available on Android/iOS.
2. **Button placement.** Tried three positions: bottom-row always, top-bar after minimize button, top-bar before close-X. Landed on **bottom row, after the `…` more button, landscape-only** — phone portrait was overflowing the row (RIGHT OVERFLOWED BY 46 PIXELS). Portrait users access PiP via the Home button + the auto-enter setting.
3. **Icon.** Material `Icons.picture_in_picture_alt_outlined` (rather than an IconsaxPlusLinear equivalent) — matches the de-facto Flutter standard used by other video apps (frosty, mydia) and YouTube/Netflix; the universal "rectangle-with-corner-rectangle" glyph is more discoverable than a generic maximize icon.
4. **Aspect ratio hardcoded 16:9.** `PlayerState` does not currently expose video width/height. Plumbing real ratios through every backend was deferred to keep the PR focused.
5. **Native player out of scope.** The separate `VideoPlayerActivity` (ExoPlayer/Compose) already has `supportsPictureInPicture` in its manifest but no logic; wiring that needs a separate Kotlin-side change and would have doubled the PR's surface area.
6. **One-pref-toggle design** rather than the three-state `Never / Always / Only with headphones` from the original discussion. Smaller surface, easier to maintain; can be expanded later if there's demand.

### Caveats & known limitations

- **iOS untested.** The Dart code is cross-platform and the iOS-side `Info.plist` change is in, but I do not have an iOS dev environment. The flow *should* work per `package:pip` docs but should be validated by someone with an iPhone before being treated as supported.
- **Aspect ratio is fixed at 16:9** as noted above. Non-16:9 videos will have black bars inside the PiP frame on Android.
- **Subtitle rendering inside the PiP frame** depends on the backend. Flutter-rendered subtitles are captured; subtitles burned into the player's native surface inherit the surface and also appear. No special handling was added beyond keeping the subtitle widget visible during PiP.

### Implementation notes

This PR was implemented with the help of an AI coding assistant (Claude Code). All decisions, UX trade-offs, and code review were human-driven; the AI handled mechanical edits and the wrapper/test scaffolding. Generated code follows the project's existing conventions (`dart format --line-length 120`, sparse comments, freezed for settings).

## Issue Being Fixed

Picture-in-Picture has been requested multiple times across several discussions. This PR addresses the **mobile (Android)** portion of those asks.

- [Discussion #494 — *Allow PiP for Mobile*](https://github.com/DonutWare/Fladder/discussions/494): the most direct ask; explicitly mobile-focused. **Fully addressed.**
- [Discussion #738 — *Double Tap to skip and PIP*](https://github.com/DonutWare/Fladder/discussions/738): combined request. The double-tap-to-seek part is already implemented (`enableDoubleTapSeek` setting). The PiP part — assumed mobile based on context — **is addressed**.

## Screenshots / Recordings

<table>
  <tr>
    <td><img width="240" alt="Settings — Auto PiP toggle" src="https://github.com/user-attachments/assets/5ddf806f-7e19-4b7b-a91e-2b521b6cd8f9" /></td>
    <td><img width="240" alt="Portrait player — no overflow" src="https://github.com/user-attachments/assets/41661ea6-fbc3-48af-a229-fdf272d99bfa" /></td>
    <td><img width="240" alt="In PiP window" src="https://github.com/user-attachments/assets/876b097c-b14d-4a1a-92de-536d2c462879" /></td>
  </tr>
  <tr>
    <td colspan="3"><img width="720" alt="Landscape player — PiP icon in bottom row" src="https://github.com/user-attachments/assets/a1115509-42ee-4351-94e5-33771f6b8d2d" /></td>
  </tr>
</table>


## Tested On

- [x] Android — Pixel 9 Pro XL emulator (API 34) and Pixel 10 Pro XL hardware (Android 16, API 36). All four scenarios verified: manual button, auto-enter on Home, toggle off → no auto-PiP, close PiP via × → playback ends and resume position is reported to Jellyfin.
- [ ] Android TV
- [ ] iOS — code in place, not validated on device.
- [ ] Linux — N/A (no PiP on desktop)
- [ ] Windows — N/A
- [ ] macOS — N/A
- [ ] Web — N/A

## Checklist

- [x] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained — `pip ^0.0.3` is a 0.0.x release with limited maintenance history; flagging as a known trade-off. Cross-platform (Android/iOS) by design. Open to swapping for a more mature alternative if maintainers prefer.
- [x] Check that any changes are related to the issue at hand.