### PR TITLE
fix(Android): Keep screen awake after returning to video playback from background

### DIFF
--- a/lib/screens/video_player/video_player.dart
+++ b/lib/screens/video_player/video_player.dart
@@ -9,7 +9,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:fladder/models/media_playback_model.dart';
 import 'package:fladder/models/playback/playback_model.dart';
 import 'package:fladder/models/playback/tv_playback_model.dart';
-import 'package:fladder/providers/pip_provider.dart';
 import 'package:fladder/providers/settings/video_player_settings_provider.dart';
 import 'package:fladder/providers/video_player_provider.dart';
 import 'package:fladder/screens/video_player/components/video_player_guide_wrapper.dart';
@@ -31,27 +30,16 @@ class _VideoPlayerState extends ConsumerState<VideoPlayer> with WidgetsBindingOb
   double lastScale = 0.0;
 
   bool errorPlaying = false;
-  bool playing = false;
 
   late PlaybackModel? currentPlaybackModel = ref.read(playBackModel);
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
-    //Don't pause on desktop focus loss
+    //Don't manage the wakelock on desktop focus loss
     if (!(AdaptiveLayout.of(context).isDesktop || kIsWeb)) {
-      // Don't pause when entering PiP — playback must continue.
-      final inPip = ref.read(pipStateProvider).asData?.value ?? false;
-      switch (state) {
-        case AppLifecycleState.resumed:
-          if (playing) ref.read(videoPlayerProvider).play();
-          break;
-        case AppLifecycleState.hidden:
-        case AppLifecycleState.paused:
-        case AppLifecycleState.detached:
-          if (playing && !inPip) ref.read(videoPlayerProvider).pause();
-          break;
-        default:
-          break;
+      if (state == AppLifecycleState.resumed) {
+        // Android drops the keep-screen-on flag on resume; re-apply it.
+        ref.read(videoPlayerProvider).reassertWakelock();
       }
     }
   }

--- a/lib/wrappers/media_control_wrapper.dart
+++ b/lib/wrappers/media_control_wrapper.dart
@@ -74,8 +74,6 @@ class MediaControlsWrapper extends BaseAudioHandler implements VideoPlayerContro
   bool _isNewPlayback = false;
   bool _isAudioQueueMode = false;
   bool _audioQueueTransitioning = false;
-
-  /// Last requested wakelock state; used to skip redundant calls during steady playback.
   bool _wakelockEnabled = false;
 
   AudioPrefetchBuffer? _prefetchBuffer;
@@ -317,15 +315,13 @@ class MediaControlsWrapper extends BaseAudioHandler implements VideoPlayerContro
     return loadPreviousVideo();
   }
 
-  /// Video needs the screen awake; audio can keep playing with the screen off.
   bool _shouldKeepScreenOn(bool playing) {
     final item = ref.read(playBackModel.select((value) => value?.item));
     return playing && item is! AudioModel;
   }
 
-  /// Single source of truth for the wakelock. Idempotent during steady
-  /// playback; pass [force] to re-apply even when [_wakelockEnabled] already
-  /// matches (needed after Android silently clears the window flag on resume).
+  /// [force] re-applies even when the cached state already matches, since
+  /// Android silently clears the keep-screen-on flag while we still think it's set.
   Future<void> _applyWakelock(bool shouldEnable, {bool force = false}) async {
     if (!force && shouldEnable == _wakelockEnabled) return;
     _wakelockEnabled = shouldEnable;
@@ -336,10 +332,6 @@ class MediaControlsWrapper extends BaseAudioHandler implements VideoPlayerContro
     }
   }
 
-  /// Re-applies the wakelock based on the current playback state. Called when
-  /// the app returns to the foreground, because Android drops the
-  /// keep-screen-on window flag across a background→foreground cycle and
-  /// nothing else restores it while playback continues.
   Future<void> reassertWakelock() async =>
       _applyWakelock(_shouldKeepScreenOn(_player?.lastState.playing ?? false), force: true);
 

--- a/lib/wrappers/media_control_wrapper.dart
+++ b/lib/wrappers/media_control_wrapper.dart
@@ -75,6 +75,9 @@ class MediaControlsWrapper extends BaseAudioHandler implements VideoPlayerContro
   bool _isAudioQueueMode = false;
   bool _audioQueueTransitioning = false;
 
+  /// Last requested wakelock state; used to skip redundant calls during steady playback.
+  bool _wakelockEnabled = false;
+
   AudioPrefetchBuffer? _prefetchBuffer;
   List<ItemBaseModel> _mpvPlaylistItems = [];
   int _mpvPlaylistCurrentIndex = 0;
@@ -264,6 +267,7 @@ class MediaControlsWrapper extends BaseAudioHandler implements VideoPlayerContro
       ));
       smtc?.setPosition(value.position);
       smtc?.setPlaybackStatus(value.playing ? PlaybackStatus.playing : PlaybackStatus.paused);
+      unawaited(_applyWakelock(_shouldKeepScreenOn(value.playing)));
       if (value.completed && !_audioQueueTransitioning) {
         _onAudioTrackCompleted();
       }
@@ -313,6 +317,32 @@ class MediaControlsWrapper extends BaseAudioHandler implements VideoPlayerContro
     return loadPreviousVideo();
   }
 
