### PR TITLE
fix: keep playback queue anchor in sync when advancing episodes

### DIFF
--- a/lib/models/playback/playback_model.dart
+++ b/lib/models/playback/playback_model.dart
@@ -177,8 +177,16 @@ class PlaybackModelHelper {
           oldModel: currentModel,
         );
     if (newModel == null) return null;
-    ref.read(videoPlayerProvider.notifier).loadPlaybackItem(newModel, Duration.zero);
-    return newModel;
+    // The new model inherits oldModel.playbackQueue verbatim, so its
+    // mainQueueCurrentId still points at the episode we just left.
+    // nextVideo/previousVideo anchor on that id, so without this advance
+    // the auto-next overlay keeps offering the episode that is already
+    // playing and re-loads it from the start.
+    final advancedQueue =
+        currentModel?.playbackQueue.advanceFromCurrentTo(currentModel.item.id, newItem.id);
+    final modelToLoad = advancedQueue != null ? newModel.updatePlaybackQueue(advancedQueue) : newModel;
+    ref.read(videoPlayerProvider.notifier).loadPlaybackItem(modelToLoad, Duration.zero);
+    return modelToLoad;
   }
 
   Future<void> loadTVChannel(ChannelModel? channel) async {

--- a/lib/models/playback/playback_model.dart
+++ b/lib/models/playback/playback_model.dart
@@ -177,11 +177,6 @@ class PlaybackModelHelper {
           oldModel: currentModel,
         );
     if (newModel == null) return null;
-    // The new model inherits oldModel.playbackQueue verbatim, so its
-    // mainQueueCurrentId still points at the episode we just left.
-    // nextVideo/previousVideo anchor on that id, so without this advance
-    // the auto-next overlay keeps offering the episode that is already
-    // playing and re-loads it from the start.
     final advancedQueue =
         currentModel?.playbackQueue.advanceFromCurrentTo(currentModel.item.id, newItem.id);
     final modelToLoad = advancedQueue != null ? newModel.updatePlaybackQueue(advancedQueue) : newModel;


### PR DESCRIPTION
## Pull Request Description

After advancing to the next episode (via the Next-Up overlay, auto-advance timer, or the next/previous controls), the player would keep offering the episode that just started playing as "Next Up" — and selecting it would just reload the same episode from position 0, making it look like playback was stuck in a loop.

The `PlaybackQueueState` introduced in #1005 anchors `nextVideo` / `previousVideo` on `mainQueueCurrentId`. The audio queue handler updates that anchor on every transition (via `advanceFromCurrentTo` / `nextTransition`), but `loadNewVideo` in `playback_model.dart` hands the new model `oldModel.playbackQueue` unchanged, so the anchor stays pinned to the original episode forever. After the first advance, `queue[anchorIdx + 1]` resolves to the episode that just became current.

This PR calls `advanceFromCurrentTo(currentModel.item.id, newItem.id)` before loading the new model, matching the audio path.

## Issue Being Fixed

Auto-advance / Next-Up gets "stuck" on the same episode after one transition: the overlay shows the currently-playing episode as the next one and selecting it restarts the current episode from the start. Regression from #1005 (`feat: Music playback`).

No existing issue filed — happy to file one if preferred.

## Screenshots / Recordings

_N/A — purely a queue-state fix; behavioural._

## Tested On

- [x] Windows
- [ ] Android
- [ ] Android TV
- [ ] iOS
- [ ] Linux
- [ ] macOS
- [ ] Web

## Checklist

- [x] No new package was added
- [x] Changes are scoped to the issue at hand (one file, one call site)