### PR TITLE
feat: Previous and next chapter buttons

### DIFF
--- a/lib/models/items/chapters_model.dart
+++ b/lib/models/items/chapters_model.dart
@@ -88,4 +88,20 @@ extension ChapterExtension on List<Chapter> {
   Chapter? getChapterFromDuration(Duration duration) {
     return lastWhereOrNull((element) => element.startPosition < duration);
   }
+
+  Chapter? previousChapter(Duration position, {Duration threshold = const Duration(milliseconds: 3000)}) {
+    if (isEmpty) return null;
+    final earlier = where((chapter) => chapter.startPosition < position - threshold).toList();
+    return earlier.isNotEmpty ? earlier.last : first;
+  }
+
+  Chapter? nextChapter(Duration position) {
+    if (isEmpty) return null;
+    for (final chapter in this) {
+      if (chapter.startPosition > position) {
+        return chapter;
+      }
+    }
+    return null;
+  }
 }

--- a/lib/screens/video_player/video_player_controls.dart
+++ b/lib/screens/video_player/video_player_controls.dart
@@ -11,6 +11,7 @@ import 'package:iconsax_plus/iconsax_plus.dart';
 import 'package:screen_brightness/screen_brightness.dart';
 
 import 'package:fladder/models/item_base_model.dart';
+import 'package:fladder/models/items/chapters_model.dart';
 import 'package:fladder/models/items/media_segments_model.dart';
 import 'package:fladder/models/items/media_streams_model.dart';
 import 'package:fladder/models/media_playback_model.dart';
@@ -428,6 +429,7 @@ class _DesktopControlsState extends ConsumerState<DesktopControls> {
                     ),
                   ),
                   previousButton,
+                  previousChapterButton(ref),
                   seekBackwardButton(ref),
                   IconButton.filledTonal(
                     iconSize: 38,
@@ -439,6 +441,7 @@ class _DesktopControlsState extends ConsumerState<DesktopControls> {
                     ),
                   ),
                   seekForwardButton(ref),
+                  nextChapterButton(ref),
                   nextVideoButton,
                   Flexible(
                     flex: 2,
@@ -683,6 +686,66 @@ class _DesktopControlsState extends ConsumerState<DesktopControls> {
         ],
       ),
     );
+  } 
+
+  Widget nextChapterButton(WidgetRef ref) {
+    return Consumer(builder: (context, ref2, child) {
+      final chapters = ref.read(playBackModel.select((value) => value?.chapters));
+      final enabled = chapters?.isNotEmpty == true;
+      return IconButton(
+        onPressed: enabled ? () => _nextChapter(ref) : null,
+        iconSize: 30,
+        tooltip: context.localized.nextChapter,
+        icon: const Icon(IconsaxPlusLinear.arrow_right_1),
+      );
+    });
+  }
+
+  Widget previousChapterButton(WidgetRef ref) {
+    return Consumer(builder: (context, ref2, child) {
+      final chapters = ref.read(playBackModel.select((value) => value?.chapters));
+      final enabled = chapters?.isNotEmpty == true;
+      return IconButton(
+        onPressed: enabled ? () => _previousChapter(ref) : null,
+        iconSize: 30,
+        tooltip: context.localized.nextChapter,
+        icon: const Icon(IconsaxPlusLinear.arrow_left_3),
+      );
+    });
+  }
+
+  void _previousChapter(WidgetRef ref) {
+    final chapters = ref.read(playBackModel.select((value) => value?.chapters)) ?? [];
+    if (chapters.isEmpty) return;
+    final position = ref.read(mediaPlaybackProvider).position;
+    final threshold = const Duration(milliseconds: 3000);
+    Chapter? prev;
+    final earlier = chapters.where((c) => c.startPosition < position - threshold).toList();
+    if (earlier.isNotEmpty) prev = earlier.last;
+    final target = prev ?? chapters.first;
+    ref.read(videoPlayerProvider).seek(target.startPosition);
+    resetTimer();
+  }
+
+  void _nextChapter(WidgetRef ref) {
+    final chapters = ref.read(playBackModel.select((value) => value?.chapters)) ?? [];
+    if (chapters.isEmpty) return;
+    final position = ref.read(mediaPlaybackProvider).position;
+    Chapter? next;
+    for (final c in chapters) {
+      if (c.startPosition > position) {
+        next = c;
+        break;
+      }
+    }
+    if (next != null) {
+      ref.read(videoPlayerProvider).seek(next.startPosition);
+    } else {
+      // fallback: load next video
+      final nextVideo = ref.read(playBackModel.select((value) => value?.nextVideo));
+      if (nextVideo != null) ref.read(playbackModelHelper).loadNewVideo(nextVideo);
+    }
+    resetTimer();
   }
 
   void skipToSegmentEnd(MediaSegment? mediaSegment, String? segmentId) {

--- a/lib/screens/video_player/video_player_controls.dart
+++ b/lib/screens/video_player/video_player_controls.dart
@@ -686,7 +686,7 @@ class _DesktopControlsState extends ConsumerState<DesktopControls> {
         ],
       ),
     );
