### PR TITLE
fix(Android): Render ASS subtitles on the native player

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -139,6 +139,9 @@ dependencies {
     implementation("androidx.media3:media3-exoplayer-hls:$media3_version")
     implementation("org.jellyfin.media3:media3-ffmpeg-decoder:$media3_version")
     implementation("io.github.peerless2012:ass-media:0.3.0")
+    // ass-media only depends on ass-kt at runtime scope, so Ass/AssRender are not on
+    // the compile classpath. We need Ass.addFont() to give libass a font (see AssFonts).
+    implementation("io.github.peerless2012:ass-kt:0.3.0")
 
     //UI
     implementation("io.github.rabehx:iconsax-compose:0.0.5")

--- a/android/app/src/main/kotlin/nl/jknaapen/fladder/player/ExoPlayer.kt
+++ b/android/app/src/main/kotlin/nl/jknaapen/fladder/player/ExoPlayer.kt
@@ -42,7 +42,10 @@ import androidx.media3.extractor.ts.TsExtractor
 import androidx.media3.ui.AspectRatioFrameLayout
 import androidx.media3.ui.CaptionStyleCompat
 import androidx.media3.ui.PlayerView
-import io.github.peerless2012.ass.media.kt.buildWithAssSupport
+import io.github.peerless2012.ass.media.AssHandler
+import io.github.peerless2012.ass.media.kt.withAssMkvSupport
+import io.github.peerless2012.ass.media.kt.withAssSupport
+import io.github.peerless2012.ass.media.parser.AssSubtitleParserFactory
 import io.github.peerless2012.ass.media.type.AssRenderType
 import kotlinx.coroutines.delay
 
@@ -52,6 +55,7 @@ import nl.jknaapen.fladder.messengers.properlySetSubAndAudioTracks
 import nl.jknaapen.fladder.objects.PlayerSettingsObject
 import nl.jknaapen.fladder.objects.VideoPlayerObject
 import nl.jknaapen.fladder.utility.AllowedOrientations
+import nl.jknaapen.fladder.utility.AssFonts
 import nl.jknaapen.fladder.utility.conditional
 import nl.jknaapen.fladder.utility.getAudioTracks
 import nl.jknaapen.fladder.utility.getSubtitleTracks
@@ -106,20 +110,30 @@ internal fun ExoPlayer(
         })
     }
 
