### PR TITLE
feat(playback): report playback progress to server during offline playback when online

### DIFF
--- a/lib/models/playback/offline_playback_model.dart
+++ b/lib/models/playback/offline_playback_model.dart
@@ -42,8 +42,7 @@ class OfflinePlaybackModel extends PlaybackModel {
   List<Chapter>? get chapters => syncedItem.chapters;
 
   @override
-  Future<Duration>? startDuration() async =>
-      isAudioPlayback ? Duration.zero : item.userData.playBackPosition;
+  Future<Duration>? startDuration() async => isAudioPlayback ? Duration.zero : item.userData.playBackPosition;
 
   @override
   ItemBaseModel? get nextVideo => queue.nextOrNull(item);
@@ -52,29 +51,21 @@ class OfflinePlaybackModel extends PlaybackModel {
   ItemBaseModel? get previousVideo => queue.previousOrNull(item);
 
   @override
-  List<SubStreamModel> get subStreams =>
-      [SubStreamModel.no(), ...syncedItem.subtitles];
+  List<SubStreamModel> get subStreams => [SubStreamModel.no(), ...syncedItem.subtitles];
 
   @override
-  Future<OfflinePlaybackModel> setSubtitle(
-      SubStreamModel? model, MediaControlsWrapper player) async {
+  Future<OfflinePlaybackModel> setSubtitle(SubStreamModel? model, MediaControlsWrapper player) async {
     final newIndex = await player.setSubtitleTrack(model, this);
-    return copyWith(
-        mediaStreams: () =>
-            mediaStreams?.copyWith(defaultSubStreamIndex: newIndex));
+    return copyWith(mediaStreams: () => mediaStreams?.copyWith(defaultSubStreamIndex: newIndex));
   }
 
   @override
-  List<AudioStreamModel> get audioStreams =>
-      [AudioStreamModel.no(), ...mediaStreams?.audioStreams ?? []];
+  List<AudioStreamModel> get audioStreams => [AudioStreamModel.no(), ...mediaStreams?.audioStreams ?? []];
 
   @override
-  Future<OfflinePlaybackModel>? setAudio(
-      AudioStreamModel? model, MediaControlsWrapper player) async {
+  Future<OfflinePlaybackModel>? setAudio(AudioStreamModel? model, MediaControlsWrapper player) async {
     final newIndex = await player.setAudioTrack(model, this);
-    return copyWith(
-        mediaStreams: () =>
-            mediaStreams?.copyWith(defaultAudioStreamIndex: newIndex));
+    return copyWith(mediaStreams: () => mediaStreams?.copyWith(defaultAudioStreamIndex: newIndex));
   }
 
   @override
@@ -102,17 +93,14 @@ class OfflinePlaybackModel extends PlaybackModel {
   }
 
   @override
-  Future<PlaybackModel?> playbackStopped(
-      Duration position, Duration? totalDuration, Ref ref) async {
+  Future<PlaybackModel?> playbackStopped(Duration position, Duration? totalDuration, Ref ref) async {
     if (ref.read(incognitoModeProvider) == true) return null;
-    final effectiveDuration =
-        totalDuration ?? item.overview.runTime ?? Duration.zero;
+    final effectiveDuration = totalDuration ?? item.overview.runTime ?? Duration.zero;
     final effectivePosition = resolvedStopPosition(position, totalDuration);
     final progress = _progressFor(effectivePosition, effectiveDuration);
     final isPlayed = UserData.isPlayed(effectivePosition, effectiveDuration);
     final userData = syncedItem.userData?.copyWith(
-      playbackPositionTicks:
-          isPlayed != false ? 0 : effectivePosition.toRuntimeTicks,
+      playbackPositionTicks: isPlayed != false ? 0 : effectivePosition.toRuntimeTicks,
       progress: isPlayed != false ? 0.0 : progress,
       played: isPlayed,
       lastPlayed: DateTime.now().toUtc(),
@@ -138,8 +126,7 @@ class OfflinePlaybackModel extends PlaybackModel {
   }
 
   @override
-  Future<PlaybackModel?> updatePlaybackPosition(
-      Duration position, bool isPlaying, Ref ref) async {
+  Future<PlaybackModel?> updatePlaybackPosition(Duration position, bool isPlaying, Ref ref) async {
     if (ref.read(incognitoModeProvider) == true) return null;
     final effectiveDuration = item.overview.runTime ?? Duration.zero;
     final progress = _progressFor(position, effectiveDuration);
@@ -178,8 +165,7 @@ class OfflinePlaybackModel extends PlaybackModel {
 
   double _progressFor(Duration position, Duration totalDuration) {
     if (totalDuration.inMilliseconds <= 0) return 0;
-    final progress =
-        position.inMilliseconds / totalDuration.inMilliseconds * 100;
+    final progress = position.inMilliseconds / totalDuration.inMilliseconds * 100;
     return progress.clamp(0.0, 100.0).toDouble();
   }
 
@@ -198,8 +184,7 @@ class OfflinePlaybackModel extends PlaybackModel {
   }
 
   @override
-  String toString() =>
-      'OfflinePlaybackModel(item: $item, syncedItem: $syncedItem)';
+  String toString() => 'OfflinePlaybackModel(item: $item, syncedItem: $syncedItem)';
 
   @override
   OfflinePlaybackModel copyWith({
@@ -219,8 +204,7 @@ class OfflinePlaybackModel extends PlaybackModel {
       media: media != null ? media() : this.media,
       syncedItem: syncedItem ?? this.syncedItem,
       mediaStreams: mediaStreams != null ? mediaStreams() : this.mediaStreams,
-      mediaSegments:
-          mediaSegments != null ? mediaSegments() : this.mediaSegments,
+      mediaSegments: mediaSegments != null ? mediaSegments() : this.mediaSegments,
       trickPlay: trickPlay != null ? trickPlay() : this.trickPlay,
       queue: queue ?? this.queue,
       playbackQueue: playbackQueue ?? this.playbackQueue,

--- a/lib/models/playback/offline_playback_model.dart
+++ b/lib/models/playback/offline_playback_model.dart
@@ -11,8 +11,11 @@ import 'package:fladder/models/items/trick_play_model.dart';
 import 'package:fladder/models/playback/playback_model.dart';
 import 'package:fladder/models/playback/playback_queue_state.dart';
 import 'package:fladder/models/syncing/sync_item.dart';
+import 'package:fladder/jellyfin/jellyfin_open_api.swagger.dart';
+import 'package:fladder/providers/connectivity_provider.dart';
 import 'package:fladder/providers/incognito_mode_provider.dart';
 import 'package:fladder/providers/sync_provider.dart';
+import 'package:fladder/providers/api_provider.dart';
 import 'package:fladder/util/duration_extensions.dart';
 import 'package:fladder/util/list_extensions.dart';
 import 'package:fladder/wrappers/media_control_wrapper.dart';
@@ -67,6 +70,25 @@ class OfflinePlaybackModel extends PlaybackModel {
 
   @override
   Future<PlaybackModel?> playbackStarted(Duration position, Ref ref) async {
+    if (ref.read(incognitoModeProvider) == true) return null;
+    final isOffline = ref.read(offlineStateProvider);
+    if (!isOffline) {
+      try {
+        await ref.read(jellyApiProvider).sessionsPlayingPost(
+          body: PlaybackStartInfo(
+            canSeek: true,
+            itemId: item.id,
+            mediaSourceId: item.id,
+            playbackStartTimeTicks: position.toRuntimeTicks,
+            playMethod: PlayMethod.directplay,
+            volumeLevel: 100,
+            isMuted: false,
+            isPaused: false,
+            repeatMode: RepeatMode.repeatall,
+          ),
+        );
+      } catch (_) {}
+    }
     return null;
   }
 
@@ -87,6 +109,19 @@ class OfflinePlaybackModel extends PlaybackModel {
       userData: userData,
     );
     await ref.read(syncProvider.notifier).updateItem(newItem);
+    // Report to server if online
+    final isOffline = ref.read(offlineStateProvider);
+    if (!isOffline) {
+      try {
+        await ref.read(jellyApiProvider).sessionsPlayingStoppedPost(
+          body: PlaybackStopInfo(
+            itemId: item.id,
+            mediaSourceId: item.id,
+            positionTicks: effectivePosition.toRuntimeTicks,
+          ),
+        );
+      } catch (_) {}
+    }
     return null;
   }
 
@@ -106,6 +141,25 @@ class OfflinePlaybackModel extends PlaybackModel {
       userData: userData,
     );
     await ref.read(syncProvider.notifier).updateItem(newItem);
+    // Report to server if online
+    final isOffline = ref.read(offlineStateProvider);
+    if (!isOffline) {
+      try {
+        await ref.read(jellyApiProvider).sessionsPlayingProgressPost(
+          body: PlaybackProgressInfo(
+            canSeek: true,
+            itemId: item.id,
+            mediaSourceId: item.id,
+            positionTicks: position.toRuntimeTicks,
+            playMethod: PlayMethod.directplay,
+            isPaused: !isPlaying,
+            volumeLevel: 100,
+            isMuted: false,
+            repeatMode: RepeatMode.repeatall,
+          ),
+        );
+      } catch (_) {}
+    }
     return null;
   }
 

--- a/lib/models/playback/offline_playback_model.dart
+++ b/lib/models/playback/offline_playback_model.dart
@@ -42,7 +42,8 @@ class OfflinePlaybackModel extends PlaybackModel {
   List<Chapter>? get chapters => syncedItem.chapters;
 
   @override
-  Future<Duration>? startDuration() async => isAudioPlayback ? Duration.zero : item.userData.playBackPosition;
+  Future<Duration>? startDuration() async =>
+      isAudioPlayback ? Duration.zero : item.userData.playBackPosition;
 
   @override
   ItemBaseModel? get nextVideo => queue.nextOrNull(item);
@@ -51,21 +52,29 @@ class OfflinePlaybackModel extends PlaybackModel {
   ItemBaseModel? get previousVideo => queue.previousOrNull(item);
 
   @override
-  List<SubStreamModel> get subStreams => [SubStreamModel.no(), ...syncedItem.subtitles];
+  List<SubStreamModel> get subStreams =>
+      [SubStreamModel.no(), ...syncedItem.subtitles];
 
   @override
-  Future<OfflinePlaybackModel> setSubtitle(SubStreamModel? model, MediaControlsWrapper player) async {
+  Future<OfflinePlaybackModel> setSubtitle(
+      SubStreamModel? model, MediaControlsWrapper player) async {
     final newIndex = await player.setSubtitleTrack(model, this);
-    return copyWith(mediaStreams: () => mediaStreams?.copyWith(defaultSubStreamIndex: newIndex));
+    return copyWith(
+        mediaStreams: () =>
+            mediaStreams?.copyWith(defaultSubStreamIndex: newIndex));
   }
 
   @override
-  List<AudioStreamModel> get audioStreams => [AudioStreamModel.no(), ...mediaStreams?.audioStreams ?? []];
+  List<AudioStreamModel> get audioStreams =>
+      [AudioStreamModel.no(), ...mediaStreams?.audioStreams ?? []];
 
   @override
-  Future<OfflinePlaybackModel>? setAudio(AudioStreamModel? model, MediaControlsWrapper player) async {
+  Future<OfflinePlaybackModel>? setAudio(
+      AudioStreamModel? model, MediaControlsWrapper player) async {
     final newIndex = await player.setAudioTrack(model, this);
-    return copyWith(mediaStreams: () => mediaStreams?.copyWith(defaultAudioStreamIndex: newIndex));
+    return copyWith(
+        mediaStreams: () =>
+            mediaStreams?.copyWith(defaultAudioStreamIndex: newIndex));
   }
 
   @override
@@ -75,32 +84,35 @@ class OfflinePlaybackModel extends PlaybackModel {
     if (!isOffline) {
       try {
         await ref.read(jellyApiProvider).sessionsPlayingPost(
-          body: PlaybackStartInfo(
-            canSeek: true,
-            itemId: item.id,
-            mediaSourceId: item.id,
-            playbackStartTimeTicks: position.toRuntimeTicks,
-            playMethod: PlayMethod.directplay,
-            volumeLevel: 100,
-            isMuted: false,
-            isPaused: false,
-            repeatMode: RepeatMode.repeatall,
-          ),
-        );
+              body: PlaybackStartInfo(
+                canSeek: true,
+                itemId: item.id,
+                mediaSourceId: item.id,
+                playbackStartTimeTicks: position.toRuntimeTicks,
+                playMethod: PlayMethod.directplay,
+                volumeLevel: 100,
+                isMuted: false,
+                isPaused: false,
+                repeatMode: RepeatMode.repeatall,
+              ),
+            );
       } catch (_) {}
     }
     return null;
   }
 
   @override
-  Future<PlaybackModel?> playbackStopped(Duration position, Duration? totalDuration, Ref ref) async {
+  Future<PlaybackModel?> playbackStopped(
+      Duration position, Duration? totalDuration, Ref ref) async {
     if (ref.read(incognitoModeProvider) == true) return null;
-    final effectiveDuration = totalDuration ?? item.overview.runTime ?? Duration.zero;
+    final effectiveDuration =
+        totalDuration ?? item.overview.runTime ?? Duration.zero;
     final effectivePosition = resolvedStopPosition(position, totalDuration);
     final progress = _progressFor(effectivePosition, effectiveDuration);
     final isPlayed = UserData.isPlayed(effectivePosition, effectiveDuration);
     final userData = syncedItem.userData?.copyWith(
-      playbackPositionTicks: isPlayed != false ? 0 : effectivePosition.toRuntimeTicks,
+      playbackPositionTicks:
+          isPlayed != false ? 0 : effectivePosition.toRuntimeTicks,
       progress: isPlayed != false ? 0.0 : progress,
       played: isPlayed,
       lastPlayed: DateTime.now().toUtc(),
@@ -114,19 +126,20 @@ class OfflinePlaybackModel extends PlaybackModel {
     if (!isOffline) {
       try {
         await ref.read(jellyApiProvider).sessionsPlayingStoppedPost(
-          body: PlaybackStopInfo(
-            itemId: item.id,
-            mediaSourceId: item.id,
-            positionTicks: effectivePosition.toRuntimeTicks,
-          ),
-        );
+              body: PlaybackStopInfo(
+                itemId: item.id,
+                mediaSourceId: item.id,
+                positionTicks: effectivePosition.toRuntimeTicks,
+              ),
+            );
       } catch (_) {}
     }
     return null;
   }
 
   @override
-  Future<PlaybackModel?> updatePlaybackPosition(Duration position, bool isPlaying, Ref ref) async {
+  Future<PlaybackModel?> updatePlaybackPosition(
+      Duration position, bool isPlaying, Ref ref) async {
     if (ref.read(incognitoModeProvider) == true) return null;
     final effectiveDuration = item.overview.runTime ?? Duration.zero;
     final progress = _progressFor(position, effectiveDuration);
@@ -146,18 +159,18 @@ class OfflinePlaybackModel extends PlaybackModel {
     if (!isOffline) {
       try {
         await ref.read(jellyApiProvider).sessionsPlayingProgressPost(
-          body: PlaybackProgressInfo(
-            canSeek: true,
-            itemId: item.id,
-            mediaSourceId: item.id,
-            positionTicks: position.toRuntimeTicks,
-            playMethod: PlayMethod.directplay,
-            isPaused: !isPlaying,
-            volumeLevel: 100,
-            isMuted: false,
-            repeatMode: RepeatMode.repeatall,
-          ),
-        );
+              body: PlaybackProgressInfo(
+                canSeek: true,
+                itemId: item.id,
+                mediaSourceId: item.id,
+                positionTicks: position.toRuntimeTicks,
+                playMethod: PlayMethod.directplay,
+                isPaused: !isPlaying,
+                volumeLevel: 100,
+                isMuted: false,
+                repeatMode: RepeatMode.repeatall,
+              ),
+            );
       } catch (_) {}
     }
     return null;
@@ -165,7 +178,8 @@ class OfflinePlaybackModel extends PlaybackModel {
 
   double _progressFor(Duration position, Duration totalDuration) {
     if (totalDuration.inMilliseconds <= 0) return 0;
-    final progress = position.inMilliseconds / totalDuration.inMilliseconds * 100;
+    final progress =
+        position.inMilliseconds / totalDuration.inMilliseconds * 100;
     return progress.clamp(0.0, 100.0).toDouble();
   }
 
@@ -184,7 +198,8 @@ class OfflinePlaybackModel extends PlaybackModel {
   }
 
   @override
-  String toString() => 'OfflinePlaybackModel(item: $item, syncedItem: $syncedItem)';
+  String toString() =>
+      'OfflinePlaybackModel(item: $item, syncedItem: $syncedItem)';
 
   @override
   OfflinePlaybackModel copyWith({
@@ -204,7 +219,8 @@ class OfflinePlaybackModel extends PlaybackModel {
       media: media != null ? media() : this.media,
       syncedItem: syncedItem ?? this.syncedItem,
       mediaStreams: mediaStreams != null ? mediaStreams() : this.mediaStreams,
-      mediaSegments: mediaSegments != null ? mediaSegments() : this.mediaSegments,
+      mediaSegments:
+          mediaSegments != null ? mediaSegments() : this.mediaSegments,
       trickPlay: trickPlay != null ? trickPlay() : this.trickPlay,
       queue: queue ?? this.queue,
       playbackQueue: playbackQueue ?? this.playbackQueue,


### PR DESCRIPTION
## Pull Request Description

This PR enables conditional real-time playback reporting to the Jellyfin server when playing downloaded media via `OfflinePlaybackModel`, provided the device is online.

Specifically:
- **`playbackStarted`**: Sends `sessionsPlayingPost` with `PlayMethod.directplay` if the device is online and not in incognito mode.
- **`updatePlaybackPosition`**: Reports periodic playback progress via `sessionsPlayingProgressPost` to the server in addition to updating the local SQLite database.
- **`playbackStopped`**: Reports playback stop via `sessionsPlayingStoppedPost` to the server in addition to saving final progress locally.
- **Scrobbler Plugin Support**: Server-side tracking/scrobbling plugins (e.g. Simkl, Trakt) that hook into playback session events now function seamlessly even when media is played from local storage.
- **Graceful Fallback**: All network requests are non-blocking, guarded by `offlineStateProvider`, and wrapped in `try/catch`. If the server is unreachable or the device loses connection, playback and local tracking continue seamlessly without interruption.
- **Privacy First**: Strictly respects `incognitoModeProvider` across start, update, and stop events.

## Issue Being Fixed

Previously, when users played downloaded/synced content through the "Offline" playback option (e.g., to play directly from disk without streaming or transcoding bandwidth), Fladder completely silenced server reporting:
- `playbackStarted` was a no-op (`return null;`).
- Progress was only stored locally, meaning the Jellyfin dashboard never showed the item in "Now Playing / Active Sessions".
- Watch progress did not sync in real-time to other devices while watching locally downloaded media.
- Server-side scrobbling plugins (Simkl, Trakt, etc.) were unable to track watch history because no playback sessions were reported.

With this change, downloaded content plays locally from disk as before, but if internet connectivity is present, the server is kept up-to-date in real-time (similar to local-first media playback in modern clients).


## Tested On

- [x] Linux
- [x] Android
- [ ] Android TV
- [ ] iOS
- [ ] Windows
- [ ] macOS
- [x] Web

> **Note on testing:** Tested on physical Linux and Android devices. Also verified on Web, though the Web version initiates direct browser downloads rather than utilizing the local sync playback engine, so this offline playback flow does not apply there.

## Checklist

- [x] If a new package was added, did you ensure it works for all supported platforms? Is the package well maintained *(No new packages were added)*
- [x] Check that any changes are related to the issue at hand.
