### PR TITLE
fix: Subtitle/audio mismatch under certain conditions and with multiple default tracks

### DIFF
--- a/lib/wrappers/players/lib_mpv.dart
+++ b/lib/wrappers/players/lib_mpv.dart
@@ -426,6 +426,15 @@ class LibMPV extends BasePlayer {
   @override
   Future<void> seek(Duration position) async => _player?.seek(position);
 
+  // mpv parses tracks asynchronously after open(); at playback start the list is still empty, so a
+  // positional lookup would miss and leave mpv on its own default pick. Wait (capped) for [index].
+  Future<void> _awaitTrack(int index, int Function(mpv.Tracks) count) async {
+    if (_player == null || index < 0 || count(_player!.state.tracks) > index + 2) return;
+    await _player!.stream.tracks
+        .firstWhere((tracks) => count(tracks) > index + 2)
+        .timeout(const Duration(seconds: 5), onTimeout: () => _player!.state.tracks);
+  }
+
   @override
   Future<int> setAudioTrack(AudioStreamModel? model, PlaybackModel playbackModel) async {
     final wantedAudioStream = model ?? playbackModel.defaultAudioStream;
@@ -433,9 +442,10 @@ class LibMPV extends BasePlayer {
     if (wantedAudioStream.index == AudioStreamModel.no().index) {
       await _player?.setAudioTrack(mpv.AudioTrack.no());
     } else {
+      final index = (playbackModel.audioStreams?.indexOf(wantedAudioStream) ?? -1) - 1;
+      await _awaitTrack(index, (tracks) => tracks.audio.length);
       final internalTracks = audioTracks.getRange(2, audioTracks.length).toList();
-      final audioTrack =
-          internalTracks.elementAtOrNull((playbackModel.audioStreams?.indexOf(wantedAudioStream) ?? -1) - 1);
+      final audioTrack = internalTracks.elementAtOrNull(index);
       if (audioTrack != null) {
         await _player?.setAudioTrack(audioTrack);
       }
@@ -455,9 +465,10 @@ class LibMPV extends BasePlayer {
       return -1;
     }
     _currentSubtitleCodec = wantedSubtitle.codec;
+    final index = playbackModel.subStreams?.sublist(1).indexWhere((element) => element.id == wantedSubtitle.id) ?? -1;
+    if (!wantedSubtitle.isExternal) await _awaitTrack(index, (tracks) => tracks.subtitle.length);
     final internalTrack = subTracks.getRange(2, subTracks.length).toList();
-    final index = playbackModel.subStreams?.sublist(1).indexWhere((element) => element.id == wantedSubtitle.id);
-    final subTrack = internalTrack.elementAtOrNull(index ?? -1);
+    final subTrack = internalTrack.elementAtOrNull(index);
     if (wantedSubtitle.isExternal && wantedSubtitle.url != null && subTrack == null) {
       await _player?.setSubtitleTrack(mpv.SubtitleTrack.uri(wantedSubtitle.url!));
     } else if (subTrack != null) {

--- a/lib/wrappers/players/lib_mpv.dart
+++ b/lib/wrappers/players/lib_mpv.dart
@@ -429,10 +429,11 @@ class LibMPV extends BasePlayer {
   // mpv parses tracks asynchronously after open(); at playback start the list is still empty, so a
   // positional lookup would miss and leave mpv on its own default pick. Wait (capped) for [index].
   Future<void> _awaitTrack(int index, int Function(mpv.Tracks) count) async {
-    if (_player == null || index < 0 || count(_player!.state.tracks) > index + 2) return;
-    await _player!.stream.tracks
+    final player = _player;
+    if (player == null || index < 0 || count(player.state.tracks) > index + 2) return;
+    await player.stream.tracks
         .firstWhere((tracks) => count(tracks) > index + 2)
-        .timeout(const Duration(seconds: 5), onTimeout: () => _player!.state.tracks);
+        .timeout(const Duration(seconds: 5), onTimeout: () => player.state.tracks);
   }
 
   @override


### PR DESCRIPTION
## Pull Request Description

At playback start, `setSubtitleTrack` / `setAudioTrack` (in `LibMPV`) ran before `media_kit` had finished parsing the file's tracks — `open()` returns before the mpv `track-list` observer fires. Both wrappers map the wanted Jellyfin stream to a player track **by list position**, so while the track list is still empty the lookup resolves to `null` and the selection is silently skipped. mpv then keeps the track it auto-selected on load — its first **default**-flagged track — which is wrong whenever a file has multiple default tracks (e.g. Jellyfin's smart subtitle selection picks the 2nd default).

This is exactly why the in-player UI showed the correct track while a different one actually played, and why re-selecting the same track fixed it (by then the track list had been parsed).

### Fix

`lib/wrappers/players/lib_mpv.dart`: before mapping the wanted stream to a player track, wait for that track to appear on `player.stream.tracks`. The wait:

- **only fires when the track isn't present yet** — already-loaded selections (manual re-selects, transcode) hit the fast path with zero added latency;
- **doesn't affect video load time** — the video is already playing (`play: true`), only the track application waits, and only until mpv finishes parsing (tens of ms);
- **is race-free** — Dart is single-threaded, so `firstWhere` subscribes synchronously before any track-list observer callback can run;
- **is capped at 5s** as a pure safety net, and **is skipped for external subtitles** (that path is unchanged).

Applied to both subtitle and audio selection. The `libMDK` wrapper has the same latent race but is intentionally left out of scope to keep the diff minimal.

### AI assistance

Root-cause investigation and the patch were done with Claude Code. The diagnosis — traced through the vendored DonutWare `media_kit` fork to confirm `open()` returns before track parsing and that `Tracks.subtitle` defaults to `[auto, no]` — the fix design, and on-device validation were human-reviewed and -owned.

## Issue Being Fixed

Resolves #1031 — when a file has multiple subtitle tracks marked as default, the UI selects the correct one but playback uses the first default track instead.

## Screenshots / Recordings

<!-- optional -->

## Tested On

- [x] Android — installed the dev build on a physical device; confirmed the correct (non-first) default subtitle track now plays from the start without needing to re-select it.
- [ ] Android TV — uses the native ExoPlayer path (selection by index, not the positional remap), so it isn't affected by this bug.
- [ ] iOS
- [ ] Linux — same `LibMPV` code path as Android; not separately re-tested but covered by the same fix.
- [ ] Windows
- [ ] macOS
- [ ] Web

## Checklist

- [x] If a new package was added, did you ensure it works for all supported platforms? — no new packages.
- [x] Check that any changes are related to the issue at hand.