+    // libass has no font provider on Android and must be handed fonts explicitly,
+    // otherwise it renders nothing at all. See AssFonts.
+    val assHandler = remember { AssHandler(AssRenderType.LEGACY).also { AssFonts.install(context, it) } }
+
     val exoPlayer = remember {
-        ExoPlayer.Builder(context, renderersFactory)
+        // This is what buildWithAssSupport() does internally, inlined for two reasons:
+        // it creates the AssHandler itself and never exposes it (we need it to push
+        // fonts into libass, see AssFonts), and it discards the caller's
+        // dataSourceFactory in favour of a plain DefaultDataSource.Factory.
+        val assParserFactory = AssSubtitleParserFactory(assHandler)
+        val mediaSourceFactory = DefaultMediaSourceFactory(
+            dataSourceFactory,
+            extractorsFactory.withAssMkvSupport(assParserFactory, assHandler),
+        ).setSubtitleParserFactory(assParserFactory)
+
+        ExoPlayer.Builder(context, renderersFactory.withAssSupport(assHandler))
             .setTrackSelector(trackSelector)
-            .setMediaSourceFactory(DefaultMediaSourceFactory(dataSourceFactory, extractorsFactory))
+            .setMediaSourceFactory(mediaSourceFactory)
             .setAudioAttributes(audioAttributes, true)
             .setHandleAudioBecomingNoisy(true)
             .setPauseAtEndOfMediaItems(true)
             .setVideoScalingMode(C.VIDEO_SCALING_MODE_SCALE_TO_FIT)
-            .buildWithAssSupport(
-                context,
-                renderersFactory = renderersFactory,
-                extractorsFactory = extractorsFactory,
-                renderType = AssRenderType.LEGACY
-            )
+            .build()
+            .also { player -> assHandler.init(player) }
     }
 
     fun updatePlaybackState() {

--- a/android/app/src/main/kotlin/nl/jknaapen/fladder/utility/AssFonts.kt
+++ b/android/app/src/main/kotlin/nl/jknaapen/fladder/utility/AssFonts.kt
@@ -1,0 +1,148 @@
+package nl.jknaapen.fladder.utility
+
+import android.content.Context
+import android.util.Log
+import io.github.peerless2012.ass.media.AssHandler
+import java.io.File
+import java.util.Collections
+import java.util.WeakHashMap
+
+/**
+ * Gives libass fonts to render ASS/SSA subtitles with.
+ *
+ * libass is built for Android without a font provider, and ass-kt hardcodes
+ *
+ *     ass_set_fonts(renderer, NULL, "sans-serif", ASS_FONTPROVIDER_FONTCONFIG, NULL, 1)
+ *
+ * so with no fonts registered every glyph lookup fails, `renderFrame()` returns a frame
+ * with no images, and `AssSubtitleParser.parse()` never emits a cue. The subtitle track is
+ * selectable and nothing appears on screen, with no error.
+ *
+ * Registering fonts is necessary but not sufficient. libass picks a font in this order
+ * (`ass_font_select` in ass_fontselect.c):
+ *
+ *   1. the family the script asks for   - "Arial", "Nirmala UI", … rarely present
+ *   2. `family_default`                 - "sans-serif" per the call above
+ *   3. the provider's `get_fallback`    - no provider exists; fontconfig is absent
+ *   4. `path_default`                   - NULL, and ass-kt cannot set it
+ *
+ * Only step 2 is reachable from here, so the fallback font has to actually be named
+ * "sans-serif". [renameFontFamily] rewrites its name table to say so.
+ */
+object AssFonts {
+
+    private const val TAG = "AssFonts"
+
+    /** Droid Sans Fallback, already shipped for mpv's `subtitleFontFile`. Covers CJK. */
+    private const val BUNDLED_FONT = "flutter_assets/assets/mp-font.ttf"
+
+    /** Must match the `family_default` ass-kt passes to `ass_set_fonts`. */
+    private const val DEFAULT_FAMILY = "sans-serif"
+
+    /**
+     * Registered under their real names so a script naming one resolves at step 1.
+     * Skipped when missing or oversized: libass copies each buffer into native memory.
+     */
+    private val SYSTEM_FONTS = listOf(
+        "/system/fonts/Roboto-Regular.ttf",
+        "/system/fonts/Roboto-Bold.ttf",
+        "/system/fonts/DroidSans.ttf",
+        "/system/fonts/DroidSans-Bold.ttf",
+    )
+
+    private const val MAX_SYSTEM_FONT_BYTES = 8L * 1024 * 1024
+
+    /** name table ids holding a family name, plus the full name that often shares its bytes. */
+    private val FAMILY_NAME_IDS = setOf(1, 4, 16)
+
+    /** Fonts live on the Ass instance, which outlives individual media items. */
+    private val installed: MutableSet<AssHandler> =
+        Collections.newSetFromMap(WeakHashMap<AssHandler, Boolean>())
+
+    @Synchronized
+    fun install(context: Context, handler: AssHandler) {
+        if (!installed.add(handler)) return
+
+        try {
+            val bundled = context.assets.open(BUNDLED_FONT).use { it.readBytes() }
+            if (!renameFontFamily(bundled, DEFAULT_FAMILY)) {
+                Log.e(TAG, "could not rename bundled font to $DEFAULT_FAMILY; ASS subtitles will not render")
+            }
+            handler.ass.addFont("mp-font.ttf", bundled)
+        } catch (e: Exception) {
+            Log.e(TAG, "could not load $BUNDLED_FONT; ASS subtitles will not render", e)
+        }
+
+        for (path in SYSTEM_FONTS) {
+            val file = File(path)
+            if (!file.isFile || file.length() !in 1..MAX_SYSTEM_FONT_BYTES) continue
+            try {
+                handler.ass.addFont(file.name, file.readBytes())
+            } catch (e: Exception) {
+                Log.w(TAG, "could not add $path", e)
+            }
+        }
+    }
+
+    /**
+     * Rewrites every family-name record in the sfnt `name` table to [newFamily], in place.
+     *
+     * Only shortens strings, never grows them, so the string storage keeps its layout and no
+     * offsets outside the name records change. Records are patched in their own encoding
+     * (UTF-16BE for Windows platform 3, single byte otherwise), and ids 1/4/16 are rewritten
+     * together because font compilers routinely point several records at the same bytes.
+     */
+    internal fun renameFontFamily(font: ByteArray, newFamily: String): Boolean {
+        fun u16(offset: Int): Int =
+            ((font[offset].toInt() and 0xFF) shl 8) or (font[offset + 1].toInt() and 0xFF)
+
+        fun u32(offset: Int): Long = (u16(offset).toLong() shl 16) or u16(offset + 2).toLong()
+
+        fun setU16(offset: Int, value: Int) {
+            font[offset] = (value ushr 8).toByte()
+            font[offset + 1] = value.toByte()
+        }
+
+        if (font.size < 12) return false
+        // Font collections have a different header; the bundled font is a plain sfnt.
+        if (String(font, 0, 4, Charsets.US_ASCII) == "ttcf") return false
+
+        var nameTable = -1
+        for (i in 0 until u16(4)) {
+            val record = 12 + i * 16
+            if (record + 16 > font.size) return false
+            if (String(font, record, 4, Charsets.US_ASCII) == "name") {
+                nameTable = u32(record + 8).toInt()
+                break
+            }
+        }
+        if (nameTable < 0 || nameTable + 6 > font.size) return false
+
+        val recordCount = u16(nameTable + 2)
+        val storage = nameTable + u16(nameTable + 4)
+        var patched = 0
+
+        for (i in 0 until recordCount) {
+            val record = nameTable + 6 + i * 12
+            if (record + 12 > font.size) break
+            if (u16(record + 6) !in FAMILY_NAME_IDS) continue
+
+            val length = u16(record + 8)
+            val offset = storage + u16(record + 10)
+            if (offset < 0 || offset + length > font.size) continue
+
+            val replacement = if (u16(record) == 3) {
+                newFamily.toByteArray(Charsets.UTF_16BE)
+            } else {
+                newFamily.toByteArray(Charsets.US_ASCII)
+            }
+            if (replacement.size > length) continue
+
+            replacement.copyInto(font, offset)
+            setU16(record + 8, replacement.size)
+            patched++
+        }
+
+        return patched > 0
+    }
+}


### PR DESCRIPTION
## Problem

ASS/SSA subtitles never render on the Android TV / leanback player. The track appears in the picker, can be selected, and simply draws nothing — no error, no crash, nothing in logs. The same file plays with subtitles correctly on desktop, on web, and even in the same app on the same device in tablet layout.

Fixes #919.

## Why only Android TV

`PlayerOptions.available` (`lib/models/settings/video_player_settings.dart:177`) returns only `nativePlayer` in leanback mode, so TV playback runs through `VideoPlayerActivity` → `android/.../player/ExoPlayer.kt` and renders ASS with **libass** via `io.github.peerless2012:ass-media`. Every other platform uses mpv/mdk. Three different subtitle renderers, and only the libass-on-Android one was broken.

## Root cause

libass is built for Android without a font provider, and `ass-kt` initialises the renderer with:

```c
// lib_ass_kt/src/main/cpp/AssKt.c
ass_set_fonts(assRenderer, NULL, "sans-serif", ASS_FONTPROVIDER_FONTCONFIG, NULL, 1);
```

It requests the **fontconfig** provider, which does not exist in that build, and passes **no default font path**. libass therefore starts with zero fonts:

```
W SubtitleRenderer: can't find selected font provider
W SubtitleRenderer: fontselect: failed to find any fallback with glyph 0x0 for font: (Arial, 700, 0)
```

The failure is silent because of where it lands in the library. `AssSubtitleParser.parse()` rasterises each event and only emits a cue from *inside* `frames?.images?.let { … }`. With no font, `renderFrame()` returns a frame containing no images, so that block never runs and **not one cue is ever handed to ExoPlayer**.

SRT is unaffected: media3 renders it with Android's own `Typeface` stack and never touches libass. That asymmetry is what makes the bug look mysterious from the outside.

## Why registering fonts isn't enough on its own

libass resolves a font in a fixed order (`ass_font_select`, `ass_fontselect.c`):

| # | Step | Result here |
| --- | --- | --- |
| 1 | family the script asks for | `Arial`, `Nirmala UI`, … not on the device |
| 2 | `family_default` | `"sans-serif"`, per the call above |
| 3 | provider's `get_fallback` | no provider exists |
| 4 | `path_default` | `NULL`, and `ass-kt` cannot set it |

Steps 1, 3 and 4 are unreachable from app code, so a font registered as `Droid Sans Fallback` is loaded and then never looked at. Step 2 is the only lever — which means the fallback font has to literally *be* named `sans-serif`.

## The fix

`AssFonts.install()` registers fonts through `Ass.addFont()` and rewrites the fallback font's sfnt `name` table so its family reads `sans-serif`. `"sans-serif"` is shorter than `"Droid Sans Fallback"`, so the records are patched in place — no table resizing, no offset changes, file size unchanged.

The fallback is `assets/mp-font.ttf` (Droid Sans Fallback), already shipped for mpv's `subtitleFontFile` (`lib/wrappers/players/base_player.dart:12`), so CJK is covered and the native player now falls back to the same font as every other platform. `Roboto` and `DroidSans` are also registered under their real names so scripts naming them resolve at step 1.

Two supporting changes:

- **`buildWithAssSupport()` is inlined** in `ExoPlayer.kt`. It constructs the `AssHandler` internally and never returns it, and that handler owns the `Ass` instance fonts attach to. Same wiring, same render type — and as a side benefit the helper no longer silently replaces the configured `dataSourceFactory` with a plain `DefaultDataSource.Factory`.
- **`ass-kt` is declared explicitly** in `build.gradle`, because `ass-media` only depends on it at *runtime* scope, leaving `Ass` off the compile classpath.

## Testing

Verified on a Sony BRAVIA 4K VH2 (Android 12, `leanback_only`, armeabi-v7a) with a direct-played mkv carrying an embedded ASS track and **no font attachments** — the case that was previously guaranteed to fail:

```
fontselect: Using default font family: (Arial, 700, 0) -> DroidSansFallback
fontselect: (Nirmala UI, 700, 0) -> DroidSansFallback
```

Subtitles render with their ASS styling intact — the source's `{\c&H00D8FF&\3c&H054D8B&}` shows up as gold text with a dark blue outline, so colours and outlines survive rather than degrading to plain text. An SRT control cut of the same file was checked before and after to confirm no regression on the non-libass path.

## Related, but deliberately not claimed

- **#1009** overlaps — it also adds font fallback handling, bundled with transcoding track-selection changes, and **will conflict with this in `ExoPlayer.kt`**. This PR is deliberately narrower: one root cause, independently verified on hardware. Happy to rebase around whichever lands first.
- **#861** (subtitle size doesn't scale with video resolution on TV) is adjacent and *not* fixed here. `AssRenderType.LEGACY` sizes libass's frame to the video dimensions rather than the display; moving to the overlay renderer would address it.
- **#912** is Linux/mpv, unrelated to this code path.
- **#473** is transcoding: Jellyfin delivers the subtitle as a sidecar URL, and `VideoPlayerImplementation.open()` only side-loads tracks with `external=true`, which is false for a stream embedded in the source. It is dropped before libass is involved. This fix is a *prerequisite* for that working, not a fix for it.

## Upstream notes

- The real defect is in `ass-kt`: requesting a provider that does not exist in the Android build while passing no default font makes libass unusable unless the host app happens to register a font named `sans-serif`. Worth filing upstream; this workaround can be dropped if `ass_set_fonts` ever becomes configurable.
- `ass-media` is pinned to **0.3.0**. Font *attachments* embedded in an mkv also appear not to load on that version (a test file with a muxed font rendered nothing); peerless2012/libass-android#63 "Fix font loading when attachments precede tracks in MKV" shipped in **0.4.0**. A version bump is worth a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
