### PR TITLE
fix: Resolve playlist membership without flooding the connection

### DIFF
--- a/lib/providers/playlist_provider.dart
+++ b/lib/providers/playlist_provider.dart
@@ -1,3 +1,5 @@
+import 'dart:developer';
+
 import 'package:chopper/chopper.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -7,6 +9,11 @@ import 'package:fladder/models/items/playlist_model.dart';
 import 'package:fladder/providers/api_provider.dart';
 import 'package:fladder/providers/service_provider.dart';
 import 'package:fladder/util/map_bool_helper.dart';
+
+/// Playlist membership lookups kept in flight at once. Sending them all at
+/// once floods the connection on libraries holding hundreds of playlists, and
+/// every other request queues up behind them.
+const _membershipLookupConcurrency = 5;
 
 final playlistStateProvider = StateProvider<List<PlaylistModel>>((ref) => []);
 
@@ -62,30 +69,66 @@ class PlaylistNotifier extends StateNotifier<_PlaylistProviderModel> {
       ],
     );
 
-    final playlists = serverPlaylists.body?.items?.map((e) => PlaylistModel.fromBaseDto(e, ref)).toList();
+    final playlists = serverPlaylists.body?.items?.map((e) => PlaylistModel.fromBaseDto(e, ref)).toList() ?? [];
 
-    ref.read(playlistStateProvider.notifier).state = playlists ?? [];
+    ref.read(playlistStateProvider.notifier).state = playlists;
 
     state = state.copyWith(
-      collections: Map.fromIterables(playlists ?? [], List.generate(playlists?.length ?? 0, (index) => null)),
+      collections: Map.fromIterables(playlists, List.generate(playlists.length, (index) => null)),
     );
 
-    playlists?.forEach(
-      (playlist) async {
-        final itemList = await api.playlistsPlaylistIdItemsGet(
-          playlistId: playlist.id,
-          enableImages: false,
-          enableUserData: false,
-          fields: [],
-        );
-        final List<String?> items = (itemList.body?.items ?? []).map((e) => e.id).toList();
-        state = state.copyWith(
-          collections: state.collections.setKey(playlist, items.contains(state.items.firstOrNull?.id)),
-        );
-      },
-    );
+    await _markPlaylistsHoldingItem(playlists);
 
     state = state.copyWith(isLoading: false);
+  }
+
+  /// Marks the playlists that already hold the item being added.
+  ///
+  /// Jellyfin has no bulk endpoint for this, so it costs one request per
+  /// playlist and they are spread over [_membershipLookupConcurrency] workers.
+  Future<void> _markPlaylistsHoldingItem(List<PlaylistModel> playlists) async {
+    final itemId = state.items.firstOrNull?.id;
+
+    // The provider is built with an empty item list, so without this the
+    // lookups would run on startup with nothing to look for.
+    if (itemId == null || playlists.isEmpty) {
+      state = state.copyWith(collections: {for (final playlist in playlists) playlist: false});
+      return;
+    }
+
+    var next = 0;
+
+    Future<void> resolveNext() async {
+      while (mounted) {
+        final index = next++;
+        if (index >= playlists.length) return;
+
+        final playlist = playlists[index];
+        final holdsItem = await _playlistHoldsItem(playlist, itemId);
+        if (!mounted) return;
+
+        state = state.copyWith(collections: state.collections.setKey(playlist, holdsItem));
+      }
+    }
+
+    await Future.wait(List.generate(_membershipLookupConcurrency, (_) => resolveNext()));
+  }
+
+  /// Whether [playlist] contains [itemId], or null when it could not be read.
+  Future<bool?> _playlistHoldsItem(PlaylistModel playlist, String itemId) async {
+    try {
+      final itemList = await api.playlistsPlaylistIdItemsGet(
+        playlistId: playlist.id,
+        enableImages: false,
+        enableUserData: false,
+        fields: [],
+      );
+      return itemList.body?.items.any((item) => item.id == itemId) ?? false;
+    } catch (e) {
+      // One unreadable playlist should not take the whole sheet down with it.
+      log('Could not read the items of playlist ${playlist.id}: $e');
+      return null;
+    }
   }
 
   Future<Response> addToPlaylist({required PlaylistModel playlist}) async {


### PR DESCRIPTION
## Pull Request Description

`PlaylistNotifier._init` asks every playlist whether it already holds the item being added, and it asks them all at the same moment: `forEach` with an `async` callback awaits nothing, so one request per playlist leaves at once with no limit on how many are in flight.

Most of that work was never needed in the first place. The provider is built with `..setItems([])`, so on startup the lookups ran with **no item to look for** and every answer was thrown away. They are now skipped entirely when there is no current item, which is the common case — the side navigation watches this provider on every launch.

When there is an item, the lookups run through a small pool of workers instead of all at once, and a playlist that cannot be read is recorded as unknown instead of throwing out of the `async` callback as an unhandled exception.

### Measured on an account with 369 playlists

|  | before | after |
| --- | --- | --- |
| `GET /Playlists/{id}/Items` on startup | 369, all at once | 0 |
| Response codes over the session | 45 × `200`, 352 × `500` | 687 × `200` |
| Unhandled exceptions | yes | none |
| Unrelated calls caught in the burst | 10–11 s | back to their usual 300–500 ms |

The `500`s were served by the reverse proxy in front of Jellyfin, not by Jellyfin itself — it simply gave up under the burst, and everything else queued behind it. With the requests spread out they all succeed.

### What this does not fix

This makes the behaviour correct, not fast. On that same account the sheet still costs one request per playlist each time it opens, so the checkboxes take a while to finish filling in, and `_init` still fetches the full playlist list (≈1 MB there) on every open.

Resolving membership only for the playlists actually on screen would be the real answer, but that means reworking the sheet's list and felt like a separate change to me. Happy to take it on if you would rather have it in one go — I left the details in #1121.

## Issue Being Fixed

Resolves #1121

## Screenshots / Recordings

_Not applicable, the change is not visible in the UI._

## Tested On

- [ ] Android
- [ ] Android TV
- [ ] iOS
- [ ] Linux
- [x] Windows
- [ ] macOS
- [ ] Web

Verified against a live server with 369 playlists: no requests on startup, the add-to-playlist sheet still ticks the playlists that already hold the item, and every request comes back `200`. `flutter analyze` clean, `dart format --line-length=120` clean.

## Checklist

- [x] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained — no new packages.
- [x] Check that any changes are related to the issue at hand.
