### PR TITLE
fix: Recover from decode-order timestamps with Android hardware decoding

### DIFF
--- a/lib/wrappers/players/lib_mpv.dart
+++ b/lib/wrappers/players/lib_mpv.dart
@@ -39,6 +39,13 @@ class LibMPV extends BasePlayer {
   VideoPlayerSettingsModel _settings = VideoPlayerSettingsModel();
 
   RestartableTimer? _retryTimer;
+
+  /// Broken-timestamp fallback, see [_onMpvLog].
+  int _invalidTimestampWarnings = 0;
+  DateTime? _invalidTimestampWindowStart;
+  bool _fixedFrameRateTiming = false;
+  static const _invalidTimestampThreshold = 8;
+  static const _invalidTimestampWindow = Duration(seconds: 5);
   DateTime _firstLoadAttempt = DateTime.now();
   final Duration _maxRetryDuration = const Duration(minutes: 1);
   final Duration _currentRetryDuration = const Duration(seconds: 5);
@@ -81,6 +88,8 @@ class LibMPV extends BasePlayer {
         libassAndroidFont: libassFallbackFont,
         libass: !kIsWeb && settings.useLibass,
         bufferSize: settings.bufferSize * 1024 * 1024, // MPV uses buffer size in bytes
+        // Warnings are needed for the broken-timestamp fallback in [_onMpvLog].
+        logLevel: mpv.MPVLogLevel.warn,
       ),
     );
 
@@ -92,6 +101,7 @@ class LibMPV extends BasePlayer {
         ),
       );
       _setupPlayerStreams(_player!);
+      _playerStreamSubs.add(_player!.stream.log.listen(_onMpvLog));
     }
 
     if (_player?.platform is mpv.NativePlayer) {
@@ -247,10 +257,46 @@ class LibMPV extends BasePlayer {
     ));
   }
 
+  /// Some files carry decode-order timestamps on a B-frame stream - an mp4
+  /// muxed without composition offsets, for one. ffmpeg's own decoders repair
+  /// that from the packet dts, but the MediaCodec decoder on Android hands mpv
+  /// no dts at all, so mpv sees the timestamps run backwards, drops the "late"
+  /// frames and plays at half the frame rate. mpv's fixed-frame-rate timing
+  /// mode ignores the decoder timestamps and shows frames in output order at
+  /// the container's rate, which is exactly right for such a file, so switch
+  /// to it once the warnings pile up. Reset per file in [loadVideo].
+  void _onMpvLog(mpv.PlayerLog entry) {
+    if (_fixedFrameRateTiming || !entry.text.startsWith('Invalid video timestamp')) return;
+    final now = DateTime.now();
+    final windowStart = _invalidTimestampWindowStart;
+    if (windowStart == null || now.difference(windowStart) > _invalidTimestampWindow) {
+      _invalidTimestampWindowStart = now;
+      _invalidTimestampWarnings = 0;
+    }
+    if (++_invalidTimestampWarnings < _invalidTimestampThreshold) return;
+    _fixedFrameRateTiming = true;
+    log('LibMPV: decoder timestamps are broken, switching to fixed-frame-rate timing');
+    unawaited(_setCorrectPts(false));
+  }
+
+  Future<void> _setCorrectPts(bool enabled) async {
+    final native = _player?.platform;
+    if (native is mpv.NativePlayer) {
+      await native.setProperty('correct-pts', enabled ? 'yes' : 'no');
+    }
+  }
+
   @override
   Future<void> loadVideo(String url, bool play, {Duration startPosition = Duration.zero}) async {
     _loadCompleter = Completer<void>();
     _firstLoadAttempt = DateTime.now();
+
+    _invalidTimestampWarnings = 0;
+    _invalidTimestampWindowStart = null;
+    if (_fixedFrameRateTiming) {
+      _fixedFrameRateTiming = false;
+      await _setCorrectPts(true);
+    }
 
     await setStartPosition(startPosition);
 


### PR DESCRIPTION
## What

On Android with hardware decoding, some files play at roughly half their frame rate with visible judder, while the same file is smooth on desktop and smooth when transcoded. This makes the MPV wrapper recover from that case automatically.

## Why it happens

Some files carry decode-order timestamps on a B-frame stream. The one I chased was an mp4 muxed by an older ffmpeg (Lavf58.20) without a `ctts` atom, so every packet has `pts == dts` even though the HEVC stream reorders frames.

- On desktop, mpv decodes with ffmpeg's own decoder (D3D11/VideoToolbox are hwaccels inside it). That decoder attaches a `pkt_dts` to every output frame, and mpv's decoder wrapper (`crazy_video_pts_stuff` in `f_decoder_wrapper.c`) switches to dts timing once the pts has misbehaved more often than the dts. The dts is monotonic and correctly delayed, so nobody notices the file is broken.
- On Android, the `mediacodec` decoder is a separate ffmpeg decoder that returns the queued input timestamp on the reordered output frame and sets no dts at all. mpv sees display-order frames with decode-order stamps, warns `Invalid video timestamp: a -> b` on nearly every frame, drops the ones that look late, and plays at ~11 fps for a 23.976 fps file.

Transcoding fixes it because the server's ffmpeg decodes it the desktop way and writes fresh timestamps.

## The fix

Raise the mpv log level to `warn` and listen to `stream.log`. Once eight `Invalid video timestamp` warnings land within five seconds, set `correct-pts=no` for that playback. That is mpv's fixed-frame-rate timing mode: frames are shown in decoder output order at the container's rate, which is exactly right for such a file. The flag is reset on the next `loadVideo`, so a healthy file after a broken one is untouched.

It is inert everywhere else: mpv warnings are rare, the listener does a string prefix check, and nothing changes until the threshold is hit.

## Measured

Pixel 8 (Exynos HEVC decoder, `hwdec=mediacodec-copy`), 1920x1040 HEVC Main 10 in mp4, direct play:

| | before | after |
|---|---|---|
| mpv `estimated-vf-fps` | 11.0 | 23.976 |
| `Invalid video timestamp` warnings | ~8 per second | 0 after the switch |
| `avsync` | drifting to 2.5 s | within 0.1 ms |
| dropped frames in 40 s | constant | 1 |

Found while profiling phone playback for [Chudder](https://github.com/JenteJan/Chudder), my fork of Fladder, where this ships in the next release along with a couple of other playback fixes from the same session. The method (VM service timeline plus mpv's own counters through `stream.log` and `getProperty`) is documented there if it is useful to anyone else.

Thanks for the foundation. Everything hard about this player was already in place; this only teaches it about one more kind of broken file.
