### PR TITLE
fix: prevent crash on Linux without NetworkManager from connectivity_plus DBus FD leak

### DIFF
--- a/lib/providers/connectivity_provider.dart
+++ b/lib/providers/connectivity_provider.dart
@@ -31,13 +31,19 @@ enum ConnectionState {
 @Riverpod(keepAlive: true)
 class ConnectivityStatus extends _$ConnectivityStatus {
   String? localUrl;
+  DateTime? _lastCheck;
+  static const Duration _minCheckInterval = Duration(seconds: 5);
 
   @override
   ConnectionState build() {
     ref.listen(userProvider, (previous, next) {
       checkLocalUrl(previous, next);
     });
-    Connectivity().onConnectivityChanged.listen(onStateChange);
+    final sub = Connectivity().onConnectivityChanged.listen(
+          onStateChange,
+          onError: (error) => log('Connectivity stream error: $error'),
+        );
+    ref.onDispose(sub.cancel);
     checkConnectivity();
     return ConnectionState.mobile;
   }
@@ -50,35 +56,49 @@ class ConnectivityStatus extends _$ConnectivityStatus {
   }
 
   Future<void> onStateChange(List<ConnectivityResult> connectivityResult) async {
-    if (connectivityResult.contains(ConnectivityResult.ethernet)) {
-      state = ConnectionState.ethernet;
-    } else if (connectivityResult.contains(ConnectivityResult.wifi)) {
-      state = ConnectionState.wifi;
-    } else if (connectivityResult.contains(ConnectivityResult.mobile)) {
-      state = ConnectionState.mobile;
-    } else if (connectivityResult.contains(ConnectivityResult.none)) {
-      state = ConnectionState.offline;
+    try {
+      if (connectivityResult.contains(ConnectivityResult.ethernet)) {
+        state = ConnectionState.ethernet;
+      } else if (connectivityResult.contains(ConnectivityResult.wifi)) {
+        state = ConnectionState.wifi;
+      } else if (connectivityResult.contains(ConnectivityResult.mobile)) {
+        state = ConnectionState.mobile;
+      } else if (connectivityResult.contains(ConnectivityResult.none)) {
+        state = ConnectionState.offline;
+      }
+      final newUrl = ref.read(userProvider.select((value) => value?.credentials.localUrl));
+      if (localUrl == newUrl) return;
+      localUrl = newUrl;
+      final localConnection = localUrl != null && localUrl?.isNotEmpty == true
+          ? await fetchSystemInfoDynamic(normalizeUrl(localUrl!))
+          : null;
+      final correctServerResponse =
+          localConnection?.id == ref.read(userProvider.select((value) => value?.credentials.serverId));
+      ref.read(localConnectionAvailableProvider.notifier).update((state) => correctServerResponse);
+    } catch (e) {
+      log('Error handling connectivity state change: $e');
     }
-    final newUrl = ref.read(userProvider.select((value) => value?.credentials.localUrl));
-    if (localUrl == newUrl) return;
-    localUrl = newUrl;
-    final localConnection =
-        localUrl != null && localUrl?.isNotEmpty == true ? await fetchSystemInfoDynamic(normalizeUrl(localUrl!)) : null;
-    final correctServerResponse =
-        localConnection?.id == ref.read(userProvider.select((value) => value?.credentials.serverId));
-    ref.read(localConnectionAvailableProvider.notifier).update((state) => correctServerResponse);
   }
 
   Future<void> checkConnectivity() async {
-    final connectivityResult = await Connectivity().checkConnectivity();
-    final serverUrl = ref.read(serverUrlProvider);
-    final checkServer = await probeJellyfinUrl(
-      serverUrl ?? "",
-    );
-    if (checkServer != null) {
-      onStateChange(connectivityResult);
-    } else {
-      onStateChange([ConnectivityResult.none]);
+    final now = DateTime.now();
+    if (_lastCheck != null && now.difference(_lastCheck!) < _minCheckInterval) {
+      return;
+    }
+    _lastCheck = now;
+    try {
+      final connectivityResult = await Connectivity().checkConnectivity();
+      final serverUrl = ref.read(serverUrlProvider);
+      final checkServer = await probeJellyfinUrl(
+        serverUrl ?? "",
+      );
+      if (checkServer != null) {
+        onStateChange(connectivityResult);
+      } else {
+        onStateChange([ConnectivityResult.none]);
+      }
+    } catch (e) {
+      log('Failed to check connectivity: $e');
     }
   }
 

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -64,8 +64,12 @@ class NotificationService {
   }
 
   static Future<String?> getInitialNotificationPayload() async {
-    final details = await _plugin.getNotificationAppLaunchDetails();
-    return details?.notificationResponse?.payload;
+    try {
+      final details = await _plugin.getNotificationAppLaunchDetails();
+      return details?.notificationResponse?.payload;
+    } catch (e) {
+      return null;
+    }
   }
 
   static Future<bool> requestPermission() async {


### PR DESCRIPTION
## Pull Request Description

On Linux systems without NetworkManager, `connectivity_plus` throws unhandled DBus exceptions on every `checkConnectivity()` call (called after each API request), leaking file descriptors until the app crashes with "Too many open files". Wrapped connectivity checks in try-catch with a 5s debounce and cancel the stream subscription on dispose.

## Issue Being Fixed

On Linux without NetworkManager, the app crashes after running for a while with `epoll_create1() failed: Too many open files`. Each `checkConnectivity()` call (triggered after every API request) opens a DBus connection that fails and leaks a file descriptor. After ~10,000 failures, the process exhausts its FD limit and crashes.

Also wrapped `getNotificationAppLaunchDetails()` in try-catch as it throws `UnimplementedError` on Linux.

Resolves #issue-number

## Screenshots / Recordings

N/A

## Tested On

- [ ] Android
- [ ] Android TV
- [ ] iOS
- [x] Linux
- [ ] Windows
- [ ] macOS
- [ ] Web

## Checklist

- [x] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained (No new packages added)
- [x] Check that any changes are related to the issue at hand.