### PR TITLE
fix: Volume indicator text in light mode

### DIFF
--- a/lib/screens/video_player/components/video_player_volume_indicator.dart
+++ b/lib/screens/video_player/components/video_player_volume_indicator.dart
@@ -62,7 +62,12 @@ class _VideoPlayerVolumeIndicatorState extends ConsumerState<VideoPlayerVolumeIn
                   Icon(
                     volumeIcon(currentVolume),
                   ),
-                  Text(context.localized.volumeIndicator(currentVolume.round()))
+                  Text(
+                    context.localized.volumeIndicator(currentVolume.round()),
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                          color: Colors.white,
+                        ),
+                  )
                 ],
               ),
             ),


### PR DESCRIPTION
## Pull Request Description

Sets an explicit white text color on the volume indicator overlay so its label is readable against the dark background.

The volume indicator's `Text` had no explicit style, so it inherited the default theme text color (dark), which was unreadable on the `0.85`-alpha black background. This matches the brightness indicator, which already sets the text color to white. The icon already rendered correctly and is unchanged.

## Issue Being Fixed

On Android, when increasing/decreasing the volume during video playback, the volume overlay's percentage text rendered dark-gray on black and was effectively unreadable. The volume icon was fine, and the brightness overlay (both icon and text) was already correct.

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Tested On

- [x] Android
- [ ] Android TV
- [ ] iOS
- [ ] Linux
- [ ] Windows
- [ ] macOS
- [ ] Web

## Checklist

- [x] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained _(no new package added)_
- [x] Check that any changes are related to the issue at hand.