-  } 
+  }
 
   Widget nextChapterButton(WidgetRef ref) {
     return Consumer(builder: (context, ref2, child) {

--- a/lib/screens/video_player/video_player_controls.dart
+++ b/lib/screens/video_player/video_player_controls.dart
@@ -690,8 +690,9 @@ class _DesktopControlsState extends ConsumerState<DesktopControls> {
 
   Widget nextChapterButton(WidgetRef ref) {
     return Consumer(builder: (context, ref2, child) {
-      final chapters = ref.read(playBackModel.select((value) => value?.chapters));
-      final enabled = chapters?.isNotEmpty == true;
+      final chapters = ref.read(playBackModel.select((value) => value?.chapters)) ?? [];
+      final position = ref.read(mediaPlaybackProvider).position;
+      final enabled = chapters.nextChapter(position) != null;
       return IconButton(
         onPressed: enabled ? () => _nextChapter(ref) : null,
         iconSize: 30,
@@ -708,7 +709,7 @@ class _DesktopControlsState extends ConsumerState<DesktopControls> {
       return IconButton(
         onPressed: enabled ? () => _previousChapter(ref) : null,
         iconSize: 30,
-        tooltip: context.localized.nextChapter,
+        tooltip: context.localized.prevChapter,
         icon: const Icon(IconsaxPlusLinear.arrow_left_3),
       );
     });
@@ -716,35 +717,19 @@ class _DesktopControlsState extends ConsumerState<DesktopControls> {
 
   void _previousChapter(WidgetRef ref) {
     final chapters = ref.read(playBackModel.select((value) => value?.chapters)) ?? [];
-    if (chapters.isEmpty) return;
     final position = ref.read(mediaPlaybackProvider).position;
-    final threshold = const Duration(milliseconds: 3000);
-    Chapter? prev;
-    final earlier = chapters.where((c) => c.startPosition < position - threshold).toList();
-    if (earlier.isNotEmpty) prev = earlier.last;
-    final target = prev ?? chapters.first;
+    final target = chapters.previousChapter(position);
+    if (target == null) return;
     ref.read(videoPlayerProvider).seek(target.startPosition);
     resetTimer();
   }
 
   void _nextChapter(WidgetRef ref) {
     final chapters = ref.read(playBackModel.select((value) => value?.chapters)) ?? [];
-    if (chapters.isEmpty) return;
     final position = ref.read(mediaPlaybackProvider).position;
-    Chapter? next;
-    for (final c in chapters) {
-      if (c.startPosition > position) {
-        next = c;
-        break;
-      }
-    }
-    if (next != null) {
-      ref.read(videoPlayerProvider).seek(next.startPosition);
-    } else {
-      // fallback: load next video
-      final nextVideo = ref.read(playBackModel.select((value) => value?.nextVideo));
-      if (nextVideo != null) ref.read(playbackModelHelper).loadNewVideo(nextVideo);
-    }
+    final next = chapters.nextChapter(position);
+    if (next == null) return;
+    ref.read(videoPlayerProvider).seek(next.startPosition);
     resetTimer();
   }
 


### PR DESCRIPTION
## Pull Request Description

Added previous and next chapter buttons in the video player. This has not been added to tv_player_controls.dart, but I will (probably) add this in another PR.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

None, besides my mild annoyance

## Screenshots / Recordings

<img width="1515" height="288" alt="image" src="https://github.com/user-attachments/assets/a60907ba-2b62-4d33-8600-2dfd9dc7a184" />

## Tested On

<!-- Please check all platforms you have tested this PR on -->

- [ ] Android
- [ ] Android TV
- [ ] iOS
- [ ] Linux
- [x] Windows
- [ ] macOS
- [x] Web

## Checklist

- [x] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained
- [x] Check that any changes are related to the issue at hand.
