### PR TITLE
fix: play synced items without a reachable server (#970)

### DIFF
--- a/lib/models/playback/playback_model.dart
+++ b/lib/models/playback/playback_model.dart
@@ -154,6 +154,9 @@ final playbackModelHelper = Provider<PlaybackModelHelper>((ref) {
   return PlaybackModelHelper(ref: ref);
 });
 
+@visibleForTesting
+bool useLocalSyncedCopy({required bool isSynced, required bool serverReachable}) => isSynced && !serverReachable;
+
 class PlaybackModelHelper {
   const PlaybackModelHelper({required this.ref});
 
@@ -267,17 +270,44 @@ class PlaybackModelHelper {
 
       if (firstItemToPlay == null) return null;
 
-      final fullItemResponse = await api.usersUserIdItemsItemIdGet(itemId: firstItemToPlay.id);
+      final syncedItem = await ref.read(syncProvider.notifier).getSyncedItem(firstItemToPlay.id);
+      final firstItemIsSynced = syncedItem != null && syncedItem.status == TaskStatus.complete;
+      final isOffline = ref.read(connectivityStatusProvider.select((value) => value == ConnectionState.offline));
 
-      final fullItem = fullItemResponse.body;
-
-      if (fullItem == null) {
-        return null;
+      if (useLocalSyncedCopy(isSynced: firstItemIsSynced, serverReachable: !isOffline)) {
+        final offlineModel = await _createOfflinePlaybackModel(
+          firstItemToPlay,
+          item.streamModel,
+          syncedItem,
+          oldModel: oldModel,
+          queueSource: effectiveQueueSource,
+        );
+        if (offlineModel != null) return offlineModel;
       }
 
-      SyncedItem? syncedItem = await ref.read(syncProvider.notifier).getSyncedItem(fullItem.id);
+      Response<ItemBaseModel>? fullItemResponse;
+      try {
+        fullItemResponse =
+            await api.usersUserIdItemsItemIdGet(itemId: firstItemToPlay.id).timeout(const Duration(seconds: 5));
+      } catch (e) {
+        log("Error fetching item, falling back to offline: ${e.toString()}");
+      }
 
-      final firstItemIsSynced = syncedItem != null && syncedItem.status == TaskStatus.complete;
+      final fullItem = fullItemResponse?.body;
+
+      if (fullItem == null) {
+        if (firstItemIsSynced) {
+          final offlineModel = await _createOfflinePlaybackModel(
+            firstItemToPlay,
+            item.streamModel,
+            syncedItem,
+            oldModel: oldModel,
+            queueSource: effectiveQueueSource,
+          );
+          if (offlineModel != null) return offlineModel;
+        }
+        return null;
+      }
 
       final actualStartPosition = startPosition ?? fullItem.userData.playBackPosition;
 
@@ -286,8 +316,6 @@ class PlaybackModelHelper {
         PlaybackType.transcode,
         if (firstItemIsSynced) PlaybackType.offline,
       };
-
-      final isOffline = ref.read(connectivityStatusProvider.select((value) => value == ConnectionState.offline));
 
       if (firstItemToPlay is AudioModel && firstItemIsSynced) {
         final offlinePlayback = await _createOfflinePlaybackModel(

--- a/test/models/playback/playback_model_test.dart
+++ b/test/models/playback/playback_model_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fladder/models/playback/playback_model.dart';
+
+void main() {
+  group('useLocalSyncedCopy', () {
+    test('plays local copy when synced and server is unreachable', () {
+      expect(useLocalSyncedCopy(isSynced: true, serverReachable: false), isTrue);
+    });
+
+    test('uses server when synced and server is reachable', () {
+      expect(useLocalSyncedCopy(isSynced: true, serverReachable: true), isFalse);
+    });
+
+    test('does not force local when item is not synced, even if server unreachable', () {
+      expect(useLocalSyncedCopy(isSynced: false, serverReachable: false), isFalse);
+    });
+
+    test('uses server when not synced and server reachable', () {
+      expect(useLocalSyncedCopy(isSynced: false, serverReachable: true), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
Resolve sync status and connectivity before the server item-fetch in `createPlaybackModel`, via a new pure `useLocalSyncedCopy` predicate. When offline, skip the server and play the local synced copy immediately. Otherwise bound the fetch with a 5s timeout and fall back to the local copy when the server is unreachable (e.g. LAN-only server while on cellular). Online, server-reachable behavior is unchanged.

Fixes #970 
Fixes #713

## Pull Request Description

Playing **synced** items previously always contacted the server *before* checking whether the item was available locally. `createPlaybackModel` awaited `usersUserIdItemsItemIdGet` unconditionally, and that call masks failures internally (returning the local item only after the underlying request hangs to its OS socket timeout). The result: browsing and playing synced content while the server was unreachable was very slow, which is the core complaint in #970.

### Behavior

- Playing a synced item no longer needs the server. When the device is **offline**, playback starts directly from the local file with **no server round-trip**.
- When there **is** a network but the server is unreachable (e.g. a LAN-only server while commuting on cellular), the server item-fetch is bounded by a **5s timeout** and falls back to the local copy.
- Auto-advance to the next synced episode goes through the same path, so it no longer hangs offline either.
- **Online with a reachable server is unchanged** — the existing quality-selection dialog (Direct Stream / Transcode / Offline) still appears for synced items, and non-synced playback is untouched.

### Implementation

- `lib/models/playback/playback_model.dart`: `createPlaybackModel` now resolves the synced item and connectivity *before* the server fetch. A new pure predicate `useLocalSyncedCopy({required bool isSynced, required bool serverReachable})` (`isSynced && !serverReachable`) centralizes the source decision and is unit-tested in isolation. The fetch is wrapped with a 5s `.timeout(...)` (matching the existing reachability-check value) and falls back to the local copy when the server can't be reached.
- The previously-duplicated synced-item lookup was removed; the lookup is now keyed on `firstItemToPlay.id` so a series/season resolves its actual resume episode.
- `test/models/playback/playback_model_test.dart`: 4 unit tests for the predicate.

The "re-sync offline progress when back online" behavior already exists (`SyncNotifier` reacts to connectivity returning and flushes pending user-data), so no change was needed there.

### Implementation notes

Implemented with the help of an AI coding assistant (Claude Code); all decisions, trade-offs, and review were human-driven. Generated code follows the project's conventions.

## Issue Being Fixed

Resolves #970

Synced shows/movies load very slowly when the server isn't reachable because the app tries to contact the server before falling back to the local copy. This PR removes that dependency for synced playback. (The issue also mentions watch-history not advancing offline; offline progress is saved locally and pushed on reconnect via the existing sync path — worth confirming during testing.)

## Screenshots / Recordings

<!-- add a short recording of offline synced playback if handy -->

## Tested On

- [x] Android
- [ ] Android TV
- [ ] iOS
- [ ] Linux
- [ ] Windows
- [ ] macOS
- [ ] Web

(but this change applicable for all who supporting offline sync)

## Checklist

- [x] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained — no new packages added.
- [x] Check that any changes are related to the issue at hand.