+  /// Video needs the screen awake; audio can keep playing with the screen off.
+  bool _shouldKeepScreenOn(bool playing) {
+    final item = ref.read(playBackModel.select((value) => value?.item));
+    return playing && item is! AudioModel;
+  }
+
+  /// Single source of truth for the wakelock. Idempotent during steady
+  /// playback; pass [force] to re-apply even when [_wakelockEnabled] already
+  /// matches (needed after Android silently clears the window flag on resume).
+  Future<void> _applyWakelock(bool shouldEnable, {bool force = false}) async {
+    if (!force && shouldEnable == _wakelockEnabled) return;
+    _wakelockEnabled = shouldEnable;
+    if (shouldEnable) {
+      await WakelockPlus.enable();
+    } else {
+      await WakelockPlus.disable();
+    }
+  }
+
+  /// Re-applies the wakelock based on the current playback state. Called when
+  /// the app returns to the foreground, because Android drops the
+  /// keep-screen-on window flag across a background→foreground cycle and
+  /// nothing else restores it while playback continues.
+  Future<void> reassertWakelock() async =>
+      _applyWakelock(_shouldKeepScreenOn(_player?.lastState.playing ?? false), force: true);
+
   @override
   Future<void> pause() async {
     await _player?.pause();
@@ -322,7 +352,7 @@ class MediaControlsWrapper extends BaseAudioHandler implements VideoPlayerContro
       updatePosition: position,
       controls: [MediaControl.play],
     ));
-    unawaited(WakelockPlus.disable());
+    unawaited(_applyWakelock(false));
     final playerState = _player;
     if (playerState != null) {
       final model = ref.read(playBackModel);
@@ -336,13 +366,11 @@ class MediaControlsWrapper extends BaseAudioHandler implements VideoPlayerContro
 
   @override
   Future<void> play() async {
-    // Only enable wakelock for video; audio can continue with screen off
     final playBackItem = ref.read(playBackModel.select((value) => value?.item));
-    if (playBackItem is! AudioModel) {
-      unawaited(WakelockPlus.enable());
-    } else {
+    if (playBackItem is AudioModel) {
       _isStopped = false;
     }
+    unawaited(_applyWakelock(_shouldKeepScreenOn(true)));
 
     await _player?.play();
 
@@ -456,7 +484,7 @@ class MediaControlsWrapper extends BaseAudioHandler implements VideoPlayerContro
     _isStopped = true;
 
     ref.read(mediaPlaybackProvider.notifier).update((state) => state.copyWith(state: VideoPlayerState.disposed));
-    unawaited(WakelockPlus.disable());
+    unawaited(_applyWakelock(false));
     _player?.stop();
     ref.read(windowTitleProvider.notifier).setPlayTitle(null);
 
@@ -510,15 +538,7 @@ class MediaControlsWrapper extends BaseAudioHandler implements VideoPlayerContro
       controls: [playing ? MediaControl.pause : MediaControl.play],
     ));
 
-    if (playing) {
-      // Only enable wakelock for video; audio can continue with screen off
-      final playBackItem = ref.read(playBackModel.select((value) => value?.item));
-      if (playBackItem is! AudioModel) {
-        unawaited(WakelockPlus.enable());
-      }
-    } else {
-      unawaited(WakelockPlus.disable());
-    }
+    unawaited(_applyWakelock(_shouldKeepScreenOn(playing)));
 
     final playerState = _player;
     if (playerState != null) {


### PR DESCRIPTION
## Pull Request Description

Fixes the screen sleeping mid-playback on Android (see #1046 for the full repro and on-device evidence).

Root cause: screen-on relied on the `FLAG_KEEP_SCREEN_ON` window flag toggled once in `play()`/`pause()`. Android drops that flag across a background→foreground cycle and nothing re-applied it — the resume handler meant to recover it (`if (playing) play()`) was dead code, since `playing` was never set `true`.

### Fix

- `media_control_wrapper.dart`: route the wakelock through one idempotent path — `_shouldKeepScreenOn(playing)` (on when playing and not an `AudioModel`) applied via `_applyWakelock(...)`, re-evaluated on every player state change instead of the scattered `WakelockPlus` calls.
- Added `reassertWakelock()` which **force**-re-applies the flag (our cached state reads "on" after the OS clears it, so a plain reconcile would skip the re-apply).
- `video_player.dart`: removed the dead `playing` flag; call `reassertWakelock()` on `AppLifecycleState.resumed`. Desktop/web stay excluded, as before.

The same handler also had a dead `pause()`-on-background branch (also gated on the never-true `playing`), which is removed too — behavior is unchanged, since playback already continued in the background. Wiring up actual background-pause would be a separate change.

### Scope

Native ExoPlayer path (Android TV) manages the flag separately in `ExoPlayer.kt` and is out of scope. No new packages.

### AI assistance

Root-cause investigation and the patch were done with Claude Code; diagnosis, fix design, and on-device validation were human-reviewed and -owned.

## Issue Being Fixed

Resolves #1046

## Screenshots / Recordings

<!-- optional -->

## Tested On

- [x] Android — dev build on a physical Pixel 10 Pro XL (Android 17): reproduced the mid-playback sleep via a background→foreground cycle, then confirmed the keep-screen-on flag stays held and the screen stays awake through the idle timeout while the video keeps playing.
- [ ] Android TV — native ExoPlayer path, out of scope.
- [ ] iOS
- [ ] Linux — same `LibMPV`/`WakelockPlus` path as Android; not separately re-tested.
- [ ] Windows
- [ ] macOS
- [ ] Web

## Checklist

- [x] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained — no new packages added.
- [x] Check that any changes are related to the issue at hand.
